### PR TITLE
Fix <<while>> macro error — replace with <<for ; condition; >> — bump…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v1.21" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v1.22" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -2382,9 +2382,9 @@ John: 1500, Thomas: 1300, William: 1300, Richard: 620, Robert: 600, Henry: 500, 
     &lt;&lt;setAge&gt;&gt;
     &lt;&lt;nobr&gt;&gt;
         &lt;&lt;if random(1,2) eq 1&gt;&gt;
-            &lt;&lt;set _n to weightedEither($fNames)&gt;&gt;&lt;&lt;while _usedChildNames.includes(_n)&gt;&gt;&lt;&lt;set _n to weightedEither($fNames)&gt;&gt;&lt;&lt;/while&gt;&gt;&lt;&lt;set _usedChildNames.push(_n)&gt;&gt;&lt;&lt;set $NPCs.push({ name: _n, agenum: $NPCAgeNum, age: $NPCAge, relationship: &quot;daughter&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
+            &lt;&lt;set _n to weightedEither($fNames)&gt;&gt;&lt;&lt;for ; _usedChildNames.includes(_n); &gt;&gt;&lt;&lt;set _n to weightedEither($fNames)&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;set _usedChildNames.push(_n)&gt;&gt;&lt;&lt;set $NPCs.push({ name: _n, agenum: $NPCAgeNum, age: $NPCAge, relationship: &quot;daughter&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
         &lt;&lt;else&gt;&gt;
-            &lt;&lt;set _n to weightedEither($mNames)&gt;&gt;&lt;&lt;while _usedChildNames.includes(_n)&gt;&gt;&lt;&lt;set _n to weightedEither($mNames)&gt;&gt;&lt;&lt;/while&gt;&gt;&lt;&lt;set _usedChildNames.push(_n)&gt;&gt;&lt;&lt;set $NPCs.push({ name: _n, agenum: $NPCAgeNum, age: $NPCAge, relationship: &quot;son&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
+            &lt;&lt;set _n to weightedEither($mNames)&gt;&gt;&lt;&lt;for ; _usedChildNames.includes(_n); &gt;&gt;&lt;&lt;set _n to weightedEither($mNames)&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;set _usedChildNames.push(_n)&gt;&gt;&lt;&lt;set $NPCs.push({ name: _n, agenum: $NPCAgeNum, age: $NPCAge, relationship: &quot;son&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
         &lt;&lt;/if&gt;&gt;
     &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;
@@ -2479,18 +2479,18 @@ John: 1500, Thomas: 1300, William: 1300, Richard: 620, Robert: 600, Henry: 500, 
     &lt;&lt;setAge&gt;&gt;
     &lt;&lt;if $agenum lte 30 and $relationship is &quot;single&quot; and $NPCAgeNum lte 30&gt;&gt;  
         &lt;&lt;if random(1,2) eq 1&gt;&gt;
-          &lt;&lt;set _n to weightedEither($fNames)&gt;&gt;&lt;&lt;while _usedSibNames.includes(_n)&gt;&gt;&lt;&lt;set _n to weightedEither($fNames)&gt;&gt;&lt;&lt;/while&gt;&gt;&lt;&lt;set _usedSibNames.push(_n)&gt;&gt;&lt;&lt;set $NPCs.push({ name: _n, agenum: $NPCAgeNum, age: $NPCAge, relationship: &quot;sister&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
+          &lt;&lt;set _n to weightedEither($fNames)&gt;&gt;&lt;&lt;for ; _usedSibNames.includes(_n); &gt;&gt;&lt;&lt;set _n to weightedEither($fNames)&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;set _usedSibNames.push(_n)&gt;&gt;&lt;&lt;set $NPCs.push({ name: _n, agenum: $NPCAgeNum, age: $NPCAge, relationship: &quot;sister&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
         &lt;&lt;else&gt;&gt;
-          &lt;&lt;set _n to weightedEither($mNames)&gt;&gt;&lt;&lt;while _usedSibNames.includes(_n)&gt;&gt;&lt;&lt;set _n to weightedEither($mNames)&gt;&gt;&lt;&lt;/while&gt;&gt;&lt;&lt;set _usedSibNames.push(_n)&gt;&gt;&lt;&lt;set $NPCs.push({ name: _n, agenum: $NPCAgeNum, age: $NPCAge, relationship: &quot;brother&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
+          &lt;&lt;set _n to weightedEither($mNames)&gt;&gt;&lt;&lt;for ; _usedSibNames.includes(_n); &gt;&gt;&lt;&lt;set _n to weightedEither($mNames)&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;set _usedSibNames.push(_n)&gt;&gt;&lt;&lt;set $NPCs.push({ name: _n, agenum: $NPCAgeNum, age: $NPCAge, relationship: &quot;brother&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
         &lt;&lt;/if&gt;&gt;
 /*        &lt;&lt;if random(1,20) eq 1&gt;&gt;
           &lt;&lt;set $NPCs.push({ name: $nbNames.pluck(), agenum: $NPCAgeNum, age: $NPCAge, relationship: &quot;sibling&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
         &lt;&lt;/if&gt;&gt; */
     &lt;&lt;else&gt;&gt;
       &lt;&lt;if random(1,2) eq 1&gt;&gt;
-        &lt;&lt;set _n to weightedEither($fNames)&gt;&gt;&lt;&lt;while _usedSibNames.includes(_n)&gt;&gt;&lt;&lt;set _n to weightedEither($fNames)&gt;&gt;&lt;&lt;/while&gt;&gt;&lt;&lt;set _usedSibNames.push(_n)&gt;&gt;&lt;&lt;set $NPCsExtended.push({ name: _n, agenum: $NPCAgeNum, age: $NPCAge, relationship: &quot;sister&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
+        &lt;&lt;set _n to weightedEither($fNames)&gt;&gt;&lt;&lt;for ; _usedSibNames.includes(_n); &gt;&gt;&lt;&lt;set _n to weightedEither($fNames)&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;set _usedSibNames.push(_n)&gt;&gt;&lt;&lt;set $NPCsExtended.push({ name: _n, agenum: $NPCAgeNum, age: $NPCAge, relationship: &quot;sister&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
       &lt;&lt;else&gt;&gt;
-        &lt;&lt;set _n to weightedEither($mNames)&gt;&gt;&lt;&lt;while _usedSibNames.includes(_n)&gt;&gt;&lt;&lt;set _n to weightedEither($mNames)&gt;&gt;&lt;&lt;/while&gt;&gt;&lt;&lt;set _usedSibNames.push(_n)&gt;&gt;&lt;&lt;set $NPCsExtended.push({ name: _n, agenum: $NPCAgeNum, age: $NPCAge, relationship: &quot;brother&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
+        &lt;&lt;set _n to weightedEither($mNames)&gt;&gt;&lt;&lt;for ; _usedSibNames.includes(_n); &gt;&gt;&lt;&lt;set _n to weightedEither($mNames)&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;set _usedSibNames.push(_n)&gt;&gt;&lt;&lt;set $NPCsExtended.push({ name: _n, agenum: $NPCAgeNum, age: $NPCAge, relationship: &quot;brother&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
       &lt;&lt;/if&gt;&gt;
  /*     &lt;&lt;if random(1,20) eq 1&gt;&gt;&lt;&lt;set $NPCsExtended.push({ name: $nbNames.pluck(), agenum: $NPCAgeNum, age: $NPCAge, relationship: &quot;sibling&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt; 
       &lt;&lt;/if&gt;&gt; */
@@ -2596,7 +2596,7 @@ John: 1500, Thomas: 1300, William: 1300, Richard: 620, Robert: 600, Henry: 500, 
             &lt;&lt;set $minAge to 0&gt;&gt;
             &lt;&lt;set $maxAge to _mistressAgenum-16&gt;&gt;
             &lt;&lt;setAge&gt;&gt;
-            &lt;&lt;set _n to weightedEither($fNames)&gt;&gt;&lt;&lt;while _usedMasterChildNames.includes(_n)&gt;&gt;&lt;&lt;set _n to weightedEither($fNames)&gt;&gt;&lt;&lt;/while&gt;&gt;&lt;&lt;set _usedMasterChildNames.push(_n)&gt;&gt;&lt;&lt;set $NPCsMaster.push({name: _n, agenum: $NPCAgeNum, age: $NPCAge, relationship: &quot;master&#39;s daughter&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
+            &lt;&lt;set _n to weightedEither($fNames)&gt;&gt;&lt;&lt;for ; _usedMasterChildNames.includes(_n); &gt;&gt;&lt;&lt;set _n to weightedEither($fNames)&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;set _usedMasterChildNames.push(_n)&gt;&gt;&lt;&lt;set $NPCsMaster.push({name: _n, agenum: $NPCAgeNum, age: $NPCAge, relationship: &quot;master&#39;s daughter&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
         &lt;&lt;/if&gt;&gt;
    &lt;&lt;else&gt;&gt;
         &lt;&lt;if _nomasterFather&gt;&gt;
@@ -2622,7 +2622,7 @@ John: 1500, Thomas: 1300, William: 1300, Richard: 620, Robert: 600, Henry: 500, 
             &lt;&lt;set $minAge to 0&gt;&gt;
             &lt;&lt;set $maxAge to _mistressAgenum-16&gt;&gt;
             &lt;&lt;setAge&gt;&gt;
-            &lt;&lt;set _n to weightedEither($mNames)&gt;&gt;&lt;&lt;while _usedMasterChildNames.includes(_n)&gt;&gt;&lt;&lt;set _n to weightedEither($mNames)&gt;&gt;&lt;&lt;/while&gt;&gt;&lt;&lt;set _usedMasterChildNames.push(_n)&gt;&gt;&lt;&lt;set $NPCsMaster.push({name: _n, agenum: $NPCAgeNum, age: $NPCAge, relationship: &quot;master&#39;s son&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
+            &lt;&lt;set _n to weightedEither($mNames)&gt;&gt;&lt;&lt;for ; _usedMasterChildNames.includes(_n); &gt;&gt;&lt;&lt;set _n to weightedEither($mNames)&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;set _usedMasterChildNames.push(_n)&gt;&gt;&lt;&lt;set $NPCsMaster.push({name: _n, agenum: $NPCAgeNum, age: $NPCAge, relationship: &quot;master&#39;s son&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
         &lt;&lt;/if&gt;&gt;
     &lt;&lt;/if&gt;&gt;
 &lt;&lt;/for&gt;&gt;&lt;&lt;/nobr&gt;&gt;


### PR DESCRIPTION
… to v1.22

SugarCube 2 does not have a <<while>> macro. Replaced all eight retry-loop instances introduced in v1.21 with the equivalent C-style <<for>> form:

  <<for ; _usedSibNames.includes(_n); >>...<</for>>

Logic is identical: the loop body re-rolls the name as long as the condition is true; on a unique name the condition is false on entry and the body is skipped.

https://claude.ai/code/session_01APoe1FNdNr4oDvPMzffNgw