### PR TITLE
Fix banished passage: wrap king-appeasement options in <<link>> tags …

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v1.16" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v1.17" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -3962,8 +3962,8 @@ You don&#39;t know which helps more, but after a few days you feel your fever br
 Now you just have to figure out how to overcome your disgrace and find your way back into the King&#39;s good graces. Groveling will obviously have to be involved, but that won&#39;t be enough. Do you also:&lt;br&gt;
 &lt;ul&gt;
 &lt;li&gt;&lt;&lt;link &quot;help him find his next mistress&quot;&gt;&gt;&lt;&lt;set $money to Math.clamp($money - 12800, 0, 1000000)&gt;&gt;&lt;&lt;storyline-return&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
-&lt;li&gt;loan him all your money to fund the war effort&lt;&lt;set $reputation +=1&gt;&gt;&lt;&lt;set $money to 0&gt;&gt;&lt;&lt;storyline-return&gt;&gt;&lt;/li&gt;
-&lt;li&gt;give him all your money to fund the war effort&lt;&lt;set $reputation +=2&gt;&gt;&lt;&lt;set $money to 0&gt;&gt;&lt;&lt;storyline-return&gt;&gt;&lt;/li&gt;
+&lt;li&gt;&lt;&lt;link &quot;loan him all your money to fund the war effort&quot;&gt;&gt;&lt;&lt;set $reputation +=1&gt;&gt;&lt;&lt;set $money to 0&gt;&gt;&lt;&lt;storyline-return&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
+&lt;li&gt;&lt;&lt;link &quot;give him all your money to fund the war effort&quot;&gt;&gt;&lt;&lt;set $reputation +=2&gt;&gt;&lt;&lt;set $money to 0&gt;&gt;&lt;&lt;storyline-return&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
 &lt;/ul&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/linkreplace&gt;&gt;


### PR DESCRIPTION
…— bump to v1.17

Options 2 and 3 (loan/give money to fund war effort) were bare plaintext with their <<set>> macros and <<storyline-return>> executing immediately on page render instead of on click. Wrapped both in <<link "text">>...<</link>> to match option 1's structure, so money and reputation changes only fire when the player selects the option and the stray "Continue" link no longer appears.

https://claude.ai/code/session_017ky3yhXrohXK4qoThXNLp3