### PR TITLE
Fix <<health-update>> widget crash when called from Reconnecting pass…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v1.26" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v1.27" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -3954,7 +3954,7 @@ As morning dawns, a terrible realization settles over your &lt;&lt;defHousehold 
 &lt;&lt;/widget&gt;&gt;
 
 &lt;&lt;widget &quot;health-update&quot;&gt;&gt;
-&lt;&lt;silently&gt;&gt;&lt;&lt;for _d range _deceased&gt;&gt;
+&lt;&lt;silently&gt;&gt;&lt;&lt;if ndef _deceased&gt;&gt;&lt;&lt;set _deceased to []&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if ndef _recovered&gt;&gt;&lt;&lt;set _recovered to []&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;for _d range _deceased&gt;&gt;
         &lt;&lt;set $NPCs[_d].health to &quot;deceased&quot;&gt;&gt;
         &lt;&lt;/for&gt;&gt;
  &lt;&lt;for _r range _recovered&gt;&gt;


### PR DESCRIPTION
…age — bump to v1.27

_deceased and _recovered were undefined when <<health-update>> (pid 40) was called from Reconnecting (pid 83), because those arrays are only initialized by the individual Quarantine Week passages. Added <<if ndef>> guards at the top of the widget to default both arrays to [] when not already set, so the <<for>> loops have a valid iterable in all call contexts.

https://claude.ai/code/session_0192AFYvXvQPGNXazSV4FYbW