### PR TITLE
Fix NPC generation errors in setAge widget interactions — bump to v1.25

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v1.24" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v1.25" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -2468,7 +2468,7 @@ John: 1500, Thomas: 1300, William: 1300, Richard: 620, Robert: 600, Henry: 500, 
         &lt;&lt;if $agenum lte 30 and $relationship is &quot;single&quot;&gt;&gt;
             &lt;&lt;set $NPCs.push({ name: weightedEither($fNames), agenum: $NPCAgeNum, age: $NPCAge, relationship: _type, health: &quot;healthy&quot;, location: $location})&gt;&gt;
         &lt;&lt;else&gt;&gt;
-            &lt;set $NPCsExtended.push({ name: weightedEither($fNames), agenum: $NPCAgeNum, age: $NPCAge, relationship: _type, health: &quot;healthy&quot;, location: $location})&gt;&gt;
+            &lt;&lt;set $NPCsExtended.push({ name: weightedEither($fNames), agenum: $NPCAgeNum, age: $NPCAge, relationship: _type, health: &quot;healthy&quot;, location: $location})&gt;&gt;
         &lt;&lt;/if&gt;&gt;
         &lt;&lt;set $hasMother to true&gt;&gt;
      &lt;&lt;/if&gt;&gt;
@@ -2513,6 +2513,7 @@ John: 1500, Thomas: 1300, William: 1300, Richard: 620, Robert: 600, Henry: 500, 
             &lt;&lt;if random(1,6) is 1&gt;&gt;
                 &lt;&lt;set $NPCs[$NPCs.length-1].relationship to &quot;step-mother&quot;&gt;&gt;
             &lt;&lt;/if&gt;&gt;
+            &lt;&lt;set $MotherAge to $NPCAgeNum&gt;&gt;
             &lt;&lt;set $hasMother to true&gt;&gt;
         &lt;&lt;else&gt;&gt;
             &lt;&lt;set $minAge to $agenum+20&gt;&gt;
@@ -2526,6 +2527,7 @@ John: 1500, Thomas: 1300, William: 1300, Richard: 620, Robert: 600, Henry: 500, 
             &lt;&lt;if random(1,6) is 1&gt;&gt;
                 &lt;&lt;set $NPCs[$NPCs.length-1].relationship to &quot;step-father&quot;&gt;&gt;
             &lt;&lt;/if&gt;&gt;
+            &lt;&lt;set $FatherAge to $NPCAgeNum&gt;&gt;
             &lt;&lt;set $hasFather to true&gt;&gt;
         &lt;&lt;/if&gt;&gt;
     &lt;&lt;/if&gt;&gt;
@@ -2640,9 +2642,9 @@ John: 1500, Thomas: 1300, William: 1300, Richard: 620, Robert: 600, Henry: 500, 
             &lt;&lt;set $minAge to 16&gt;&gt;
         &lt;&lt;/if&gt;&gt;
     &lt;&lt;set $maxAge to _masterAgenum+30&gt;&gt;
-    &lt;&lt;setAge&gt;
+    &lt;&lt;setAge&gt;&gt;
     &lt;&lt;set $NPCsMaster.push({name: weightedEither($fNames), agenum: $NPCAgeNum, age: $NPCAge, relationship: &quot;mistress&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
-    &lt;&lt;set _mistressAgenum to NPCAgeNum&gt;&gt;
+    &lt;&lt;set _mistressAgenum to $NPCAgeNum&gt;&gt;
     &lt;&lt;set _mhhInitsize to 2&gt;&gt;
 &lt;&lt;else&gt;&gt;
     &lt;&lt;set _mistressAgenum to _masterAgenum&gt;&gt;


### PR DESCRIPTION
Five bugs fixed in char-gen-widgets (pid 14):

1. Orphan-prevention mother block (addParentNPC): added <<set $MotherAge to $NPCAgeNum>> before <<set $hasMother to true>>. When a child/adolescent had no parent generated by the random rolls, the forced mother was pushed to $NPCs and $hasMother set true, but $MotherAge was never assigned. This caused addSiblingsNPC to compute undefined-40 = NaN, making random() throw "random min parameter must be an integer".

2. Orphan-prevention father block (addParentNPC): same fix — added <<set $FatherAge to $NPCAgeNum>> before <<set $hasFather to true>>. Without this, addSiblingsNPC's $hasFather branch computed undefined-20 = NaN for $maxAge, producing "random max parameter must be an integer".

3. Mother NPCsExtended push (addParentNPC): fixed <set ... to <<set (missing opening <). Older/married players' mothers were silently not added to the extended household.

4. <<setAge> typo (addMasterHousehold): fixed missing closing > so the macro is properly invoked when generating the master's mistress age.

5. _mistressAgenum assignment (addMasterHousehold): fixed <<set _mistressAgenum to NPCAgeNum>> to <<set _mistressAgenum to $NPCAgeNum>>. Without the $ sigil, NPCAgeNum resolved to undefined, making $maxAge NaN when computing ages for the master's daughters.

https://claude.ai/code/session_01KYB6KuT4dnbfbcCFhajhdi