### PR TITLE
Convert Apothecary from page navigation to popup modal — bump to v1.31

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v1.30" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v1.31" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -4903,7 +4903,9 @@ Luckily, there are no plague cases in your &lt;&lt;defParish &quot;parish&quot;&
 &lt;!-- PLACE LINKS TO YOUR MENU BELOW, BUT REMEMBER TO WRAP IN &lt;LI&gt; TAGS --&gt;
 
 &lt;!--removing conditional code on apothecary so it&#39;s always accessible &lt;&lt;if not tags().includes(&quot;quarantine&quot;)&gt;&gt;&lt;&lt;if visited(&quot;First Plague Day&quot;)&gt;&gt;&lt;li&gt;[[Apothecary]]&lt;/li&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;--&gt;
-&lt;li&gt;[[Apothecary]]&lt;/li&gt;
+&lt;li&gt;&lt;&lt;link &quot;Apothecary&quot;&gt;&gt;
+    &lt;&lt;run Dialog.setup(&quot;Apothecary&quot;, &quot;apothecary&quot;); Dialog.wiki(Story.get(&quot;Apothecary&quot;).text); Dialog.open()&gt;&gt;
+&lt;&lt;/link&gt;&gt;&lt;/li&gt;
 &lt;li&gt;&lt;&lt;link &quot;Inventory&quot;&gt;&gt;
     &lt;&lt;run Dialog.setup(&quot;Inventory&quot;, &quot;inventory&quot;); Dialog.wiki(Story.get(&quot;Inventory&quot;).text); Dialog.open()&gt;&gt;
 &lt;&lt;/link&gt;&gt;&lt;/li&gt;
@@ -5030,33 +5032,31 @@ A medicine or treatment meant to promote healing or alleviate symptoms for a dis
 &lt;tr&gt;&lt;h3&gt;Preventative Medicines&lt;/h3&gt;&lt;/tr&gt;
 &lt;tr&gt;
 &lt;td&gt;
-		&lt;&lt;link &quot;Celestial Water&quot;&gt;&gt;
-		&lt;&lt;run Dialog.setup(&quot;Celestial Water&quot;); Dialog.wiki(&quot;Take every morning to prevent catching plague, as many drops as desired stirred into broth, posset, or half a glass of white wine. One month&#39;s dose.&quot;); Dialog.open()&gt;&gt;
-		&lt;&lt;/link&gt;&gt;
+		&lt;span class=&quot;def&quot; data-def=&quot;Take every morning to prevent catching plague, as many drops as desired stirred into broth, posset, or half a glass of white wine. One month&#39;s dose.&quot;&gt;Celestial Water&lt;/span&gt;
 	&lt;/td&gt;
 	&lt;td&gt;&lt;&lt;conversion _celestialPrice&gt;&gt;&lt;/td&gt;
 	&lt;td&gt;$remedies.Celestial.quantity&lt;/td&gt;
 	&lt;td&gt;
 		&lt;&lt;if $money gte _celestialPrice&gt;&gt;
 			&lt;&lt;link &quot;Buy&quot;&gt;&gt;&lt;&lt;money `-1 * _celestialPrice`&gt;&gt;
-				&lt;&lt;set $remedies.Celestial.quantity +=1&gt;&gt;&lt;&lt;run Engine.show()&gt;&gt;
+				&lt;&lt;set $remedies.Celestial.quantity +=1&gt;&gt;&lt;&lt;run $(Dialog.body()).empty(); Dialog.wiki(Story.get(&quot;Apothecary&quot;).text)&gt;&gt;
 			&lt;&lt;/link&gt;&gt;&lt;&lt;else&gt;&gt;You don&#39;t have enough to buy this.
 		&lt;&lt;/if&gt;&gt;
 	&lt;/td&gt;
 &lt;/tr&gt;
-&lt;tr&gt;&lt;td&gt;&lt;&lt;link &quot;London Treacle&quot;&gt;&gt;&lt;&lt;run Dialog.setup(&quot;London Treacle&quot;); Dialog.wiki(&quot;A restorative drink that may help prevent plague infection&quot;); Dialog.open()&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/td&gt;&lt;td&gt;&lt;&lt;conversion _treaclePrice&gt;&gt;&lt;/td&gt;&lt;td&gt;$remedies.Treacle.quantity&lt;/td&gt;
+&lt;tr&gt;&lt;td&gt;&lt;span class=&quot;def&quot; data-def=&quot;A restorative drink that may help prevent plague infection&quot;&gt;London Treacle&lt;/span&gt;&lt;/td&gt;&lt;td&gt;&lt;&lt;conversion _treaclePrice&gt;&gt;&lt;/td&gt;&lt;td&gt;$remedies.Treacle.quantity&lt;/td&gt;
 &lt;td id=&quot;treacle&quot;&gt;
-&lt;&lt;if $money gte _treaclePrice&gt;&gt;&lt;&lt;link &quot;Buy&quot;&gt;&gt;&lt;&lt;money `-1 * _treaclePrice`&gt;&gt;&lt;&lt;set $remedies.Treacle.quantity += 1&gt;&gt;&lt;&lt;run Engine.show()&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;&lt;else&gt;&gt;You don&#39;t have enough to buy this.&lt;&lt;/if&gt;&gt;&lt;/td&gt;&lt;/tr&gt;
+&lt;&lt;if $money gte _treaclePrice&gt;&gt;&lt;&lt;link &quot;Buy&quot;&gt;&gt;&lt;&lt;money `-1 * _treaclePrice`&gt;&gt;&lt;&lt;set $remedies.Treacle.quantity += 1&gt;&gt;&lt;&lt;run $(Dialog.body()).empty(); Dialog.wiki(Story.get(&quot;Apothecary&quot;).text)&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;&lt;else&gt;&gt;You don&#39;t have enough to buy this.&lt;&lt;/if&gt;&gt;&lt;/td&gt;&lt;/tr&gt;
 
 &lt;tr&gt;&lt;h3&gt;Fumigants&lt;/h3&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;td&gt;&lt;&lt;link &quot;A purse of incense&quot;&gt;&gt;&lt;&lt;run Dialog.setup(&quot;Incense Purse&quot;); Dialog.wiki(&quot;A purse of incense to be worn around your neck to prevent catching plague. Must be re-incensed regularly. One month&#39;s supply.&quot;); Dialog.open()&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/td&gt;&lt;td&gt;&lt;&lt;conversion _pursePrice&gt;&gt;&lt;/td&gt;&lt;td&gt;$fumes.Purse.quantity&lt;/td&gt;&lt;td&gt;&lt;&lt;if $money gte _pursePrice&gt;&gt;&lt;&lt;link &quot;Buy&quot;&gt;&gt;&lt;&lt;money `-1 * _pursePrice`&gt;&gt;&lt;&lt;set $fumes.Purse.quantity +=1&gt;&gt;&lt;&lt;run Engine.show()&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;&lt;else&gt;&gt;You don&#39;t have enough to buy this.&lt;&lt;/if&gt;&gt;&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;&lt;span class=&quot;def&quot; data-def=&quot;A purse of incense to be worn around your neck to prevent catching plague. Must be re-incensed regularly. One month&#39;s supply.&quot;&gt;A purse of incense&lt;/span&gt;&lt;/td&gt;&lt;td&gt;&lt;&lt;conversion _pursePrice&gt;&gt;&lt;/td&gt;&lt;td&gt;$fumes.Purse.quantity&lt;/td&gt;&lt;td&gt;&lt;&lt;if $money gte _pursePrice&gt;&gt;&lt;&lt;link &quot;Buy&quot;&gt;&gt;&lt;&lt;money `-1 * _pursePrice`&gt;&gt;&lt;&lt;set $fumes.Purse.quantity +=1&gt;&gt;&lt;&lt;run $(Dialog.body()).empty(); Dialog.wiki(Story.get(&quot;Apothecary&quot;).text)&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;&lt;else&gt;&gt;You don&#39;t have enough to buy this.&lt;&lt;/if&gt;&gt;&lt;/td&gt;&lt;/tr&gt;
 
-&lt;tr&gt;&lt;td&gt;&lt;&lt;link &quot;St. Giles Powder&quot;&gt;&gt;&lt;&lt;run Dialog.setup(&quot;St. Giles Powder&quot;); Dialog.wiki(&quot;Fumigates your home with a pleasant-smelling substance. Burn 1 tsp twice each day as a preventative; burn 1 tsp 4-5 times each day in infected homes. One month&#39;s supply.&quot;); Dialog.open()&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/td&gt;&lt;td&gt;&lt;&lt;conversion _fancyfumesPrice&gt;&gt;&lt;/td&gt;&lt;td&gt;$fumes.Fancy.quantity&lt;/td&gt;&lt;td id=&quot;fancy&quot;&gt;&lt;&lt;if $money gte _fancyfumesPrice&gt;&gt;&lt;&lt;link &quot;Buy&quot;&gt;&gt;&lt;&lt;money `-1 * _fancyfumesPrice`&gt;&gt;&lt;&lt;set $fumes.Fancy.quantity += 1&gt;&gt;&lt;&lt;run Engine.show()&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;&lt;else&gt;&gt;You don&#39;t have enough to buy this.&lt;&lt;/if&gt;&gt;&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;&lt;span class=&quot;def&quot; data-def=&quot;Fumigates your home with a pleasant-smelling substance. Burn 1 tsp twice each day as a preventative; burn 1 tsp 4-5 times each day in infected homes. One month&#39;s supply.&quot;&gt;St. Giles Powder&lt;/span&gt;&lt;/td&gt;&lt;td&gt;&lt;&lt;conversion _fancyfumesPrice&gt;&gt;&lt;/td&gt;&lt;td&gt;$fumes.Fancy.quantity&lt;/td&gt;&lt;td id=&quot;fancy&quot;&gt;&lt;&lt;if $money gte _fancyfumesPrice&gt;&gt;&lt;&lt;link &quot;Buy&quot;&gt;&gt;&lt;&lt;money `-1 * _fancyfumesPrice`&gt;&gt;&lt;&lt;set $fumes.Fancy.quantity += 1&gt;&gt;&lt;&lt;run $(Dialog.body()).empty(); Dialog.wiki(Story.get(&quot;Apothecary&quot;).text)&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;&lt;else&gt;&gt;You don&#39;t have enough to buy this.&lt;&lt;/if&gt;&gt;&lt;/td&gt;&lt;/tr&gt;
 
-&lt;tr&gt;&lt;td&gt;&lt;&lt;link &quot;Cheap Fumigants&quot;&gt;&gt;&lt;&lt;run Dialog.setup(&quot;Cheap Fumigation&quot;); Dialog.wiki(&quot;Fumigates your home with brimstone, saltpeter, and a little myrrh. The myrrh does little to cover the sulfuric smell. Burn 1 tsp twice daily as a preventative; burn 1 tsp 4-5 times each day in infected homes. One month&#39;s supply.&quot;); Dialog.open()&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/td&gt;&lt;td&gt;&lt;&lt;conversion _genericfumesPrice&gt;&gt;&lt;/td&gt;&lt;td&gt;$fumes.Generic.quantity&lt;/td&gt;&lt;td&gt;&lt;&lt;if $money gte _genericfumesPrice&gt;&gt;&lt;&lt;link &quot;Buy&quot;&gt;&gt;&lt;&lt;money `-1 * _genericfumesPrice`&gt;&gt;&lt;&lt;set $fumes.Generic.quantity += 1&gt;&gt;&lt;&lt;run Engine.show()&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;&lt;else&gt;&gt;You don&#39;t have enough to buy this.&lt;&lt;/if&gt;&gt;&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;&lt;span class=&quot;def&quot; data-def=&quot;Fumigates your home with brimstone, saltpeter, and a little myrrh. The myrrh does little to cover the sulfuric smell. Burn 1 tsp twice daily as a preventative; burn 1 tsp 4-5 times each day in infected homes. One month&#39;s supply.&quot;&gt;Cheap Fumigants&lt;/span&gt;&lt;/td&gt;&lt;td&gt;&lt;&lt;conversion _genericfumesPrice&gt;&gt;&lt;/td&gt;&lt;td&gt;$fumes.Generic.quantity&lt;/td&gt;&lt;td&gt;&lt;&lt;if $money gte _genericfumesPrice&gt;&gt;&lt;&lt;link &quot;Buy&quot;&gt;&gt;&lt;&lt;money `-1 * _genericfumesPrice`&gt;&gt;&lt;&lt;set $fumes.Generic.quantity += 1&gt;&gt;&lt;&lt;run $(Dialog.body()).empty(); Dialog.wiki(Story.get(&quot;Apothecary&quot;).text)&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;&lt;else&gt;&gt;You don&#39;t have enough to buy this.&lt;&lt;/if&gt;&gt;&lt;/td&gt;&lt;/tr&gt;
 &lt;/table&gt;&lt;br&gt;
 Remaining money: &lt;&lt;conversion&gt;&gt;&lt;br&gt;
-&lt;&lt;return&gt;&gt;
+&lt;&lt;link &quot;Close&quot;&gt;&gt;&lt;&lt;run Dialog.close()&gt;&gt;&lt;&lt;/link&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;
 
 &lt;img src=&quot;https://iiif.wellcomecollection.org/image/L0064305/full/760%2C/0/default.jpg&quot; width=&quot;100%&quot;&gt;</tw-passagedata><tw-passagedata pid="80" name="preventatives-treatments" tags="widget" position="775,150" size="100,100">&lt;&lt;widget &quot;preventative&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;


### PR DESCRIPTION
The Apothecary was the only menu item that navigated to a separate passage instead of opening a dialog popup. This caused the storyline passage to reload on return, re-running random events, plague infection rolls, and fumigant consumption — creating discontinuities in the story.

Changes:
- storyMenu (pid 72): Replace [[Apothecary]] link with Dialog.setup/wiki/open, matching the pattern used by Inventory and Household Status
- Apothecary (pid 79): Replace Engine.show() buy-button refreshes with in-dialog content refresh via $(Dialog.body()).empty() + Dialog.wiki()
- Replace <<return>> with a "Close" button that calls Dialog.close()
- Convert item description dialog links to data-def tooltip spans to avoid nested dialog conflicts

https://claude.ai/code/session_018kngnCN55swagYwCEAPvqQ