### PR TITLE
Fix duplicate master's wife generating pending age — bump to v1.19

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v1.18" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v1.19" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -2679,8 +2679,25 @@ When you go to church on Easter Sunday, you are reminded of how lucky you are as
       &lt;&lt;/if&gt;&gt;
       &lt;&lt;set $NPCsMaster.push({name: weightedEither($fNames), age: _fAge, agenum: _fAgenum, relationship: &quot;master&#39;s daughter&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
     &lt;&lt;elseif _fRel is &quot;master&#39;s wife&quot;&gt;&gt;
-      &lt;&lt;set _wifeIdx to $NPCsMaster.length&gt;&gt;
-      &lt;&lt;set $NPCsMaster.push({name: weightedEither($fNames), age: &quot;pending&quot;, agenum: 0, relationship: &quot;master&#39;s wife&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
+      &lt;&lt;if _wifeIdx gte 0&gt;&gt;
+        &lt;&lt;set _fAgenum to random(5,76)&gt;&gt;
+        &lt;&lt;if _fAgenum gte 50&gt;&gt;&lt;&lt;set _fAge to &quot;elderly adult&quot;&gt;&gt;
+        &lt;&lt;elseif _fAgenum gte 30&gt;&gt;&lt;&lt;set _fAge to &quot;middle-aged adult&quot;&gt;&gt;
+        &lt;&lt;elseif _fAgenum gte 16&gt;&gt;&lt;&lt;set _fAge to &quot;young adult&quot;&gt;&gt;
+        &lt;&lt;elseif _fAgenum gte 10&gt;&gt;&lt;&lt;set _fAge to &quot;adolescent&quot;&gt;&gt;
+        &lt;&lt;else&gt;&gt;&lt;&lt;set _fAge to &quot;child&quot;&gt;&gt;
+        &lt;&lt;/if&gt;&gt;
+        &lt;&lt;if _fAge is &quot;elderly adult&quot; and _oldestChildRank lt 5&gt;&gt;&lt;&lt;set _oldestChildRank to 5&gt;&gt;
+        &lt;&lt;elseif _fAge is &quot;middle-aged adult&quot; and _oldestChildRank lt 4&gt;&gt;&lt;&lt;set _oldestChildRank to 4&gt;&gt;
+        &lt;&lt;elseif _fAge is &quot;young adult&quot; and _oldestChildRank lt 3&gt;&gt;&lt;&lt;set _oldestChildRank to 3&gt;&gt;
+        &lt;&lt;elseif _fAge is &quot;adolescent&quot; and _oldestChildRank lt 2&gt;&gt;&lt;&lt;set _oldestChildRank to 2&gt;&gt;
+        &lt;&lt;elseif _fAge is &quot;child&quot; and _oldestChildRank lt 1&gt;&gt;&lt;&lt;set _oldestChildRank to 1&gt;&gt;
+        &lt;&lt;/if&gt;&gt;
+        &lt;&lt;set $NPCsMaster.push({name: weightedEither($fNames), age: _fAge, agenum: _fAgenum, relationship: &quot;master&#39;s daughter&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
+      &lt;&lt;else&gt;&gt;
+        &lt;&lt;set _wifeIdx to $NPCsMaster.length&gt;&gt;
+        &lt;&lt;set $NPCsMaster.push({name: weightedEither($fNames), age: &quot;pending&quot;, agenum: 0, relationship: &quot;master&#39;s wife&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
+      &lt;&lt;/if&gt;&gt;
     &lt;&lt;/if&gt;&gt;
   &lt;&lt;else&gt;&gt;
     &lt;&lt;set _mRel to either(&quot;master&#39;s son&quot;, &quot;master&#39;s father&quot;)&gt;&gt;


### PR DESCRIPTION
In addMasterHousehold (pid=14), _wifeIdx was a single integer that was overwritten each time the loop rolled "master's wife". Only the last wife had her age resolved after the loop; all earlier wives remained with age: "pending" and agenum: 0.

Fix: when a wife already exists (_wifeIdx gte 0), the duplicate roll now generates a master's daughter with proper agenum/age bracket logic instead of a second wife entry.

https://claude.ai/code/session_01UxgARD7EgVDerKfv5HtNkd