### PR TITLE
Weight $age selection in random-character widget by historical demogr…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v1.48" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v1.49" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -3069,7 +3069,7 @@ Household size: &lt;&lt;if $fled is 5&gt;&gt;&lt;&lt;set _hhSize to $FledFamily.
 &lt;&lt;widget &quot;random-character&quot;&gt;&gt;
 &lt;&lt;nobr&gt;&gt;
 &lt;&lt;set $gender to either(&quot;male&quot;, &quot;female&quot;)&gt;&gt;
-&lt;&lt;set $age to either(&quot;child&quot;, &quot;adolescent&quot;, &quot;young adult&quot;, &quot;middle-aged adult&quot;, &quot;elderly adult&quot;)&gt;&gt;
+&lt;&lt;set $age to weightedEither({&quot;child&quot;: 14, &quot;adolescent&quot;: 16, &quot;young adult&quot;: 25, &quot;middle-aged adult&quot;: 35, &quot;elderly adult&quot;: 10})&gt;&gt;
 &lt;&lt;if $age is &quot;child&quot; or $age is &quot;adolescent&quot;&gt;&gt;
 &lt;&lt;set $relationship to either(&quot;single&quot;, &quot;betrothed&quot;)&gt;&gt;
 &lt;&lt;else&gt;&gt;


### PR DESCRIPTION
…aphics — bump to v1.49

Replace equal-weight either() with weightedEither() for the player character age selection in the char-gen-widgets passage (pid 14), using 17th-century London demographic data:

  child          14%  (ages 5–9)
  adolescent     16%  (ages 10–15)
  young adult    25%  (ages 16–29)
  middle-aged    35%  (ages 30–49)
  elderly adult  10%  (ages 50+)

Constraints satisfied: child+adolescent = 30% (historical ~30% aged ≤15), elderly = 10% (historical ~10% aged 60+).

https://claude.ai/code/session_019aMJ7MTVnTJbCxEKWyqbAA