### PR TITLE
Add dismiss-servant widget for servants with bad reputation — bump to…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v1.44" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v1.45" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -6680,6 +6680,9 @@ Unfortunately, you have suffered a miscarriage and are no longer pregnant. &lt;&
 	&lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 
+/* Servant dismissal for bad reputation */
+&lt;&lt;dismiss-servant&gt;&gt;
+
 /* Prevent repeat infections */
 &lt;&lt;if $plagueInfection is 1 and $playerPlagueStatus is &quot;recovered&quot;&gt;&gt;
 	&lt;&lt;set $plagueInfection to 2&gt;&gt;
@@ -6764,7 +6767,14 @@ Unfortunately, you have suffered a miscarriage and are no longer pregnant. &lt;&
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="115" name="Claude-widgets" tags="widget" position="425,1075" size="100,100">/* all widgets generated via Claude  or other AI should be temporarily placed here then manually moved to new locations as needed */
 
-</tw-passagedata><tw-passagedata pid="116" name="june-1665-helper-widget" tags="widget" position="575,975" size="100,100">&lt;&lt;widget &quot;june-1665-helper&quot;&gt;&gt;
+&lt;&lt;widget &quot;dismiss-servant&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
+&lt;&lt;if $socio is &quot;servants&quot; and $reputation lte 2&gt;&gt;
+	&lt;&lt;if random(1,2) is 1&gt;&gt;
+		Due to your poor reputation, your master has dismissed you and you have been unable to find a new position. You will have to hope you can &lt;&lt;link &quot;survive as a day labourer&quot;&gt;&gt;&lt;&lt;set $socio to &quot;day labourers&quot;&gt;&gt;&lt;&lt;if $relationship is &quot;single&quot; or $relationship is &quot;betrothed&quot;&gt;&gt;&lt;&lt;set $NPCs to $NPCsExtended.slice()&gt;&gt;&lt;&lt;set $NPCsExtended to []&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $NPCsMaster to []&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;NPCpronouns&gt;&gt;&lt;&lt;/link&gt;&gt;.
+		&lt;br&gt;&lt;br&gt;
+	&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="116" name="june-1665-helper-widget" tags="widget" position="575,975" size="100,100">&lt;&lt;widget &quot;june-1665-helper&quot;&gt;&gt;
 &lt;&lt;nobr&gt;&gt;
 The &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; grows worse and the streets are soon filled with coaches and wagons full of people fleeing with their goods to the countryside. The &lt;&lt;defQueenMother &quot;Queen Mother&quot;&gt;&gt; &lt;&lt;defHenriettaMaria &quot;Henrietta Maria&quot;&gt;&gt; moves back to France&lt;&lt;if $religion is &quot;Catholic&quot;&gt;&gt;, much to your dismay, and that of your fellow Catholics who flock to her chapel each week&lt;&lt;else&gt;&gt;, much to your relief, and that of all your fellow God-fearing &lt;&lt;defProtestants &quot;Protestants&quot;&gt;&gt;&lt;&lt;/if&gt;&gt;. On June 29th, the King packs up his entire &lt;&lt;defHousehold &quot;household&quot;&gt;&gt; in 148 carriages and moves 12 miles away, to his palace at &lt;&lt;defHamptonCourt &quot;Hampton Court&quot;&gt;&gt;.
     &lt;br&gt;&lt;br&gt;


### PR DESCRIPTION
… v1.45

When a servant's reputation falls to "a worthless and base rogue" ($reputation <= 2), there is a 50/50 chance each month that their master dismisses them. The player must click "survive as a day labourer" to acknowledge the change, which sets $socio to "day labourers" and handles household NPC transitions (removing master's NPCs for live-in servants, or clearing $NPCsMaster for servants with separate households).

https://claude.ai/code/session_01HJFwrZYSjZ1dejYrsHkkuY