### PR TITLE
Add scrollbars to Apothecary, Inventory, and Household pop-ups — bump…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v1.31" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v1.32" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -818,6 +818,14 @@ ul.simple-inventory-list{margin:0 auto;padding:0}.simple-inventory-listing{list-
 .shopping-interface {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
+}
+
+/* Scrollable pop-up dialogs for Apothecary, Inventory, and Household */
+#ui-dialog-body.apothecary,
+#ui-dialog-body.inventory,
+#ui-dialog-body.household {
+    max-height: 70vh;
+    overflow-y: auto;
 }</style><script role="script" id="twine-user-script" type="text/twine-javascript">/* adding tooltip behavior modification for mobile*/
 $(document).on('mouseenter', '.def', function() {
     if (!('ontouchstart' in window)) {


### PR DESCRIPTION
… to v1.32

Adds max-height: 70vh and overflow-y: auto to the three sidebar pop-up dialog bodies (.apothecary, .inventory, .household) so that users can scroll when pop-up content exceeds the visible screen area.

https://claude.ai/code/session_014acuDnagPs1BVLZNgr9V8F