### PR TITLE
Fix broken <<if>> nesting in Reconnecting passage (pid 83) — bump to …

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v1.27" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v1.28" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -5229,8 +5229,6 @@ You decide to:
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="83" name="Reconnecting" tags="quarantine" position="650,325" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;check-NPCs&gt;&gt;
 &lt;&lt;if _infectedFamily.length gt 0&gt;&gt;Unfortunately, you&#39;re going to be here a while longer. Your &lt;&lt;defHousehold &quot;household&quot;&gt;&gt; is still infected.
-                &lt;&lt;/if&gt;&gt;
-            &lt;&lt;/for&gt;&gt;
 &lt;&lt;if $quarantine is 1&gt;&gt;
 	[[You continue to tend to the sick-&gt;Quarantine, Week 2]] 
 &lt;&lt;elseif $quarantine is 2&gt;&gt;


### PR DESCRIPTION
…v1.28

Stray <<</if>> and <<</for>> closing tags were left in pid 83 after the infected-family check logic was refactored into the <<check-NPCs>> widget. These orphaned tags caused the outer <<if _infectedFamily.length gt 0>> block to close prematurely, leaving the <<else>> / <<</if>> that wrap the "Lord be praised" / <<orphan-check>> section dangling outside any open <<if>>, producing the runtime error:
  Error: child tag <</if>> was found outside of a call to its parent macro <<if>>

Removed the two stray tags so the outer if/else/endif correctly governs both the "still infected" quarantine-week branch and the "survived" orphan-check branch.

https://claude.ai/code/session_016HtkQHJ5kqEY36mrHcitD3