### PR TITLE
Add fumes and remedies stats section to end-game stats page — bump to…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v1.41" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v1.42" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -4601,6 +4601,26 @@ But at least you didn&#39;t die of plague!
 &lt;&lt;/for&gt;&gt;&lt;/ol&gt;
 &lt;&lt;else&gt;&gt;
 &lt;p&gt;No decisions recorded yet.&lt;/p&gt;&lt;&lt;/if&gt;&gt;
+
+&lt;h3&gt;Fumes and Remedies&lt;/h3&gt;
+
+&lt;h4&gt;Fumigants&lt;/h4&gt;
+&lt;p&gt;Using fumigants during quarantine decreased the chance of plague spreading to each healthy member of your household by 50% (from a 1 in 2 chance to a 1 in 4 chance per person per week).&lt;/p&gt;
+&lt;table width=90%&gt;&lt;th width=70%&gt;Item&lt;/th&gt;&lt;th width=30%&gt;Remaining&lt;/th&gt;
+&lt;&lt;for _key range $fumes&gt;&gt;
+&lt;tr&gt;&lt;td&gt;_key.name&lt;/td&gt;&lt;td&gt;_key.quantity&lt;/td&gt;&lt;/tr&gt;
+&lt;&lt;/for&gt;&gt;
+&lt;/table&gt;
+
+&lt;h4&gt;Remedies&lt;/h4&gt;
+&lt;table width=90%&gt;&lt;th width=35%&gt;Item&lt;/th&gt;&lt;th width=15%&gt;Remaining&lt;/th&gt;&lt;th width=50%&gt;Game Effect&lt;/th&gt;
+&lt;tr&gt;&lt;td&gt;$remedies.Plaster.name&lt;/td&gt;&lt;td&gt;$remedies.Plaster.quantity&lt;/td&gt;&lt;td&gt;Decreased the chance of death from plague from 1 in 2 (50%) to 1 in 3 (~33%) for you and your infected household members&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;$remedies.Celestial.name&lt;/td&gt;&lt;td&gt;$remedies.Celestial.quantity&lt;/td&gt;&lt;td&gt;Preventative medicine with no direct effect on survival rates&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;$remedies.Treacle.name&lt;/td&gt;&lt;td&gt;$remedies.Treacle.quantity&lt;/td&gt;&lt;td&gt;No mechanical effect on survival rates&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;$remedies.Cordial.name&lt;/td&gt;&lt;td&gt;$remedies.Cordial.quantity&lt;/td&gt;&lt;td&gt;No mechanical effect on survival rates&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;$remedies.Suppository.name&lt;/td&gt;&lt;td&gt;$remedies.Suppository.quantity&lt;/td&gt;&lt;td&gt;No mechanical effect on survival rates&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;$remedies.Immodium.name&lt;/td&gt;&lt;td&gt;$remedies.Immodium.quantity&lt;/td&gt;&lt;td&gt;No mechanical effect on survival rates&lt;/td&gt;&lt;/tr&gt;
+&lt;/table&gt;
 
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="49" name="transported" tags="" position="1900,475" size="100,100">The local authorities decide to have you bound into &lt;&lt;defIndenturedServitude &quot;indentured servitude&quot;&gt;&gt; and shipped to the colony of Virginia. 
 &lt;br&gt;


### PR DESCRIPTION
… v1.42

Add a new "Fumes and Remedies" section to the stats passage (pid=48) that displays all fumigants and remedies with remaining quantities and their actual game effects. Fumigants reduced plague spread by 50% (from 1 in 2 to 1 in 4 per person per week). Only the blistering plaster had a mechanical effect on survival (death from 50% to ~33%).

https://claude.ai/code/session_01PPQAGSSfmXKtkY6VNxDgLB