### PR TITLE
Fix dismiss-servant widget to run state changes immediately — bump to…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v1.45" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v1.46" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -6770,7 +6770,7 @@ Unfortunately, you have suffered a miscarriage and are no longer pregnant. &lt;&
 &lt;&lt;widget &quot;dismiss-servant&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
 &lt;&lt;if $socio is &quot;servants&quot; and $reputation lte 2&gt;&gt;
 	&lt;&lt;if random(1,2) is 1&gt;&gt;
-		Due to your poor reputation, your master has dismissed you and you have been unable to find a new position. You will have to hope you can &lt;&lt;link &quot;survive as a day labourer&quot;&gt;&gt;&lt;&lt;set $socio to &quot;day labourers&quot;&gt;&gt;&lt;&lt;if $relationship is &quot;single&quot; or $relationship is &quot;betrothed&quot;&gt;&gt;&lt;&lt;set $NPCs to $NPCsExtended.slice()&gt;&gt;&lt;&lt;set $NPCsExtended to []&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $NPCsMaster to []&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;NPCpronouns&gt;&gt;&lt;&lt;/link&gt;&gt;.
+		&lt;&lt;set $socio to &quot;day labourers&quot;&gt;&gt;&lt;&lt;if $relationship is &quot;single&quot; or $relationship is &quot;betrothed&quot;&gt;&gt;&lt;&lt;set $NPCs to $NPCsExtended.slice()&gt;&gt;&lt;&lt;set $NPCsExtended to []&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $NPCsMaster to []&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;NPCpronouns&gt;&gt;Due to your poor reputation, your master has dismissed you and you have been unable to find a new position. You will have to hope you can survive as a day labourer.
 		&lt;br&gt;&lt;br&gt;
 	&lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;


### PR DESCRIPTION
… v1.46

Replace the <<link>> wrapper with inline <<set>> calls so $socio, household NPC changes, and <<NPCpronouns>> execute at render time instead of waiting for a click. "survive as a day labourer" is now plain display text.

https://claude.ai/code/session_01HJFwrZYSjZ1dejYrsHkkuY