### PR TITLE
Add 1665-1666 parish burial and plague CSV

### DIFF
--- a/1665-1666-burials-plague.csv
+++ b/1665-1666-burials-plague.csv
@@ -1,0 +1,12354 @@
+Year,Start-Day,Start-Month,End-Day,End-Month,Parish Name,Total Parish Burials,Parish Plague Burials
+1665,20,December,27,,St ALban Woodstreet,0,0
+1665,20,December,27,,St George Borolphlane,0,0
+1665,20,December,27,,St Martin Ludgate,0,0
+1665,20,December,27,,Alhallows Barking,2,0
+1665,20,December,27,,St Gregory by St Pauls,2,0
+1665,20,December,27,,St Martin Orgars,2,0
+1665,20,December,27,,Alhallows Breadstreet,1,0
+1665,20,December,27,,St Hellen,0,0
+1665,20,December,27,,St Martin Outwitch,0,0
+1665,20,December,27,,Alha••ows Great,0,0
+1665,20,December,27,,St James Dukes place,1,0
+1665,20,December,27,,St Martin Vintrey,2,0
+1665,20,December,27,,Alhallows Honylane,0,0
+1665,20,December,27,,St James Garlickhithe,0,0
+1665,20,December,27,,St Matthew Fridaystreet,0,0
+1665,20,December,27,,Al••llows Lesse,2,0
+1665,20,December,27,,St John Baptist,1,0
+1665,20,December,27,,St Maudlin Milkstreet,0,0
+1665,20,December,27,,A••allows Lumbardstreet,2,0
+1665,20,December,27,,St John Evangelist,0,0
+1665,20,December,27,,St Maudlin Oldfishstreet,1,0
+1665,20,December,27,,Alh•llows Staining,0,0
+1665,20,December,27,,St John Zachary,0,0
+1665,20,December,27,,St Michael Bassishaw,1,0
+1665,20,December,27,,A••allows the Wall,0,0
+1665,20,December,27,,St Katharine Coleman,0,0
+1665,20,December,27,,St Michael Cornhil,2,0
+1665,20,December,27,,St Alphage,0,0
+1665,20,December,27,,St Katharine Crechurch,0,0
+1665,20,December,27,,St Michael Crookedlane,1,0
+1665,20,December,27,,St Andrew Hubbard,1,0
+1665,20,December,27,,St Lawrence Jewry,1,0
+1665,20,December,27,,St Michael Queenhithe,0,0
+1665,20,December,27,,St Andrew Undershaft,1,0
+1665,20,December,27,,St Lawrence Pountney,0,0
+1665,20,December,27,,St Michael Quern,0,0
+1665,20,December,27,,St Andrew Wardrobe,3,0
+1665,20,December,27,,St Leonard Eastcheap,0,0
+1665,20,December,27,,St Michael Royal,1,0
+1665,20,December,27,,St Ann Aldersgate,1,0
+1665,20,December,27,,St Leonard Fosterlane,0,0
+1665,20,December,27,,St Michael Woodstreet,2,0
+1665,20,December,27,,St Ann Blackfryers,0,0
+1665,20,December,27,,St Magnus Parish,1,0
+1665,20,December,27,,St Mildred Breadstreet,0,0
+1665,20,December,27,,St Antholins Parish,0,0
+1665,20,December,27,,St Margaret Lothbury,0,0
+1665,20,December,27,,St Mildred Poultrey,1,0
+1665,20,December,27,,St Austins Parish,0,0
+1665,20,December,27,,St Margaret Moses,0,0
+1665,20,December,27,,St Nicholas Acons,0,0
+1665,20,December,27,,St Bartholomew Exchange,0,0
+1665,20,December,27,,St Margaret Newfishstreet,1,0
+1665,20,December,27,,St Nicholas Coleabby,3,0
+1665,20,December,27,,St Bennet Fynck,0,0
+1665,20,December,27,,St Margaret Pattons,0,0
+1665,20,December,27,,St Nicholas Olaves,1,0
+1665,20,December,27,,St Bennet Gracechurch,0,0
+1665,20,December,27,,St Mary Abchurch,0,0
+1665,20,December,27,,St Olave Hartstreet,0,0
+1665,20,December,27,,St Bennet Paulswharf,3,0
+1665,20,December,27,,St Mary Aldermanbury,0,0
+1665,20,December,27,,St Olave Jewry,0,0
+1665,20,December,27,,St Bennet Sherehog,0,0
+1665,20,December,27,,St Mary Aldermary,1,0
+1665,20,December,27,,St Olave Silverstreet,2,0
+1665,20,December,27,,St Botolph Billingsgate,0,0
+1665,20,December,27,,St Mary le Bow,1,0
+1665,20,December,27,,St Panc•as Soperlane,0,0
+1665,20,December,27,,Christs Church,2,0
+1665,20,December,27,,St Mary Bothaw,0,0
+1665,20,December,27,,St Peter Cheap,0,0
+1665,20,December,27,,St Christophers,0,0
+1665,20,December,27,,St Mary Colechurch,0,0
+1665,20,December,27,,St Peter Cornhil,0,0
+1665,20,December,27,,St Clement Eastcheap,0,0
+1665,20,December,27,,St Mary Hill,0,0
+1665,20,December,27,,St Peter Paulswharf,0,0
+1665,20,December,27,,St Dionis Backchurch,1,0
+1665,20,December,27,,St Mary Mounthaw,0,0
+1665,20,December,27,,St Peter Poor,2,0
+1665,20,December,27,,St Dunstan East,1,0
+1665,20,December,27,,St Mary Sommerset,0,0
+1665,20,December,27,,St Steven Colemanstreet,3,0
+1665,20,December,27,,St Edmund Lumbardstr,1,0
+1665,20,December,27,,St Mary Stayning,0,0
+1665,20,December,27,,St Steven Walbrook,1,0
+1665,20,December,27,,St Ethelborough,1,0
+1665,20,December,27,,St Mary Woolchurch,1,0
+1665,20,December,27,,St Swithin,0,0
+1665,20,December,27,,St Faith,0,0
+1665,20,December,27,,St Mary Woolnoth,0,0
+1665,20,December,27,,St Thomas Apostle,0,0
+1665,20,December,27,,St Foster,3,0
+1665,20,December,27,,St Martin Iremongerlane,0,0
+1665,20,December,27,,Trinity Parish,0,0
+1665,20,December,27,,St Gabriel Fenchurch,0,0
+1665,20,December,27,,St Andrew Holborn,19,0
+1665,20,December,27,,St Botolph Aldgate,12,0
+1665,20,December,27,,Saviours Southwark,8,0
+1665,20,December,27,,St Bartholomew Great,5,0
+1665,20,December,27,,St Botolph Bishopsgate,9,0
+1665,20,December,27,,S. Sepulchres Parish,21,0
+1665,20,December,27,,St Bartholomew Lesse,2,0
+1665,20,December,27,,St Dunstan West,3,0
+1665,20,December,27,,St Thomas Southwark,0,0
+1665,20,December,27,,St Bridget,0,0
+1665,20,December,27,,St George Southwark,2,0
+1665,20,December,27,,Trinity Minories,0,0
+1665,20,December,27,,Bridewel Precinct,1,0
+1665,20,December,27,,St Giles Cripplegate,27,0
+1665,20,December,27,,At the Pesthouse,0,0
+1665,20,December,27,,St Botolph Aldersgate,2,0
+1665,20,December,27,,St Olave Southwark,14,0
+1665,20,December,27,,St Gile• in the fields,14,1
+1665,20,December,27,,Lambeth Parish,2,0
+1665,20,December,27,,St Mary Islington,0,0
+1665,20,December,27,,Hackney Parish,0,0
+1665,20,December,27,,St Leonard Shoreditch,9,0
+1665,20,December,27,,St Mary Whitechappel,8,0
+1665,20,December,27,,St James Clerkenwel,8,0
+1665,20,December,27,,St Magdalen Bermondsey,4,0
+1665,20,December,27,,Rothorith Parish,0,0
+1665,20,December,27,,St Kath. near the Tower,4,0
+1665,20,December,27,,St Mary Newington,0,0
+1665,20,December,27,,Stepney Parish,18,0
+1665,20,December,27,,St Clement Danes,8,0
+1665,20,December,27,,St Martin in the fields,17,0
+1665,20,December,27,,St Margaret Westminster,14,0
+1665,20,December,27,,St Paul Covent Garden,0,0
+1665,20,December,27,,St Mary Savoy,0,0
+1665,27,December,3,January,St ALban Woodstreet,2,0
+1665,27,December,3,January,St George Botolphlane,0,0
+1665,27,December,3,January,St Martin Ludgate,2,0
+1665,27,December,3,January,Alhallows Barking,1,0
+1665,27,December,3,January,St Gregory by St Pauls,4,0
+1665,27,December,3,January,St Martin Orgars,0,0
+1665,27,December,3,January,Alhallows Breadstreet,0,0
+1665,27,December,3,January,St Hellen,0,0
+1665,27,December,3,January,St Martin Outwitch,0,0
+1665,27,December,3,January,Alhallows Great,1,0
+1665,27,December,3,January,St James Dukes place,1,0
+1665,27,December,3,January,St Martin Vintrey,0,0
+1665,27,December,3,January,Alhallows Honylane,0,0
+1665,27,December,3,January,St James Garlickhithe,1,0
+1665,27,December,3,January,St Matthew Fridaystreet,0,0
+1665,27,December,3,January,Alhallows Lesse,0,0
+1665,27,December,3,January,St John Baptist,1,0
+1665,27,December,3,January,St Maudlin Milkstreet,0,0
+1665,27,December,3,January,Alhallows Lumbardstreet,1,0
+1665,27,December,3,January,St John Evangelist,0,0
+1665,27,December,3,January,St Maudlin Oldfishstreet,0,0
+1665,27,December,3,January,Alhallows Staining,0,0
+1665,27,December,3,January,St John Zachary,1,0
+1665,27,December,3,January,St Michael Bas•••haw,0,0
+1665,27,December,3,January,Alhallows the Wall,0,0
+1665,27,December,3,January,St Katharine Coleman,0,0
+1665,27,December,3,January,St Michael Cornhil,0,0
+1665,27,December,3,January,St Alphage,0,0
+1665,27,December,3,January,St Katharine Crechurch,0,0
+1665,27,December,3,January,St Michael Crookedlane,0,0
+1665,27,December,3,January,St Andrew Hubbard,1,0
+1665,27,December,3,January,St Lawrence Jewry,0,0
+1665,27,December,3,January,St Michael Queenhithe,0,0
+1665,27,December,3,January,St Andrew Undershaft,2,0
+1665,27,December,3,January,St Lawrence Pountney,0,0
+1665,27,December,3,January,St Michael Quern,1,0
+1665,27,December,3,January,St Andrew Wardrobe,4,0
+1665,27,December,3,January,St Leonard Eastcheap,1,0
+1665,27,December,3,January,St Michael Royal,0,0
+1665,27,December,3,January,St Ann Aldersgate,0,0
+1665,27,December,3,January,St Leonard Fosterlane,1,0
+1665,27,December,3,January,St Michael Woodstreet,2,0
+1665,27,December,3,January,St Ann Blackfryers,4,0
+1665,27,December,3,January,St Magnus Parish,3,0
+1665,27,December,3,January,St Mildred Breadstreet,0,0
+1665,27,December,3,January,St Antholins Parish,0,0
+1665,27,December,3,January,St Margaret Lothbury,1,0
+1665,27,December,3,January,St Mildred Poultrey,0,0
+1665,27,December,3,January,St Austins Parish,0,0
+1665,27,December,3,January,St Margaret Moses,1,0
+1665,27,December,3,January,St Nicholas Acons,0,0
+1665,27,December,3,January,St Bartholomew Exchange,0,0
+1665,27,December,3,January,St Margaret Newfishstreet,0,0
+1665,27,December,3,January,St Nicholas Coleabby,0,0
+1665,27,December,3,January,St Bennet Fynck,2,0
+1665,27,December,3,January,St Margaret Pattons,0,0
+1665,27,December,3,January,St Nicholas Olaves,0,0
+1665,27,December,3,January,St Bennet Gracechurch,0,0
+1665,27,December,3,January,St Mary Abchurch,1,0
+1665,27,December,3,January,St Olave Hartstreet,2,0
+1665,27,December,3,January,St Bennet Paulswharf,2,0
+1665,27,December,3,January,St Mary Aldermanbury,0,0
+1665,27,December,3,January,St Olave Jewry,0,0
+1665,27,December,3,January,St Bennet Sherehog,1,0
+1665,27,December,3,January,St Mary Aldermary,2,0
+1665,27,December,3,January,St Olave Silverstreet,2,0
+1665,27,December,3,January,St Botolph Billingsgate,2,0
+1665,27,December,3,January,St Mary le Bow,0,0
+1665,27,December,3,January,St Pancras Soperlane,0,0
+1665,27,December,3,January,Christs Church,1,0
+1665,27,December,3,January,St Mary Bothaw,0,0
+1665,27,December,3,January,St Peter Cheap,0,0
+1665,27,December,3,January,St Christophers,0,0
+1665,27,December,3,January,St Mary Colechurch,0,0
+1665,27,December,3,January,St Peter Cornhil,0,0
+1665,27,December,3,January,St Clement Eastcheap,0,0
+1665,27,December,3,January,St Mary Hill,0,0
+1665,27,December,3,January,St Peter Paulswharf,0,0
+1665,27,December,3,January,St Dionis Backchurch,1,0
+1665,27,December,3,January,St Mary Mounthaw,1,0
+1665,27,December,3,January,St Peter Poor,3,0
+1665,27,December,3,January,St Dunstan East,3,0
+1665,27,December,3,January,St Mary Sommerset,1,0
+1665,27,December,3,January,St Steven Colemanstreet,2,0
+1665,27,December,3,January,St Edmund Lumbardstr.,0,0
+1665,27,December,3,January,St Mary Stayning,0,0
+1665,27,December,3,January,St Steven Walbrook,0,0
+1665,27,December,3,January,St Ethelborough,0,0
+1665,27,December,3,January,St Mary Woolchurch,0,0
+1665,27,December,3,January,St Swithin,0,0
+1665,27,December,3,January,St Faith,0,0
+1665,27,December,3,January,St Mary Woolnoth,0,0
+1665,27,December,3,January,St Thomas Apostle,0,0
+1665,27,December,3,January,St Foster,0,0
+1665,27,December,3,January,St Martin Iremongerlane,1,0
+1665,27,December,3,January,Trinity Parish,3,0
+1665,27,December,3,January,St Gabriel Fenchurch,0,0
+1665,27,December,3,January,St Andrew Holborn,17,0
+1665,27,December,3,January,St Botolph Aldgate,17,0
+1665,27,December,3,January,Saviours Southwark,10,0
+1665,27,December,3,January,St Bartholomew Great,0,0
+1665,27,December,3,January,St Botolph Bishopsgate,10,0
+1665,27,December,3,January,S. Sepulchres Parish,17,0
+1665,27,December,3,January,St Bartholomew Lesse,2,0
+1665,27,December,3,January,St Dunstan West,7,0
+1665,27,December,3,January,St Thomas Southwark,3,0
+1665,27,December,3,January,St Bridget,6,0
+1665,27,December,3,January,St George Southwark,3,0
+1665,27,December,3,January,Trinity Minories,0,0
+1665,27,December,3,January,Bridewel Precinct,0,0
+1665,27,December,3,January,St Giles Cripplegate,23,0
+1665,27,December,3,January,At the Pesthouse,0,0
+1665,27,December,3,January,St Botolph Aldersgate,6,0
+1665,27,December,3,January,St Olave Southwark,15,0
+1665,27,December,3,January,St Giles in the fields,16,0
+1665,27,December,3,January,Lambeth Parish,4,0
+1665,27,December,3,January,St Mary Illington,0,0
+1665,27,December,3,January,Hackney Parish,6,0
+1665,27,December,3,January,St Leonard Shoreditch,5,0
+1665,27,December,3,January,St Mary Whitechappel,17,0
+1665,27,December,3,January,St James Clerkenwel,9,0
+1665,27,December,3,January,St Magdalen Bermondsey,4,0
+1665,27,December,3,January,Rothorith Parish,0,0
+1665,27,December,3,January,St Kath. near the Tower,1,0
+1665,27,December,3,January,St Mary Newington,7,0
+1665,27,December,3,January,Stepney Parish,33,0
+1665,27,December,3,January,St Clement Danes,12,0
+1665,27,December,3,January,St Martin in the fields,17,0
+1665,27,December,3,January,St Margaret Westminster,14,0
+1665,27,December,3,January,St Paul Covent Garden,0,0
+1665,27,December,3,January,St Mary Savoy,2,0
+1665,3,January,10,,St ALban Woodstreet,0,0
+1665,3,January,10,,St George Botolphlane,0,0
+1665,3,January,10,,St Martin Ludgate,4,0
+1665,3,January,10,,Alhallows Barking,4,0
+1665,3,January,10,,St Gregory by St Pauls,2,0
+1665,3,January,10,,St Martin Orgars,1,0
+1665,3,January,10,,Alhallows Breadstreet,0,0
+1665,3,January,10,,St Hellen,1,0
+1665,3,January,10,,St Martin Outwitch,0,0
+1665,3,January,10,,Alhallows Great,1,0
+1665,3,January,10,,St James Dukes place,1,0
+1665,3,January,10,,St Martin Vintrey,2,0
+1665,3,January,10,,Alhallows Honylane,0,0
+1665,3,January,10,,St James Garlickhithe,1,0
+1665,3,January,10,,St Matthew Fridaystreet,1,0
+1665,3,January,10,,Alhallows Lesse,3,0
+1665,3,January,10,,St John Baptist,1,0
+1665,3,January,10,,St Maudlin Milkstreet,0,0
+1665,3,January,10,,Alhallows Lumbardstreet,0,0
+1665,3,January,10,,St John Evangelist,0,0
+1665,3,January,10,,St Maudlin Oldfishstreet,1,0
+1665,3,January,10,,Alhallows Stayning,1,0
+1665,3,January,10,,St John Zachary,0,0
+1665,3,January,10,,St Michael Bassishaw,2,0
+1665,3,January,10,,Alhallows the Wall,7,0
+1665,3,January,10,,St Katharine Coleman,1,0
+1665,3,January,10,,St Michael Cornhil,1,0
+1665,3,January,10,,St Alphage,3,0
+1665,3,January,10,,St Katharine Crechurch,1,0
+1665,3,January,10,,St Michael Crookedlane,0,0
+1665,3,January,10,,St Andrew Hubbard,1,0
+1665,3,January,10,,St Lawrence Jewry,1,0
+1665,3,January,10,,St Michael Queenhithe,3,0
+1665,3,January,10,,St Andrew Undershaft,2,0
+1665,3,January,10,,St Lawrence Pountney,1,0
+1665,3,January,10,,St Michael Quern,0,0
+1665,3,January,10,,St Andrew Wardrobe,3,0
+1665,3,January,10,,St Leonard Eastcheap,0,0
+1665,3,January,10,,St Michael Royal,0,0
+1665,3,January,10,,St Ann Aldersgate,1,0
+1665,3,January,10,,St Leonard Fosterlane,3,0
+1665,3,January,10,,St Michael Woodstreet,1,0
+1665,3,January,10,,St Ann Blackfryers,2,0
+1665,3,January,10,,St Magnus Parish,0,0
+1665,3,January,10,,St Mildred Breadstreet,0,0
+1665,3,January,10,,St Antholins Parish,1,0
+1665,3,January,10,,St Margaret Lothbury,0,0
+1665,3,January,10,,St Mildred Poultrey,1,0
+1665,3,January,10,,St Austins Parish,2,0
+1665,3,January,10,,St Margaret Moses,0,0
+1665,3,January,10,,St Nicholas Acons,0,0
+1665,3,January,10,,St Bartholomew Exchange,0,0
+1665,3,January,10,,St Margaret Newfishstre.,0,0
+1665,3,January,10,,St Nicholas Coleabby,0,0
+1665,3,January,10,,St Bennet Fynck,0,0
+1665,3,January,10,,St Margaret Pattons,0,0
+1665,3,January,10,,St Nicholas Olaves,1,0
+1665,3,January,10,,St Bennet Gracechurch,0,0
+1665,3,January,10,,St Mary Abchurch,1,0
+1665,3,January,10,,St Olave Hartstreet,4,0
+1665,3,January,10,,St Bennet Paulswharf,4,0
+1665,3,January,10,,St Mary Aldermanbury,2,0
+1665,3,January,10,,St Olave Jewry,0,0
+1665,3,January,10,,St Bennet Sherehog,0,0
+1665,3,January,10,,St Mary Aldermary,1,0
+1665,3,January,10,,St Olave Silverstreet,3,0
+1665,3,January,10,,St Botolph Billingsgate,0,0
+1665,3,January,10,,St Mary le Bow,0,0
+1665,3,January,10,,St Pancras Soperlane,1,0
+1665,3,January,10,,Christ Church,5,0
+1665,3,January,10,,St Mary Bothaw,0,0
+1665,3,January,10,,St Peter Cheap,0,0
+1665,3,January,10,,St Christophers,0,0
+1665,3,January,10,,St Mary Colechurch,0,0
+1665,3,January,10,,St Peter Cornhil,0,0
+1665,3,January,10,,St Clement Eastcheap,0,0
+1665,3,January,10,,St Mary Hill,0,0
+1665,3,January,10,,St Peter Paulswharf,0,0
+1665,3,January,10,,St Dionis Backchurch,0,0
+1665,3,January,10,,St Mary Mounthaw,0,0
+1665,3,January,10,,St Peter Poor,1,0
+1665,3,January,10,,St Dunstan East,3,0
+1665,3,January,10,,St Mary Sommerset,0,0
+1665,3,January,10,,St Steven Colemanstreet,2,0
+1665,3,January,10,,St Edmund Lumbardstr.,3,0
+1665,3,January,10,,St Mary Stayning,0,0
+1665,3,January,10,,St Steven Walbrook,0,0
+1665,3,January,10,,St Ethelborough,0,0
+1665,3,January,10,,St Mary Woolchurch,0,0
+1665,3,January,10,,St Swithin,1,0
+1665,3,January,10,,St Faith,0,0
+1665,3,January,10,,St Mary Woolnoth,0,0
+1665,3,January,10,,St Thomas Apostles,1,0
+1665,3,January,10,,St Foster,0,0
+1665,3,January,10,,St Martin Iremongerlane,0,0
+1665,3,January,10,,Trinity Parish,0,0
+1665,3,January,10,,St Gabriel Fenchurch,1,0
+1665,3,January,10,,St Andrew Holborn,25,0
+1665,3,January,10,,St Botolph Aldgate,13,0
+1665,3,January,10,,Saviours Southwark,12,0
+1665,3,January,10,,St Bartholomew Great,0,0
+1665,3,January,10,,St Botolph Bishopsgate,10,0
+1665,3,January,10,,S Sepulchres Parish,21,0
+1665,3,January,10,,St Bartholomew Lesse,0,0
+1665,3,January,10,,St Dunstan West,5,0
+1665,3,January,10,,St Thomas Southwark,0,0
+1665,3,January,10,,St Bridget,11,0
+1665,3,January,10,,St George Southwark,3,0
+1665,3,January,10,,Trinity Minories,0,0
+1665,3,January,10,,Bridewel Precinct,0,0
+1665,3,January,10,,St Giles Cripplegate,28,0
+1665,3,January,10,,At the Pesthouse,0,0
+1665,3,January,10,,St Botolph Aldersgate,1,0
+1665,3,January,10,,St Olave Southwark,13,0
+1665,3,January,10,,St Giles in the fields,12,0
+1665,3,January,10,,Lambeth Parish,5,0
+1665,3,January,10,,St Mary Islington,0,0
+1665,3,January,10,,Hackney Parish,0,0
+1665,3,January,10,,St Leonard Shoreditch,8,0
+1665,3,January,10,,St Mary Whitechappel,13,0
+1665,3,January,10,,St James Clerkenwel,7,0
+1665,3,January,10,,St Magdalen Bermondsey,6,0
+1665,3,January,10,,Rothorith Parish,0,0
+1665,3,January,10,,St Kath. near the Tower,6,0
+1665,3,January,10,,St Mary Newington,3,0
+1665,3,January,10,,Stepney Parish,40,0
+1665,3,January,10,,St Clement Danes,8,0
+1665,3,January,10,,St Martin in the fields,24,0
+1665,3,January,10,,St Margaret Westminster,19,0
+1665,3,January,10,,St Paul Covent Garden,3,0
+1665,3,January,10,,St Mary Savoy,3,0
+1665,10,January,17,,St ALban Woodstreet,0,0
+1665,10,January,17,,St George Botolphlane,0,0
+1665,10,January,17,,St Martin Ludgate,2,0
+1665,10,January,17,,Alhallows Barking,4,0
+1665,10,January,17,,St Gregory by St Pauls,2,0
+1665,10,January,17,,St Martin Orgars,0,0
+1665,10,January,17,,Alhallows Breadstreet,1,0
+1665,10,January,17,,St Hellen,0,0
+1665,10,January,17,,St Martin Outwitch,0,0
+1665,10,January,17,,Alhallows Great,4,0
+1665,10,January,17,,St James Dukes place,2,0
+1665,10,January,17,,St Martin Vintrey,0,0
+1665,10,January,17,,Alhallows Honylane,0,0
+1665,10,January,17,,St James Garlickhithe,0,0
+1665,10,January,17,,St Matthew Fridaystreet,0,0
+1665,10,January,17,,Alhallows Lesse,0,0
+1665,10,January,17,,St John Baptist,0,0
+1665,10,January,17,,St Maudlin Milkstreet,0,0
+1665,10,January,17,,Alhallows Lumbardstreet,2,0
+1665,10,January,17,,St John Evangelist,0,0
+1665,10,January,17,,St Maudlin Oldfishstreet,1,0
+1665,10,January,17,,Alhallows Stayning,2,0
+1665,10,January,17,,St John Zachary,0,0
+1665,10,January,17,,St Michael Bassishaw,1,0
+1665,10,January,17,,Alhallows the Wall,3,0
+1665,10,January,17,,St Katharine Coleman,2,0
+1665,10,January,17,,St Michael Cornhil,2,0
+1665,10,January,17,,St Alphage,0,0
+1665,10,January,17,,St Katharine Crechurch,2,0
+1665,10,January,17,,St Michael Crookedlane,1,0
+1665,10,January,17,,St Andrew Hubbard,1,0
+1665,10,January,17,,St Lawrence Jewry,1,0
+1665,10,January,17,,St Michael Queenhithe,0,0
+1665,10,January,17,,St Andrew Undershaft,3,0
+1665,10,January,17,,St Lawrence Pountney,0,0
+1665,10,January,17,,St Michael Quern,1,0
+1665,10,January,17,,St Andrew Wardrobe,4,0
+1665,10,January,17,,St Leonard Eastcheap,0,0
+1665,10,January,17,,St Michael Royal,0,0
+1665,10,January,17,,St Ann Aldersgate,1,0
+1665,10,January,17,,St Leonard Fosterlane,2,0
+1665,10,January,17,,St Michael Woodstreet,1,0
+1665,10,January,17,,St Ann Blackfryers,1,0
+1665,10,January,17,,St Magnus Parish,1,0
+1665,10,January,17,,St Mildred Breadstreet,0,0
+1665,10,January,17,,St Antholins Parish,1,0
+1665,10,January,17,,St Margaret Lothbury,1,0
+1665,10,January,17,,St Mildred Poultrey,0,0
+1665,10,January,17,,St Austins Parish,0,0
+1665,10,January,17,,St Margaret Moses,0,0
+1665,10,January,17,,St Nicholas Acons,0,0
+1665,10,January,17,,St Bartholomew Exchange,0,0
+1665,10,January,17,,St Margaret Newfishstre.,0,0
+1665,10,January,17,,St Nicholas Coleabby,0,0
+1665,10,January,17,,St Bennet Fynck,3,0
+1665,10,January,17,,St Margaret Pattons,1,0
+1665,10,January,17,,St Nicholas Olaves,0,0
+1665,10,January,17,,St Bennet Gracechurch,0,0
+1665,10,January,17,,St Mary Abchurch,0,0
+1665,10,January,17,,St Olave Hartstreet,0,0
+1665,10,January,17,,St Bennet Paulswharf,1,0
+1665,10,January,17,,St Mary Aldermanbury,2,0
+1665,10,January,17,,St Olave Jewry,0,0
+1665,10,January,17,,St Bennet Sherehog,0,0
+1665,10,January,17,,St Mary Aldermary,1,0
+1665,10,January,17,,St Olave Silverstreet,0,0
+1665,10,January,17,,St Botolph Billingsgate,0,0
+1665,10,January,17,,St Mary le Bow,1,0
+1665,10,January,17,,St Pancras Soperlane,2,0
+1665,10,January,17,,Christ Church,10,0
+1665,10,January,17,,St Mary Bothaw,1,0
+1665,10,January,17,,St Peter Cheap,1,0
+1665,10,January,17,,St Christophers,0,0
+1665,10,January,17,,St Mary Colechurch,0,0
+1665,10,January,17,,St Peter Cornhil,2,0
+1665,10,January,17,,St Clement Eastcheap,1,0
+1665,10,January,17,,St Mary Hill,0,0
+1665,10,January,17,,St Peter Paulswharf,0,0
+1665,10,January,17,,St Dionis Backchurch,0,0
+1665,10,January,17,,St Mary Mounthaw,1,0
+1665,10,January,17,,St Peter Poor,1,0
+1665,10,January,17,,St Dunstan East,0,0
+1665,10,January,17,,St Mary Sommerset,3,0
+1665,10,January,17,,St Steven Colemanstreet,3,0
+1665,10,January,17,,St Edmund Lumbardstr.,0,0
+1665,10,January,17,,St Mary Stayning,0,0
+1665,10,January,17,,St Steven Walbrook,0,0
+1665,10,January,17,,St Ethelborough,0,0
+1665,10,January,17,,St Mary Woolchurch,0,0
+1665,10,January,17,,St Swithin,1,0
+1665,10,January,17,,St Faith,0,0
+1665,10,January,17,,St Mary Woolnoth,0,0
+1665,10,January,17,,St Thomas Apostles,1,0
+1665,10,January,17,,St Foster,1,0
+1665,10,January,17,,St Martin Iremongerlane,0,0
+1665,10,January,17,,Trinity Parish,3,0
+1665,10,January,17,,St Gabriel Fenchurch,1,0
+1665,10,January,17,,St Andrew Holborn,18,0
+1665,10,January,17,,St Botolph Aldgate,17,0
+1665,10,January,17,,Saviours Southwark,15,0
+1665,10,January,17,,St Bartholomew Great,1,0
+1665,10,January,17,,St Botolph Bishopsgate,7,0
+1665,10,January,17,,S Sepulchres Parish,16,0
+1665,10,January,17,,St Bartholomew Lesse,1,0
+1665,10,January,17,,St Dunstan West,8,0
+1665,10,January,17,,St Thomas Southwark,0,0
+1665,10,January,17,,St Bridget,12,0
+1665,10,January,17,,St George Southwark,2,0
+1665,10,January,17,,Trinity Minories,1,0
+1665,10,January,17,,Bridewel Precinct,1,0
+1665,10,January,17,,St Giles Cripplegate,34,0
+1665,10,January,17,,At the Pesthouse,0,0
+1665,10,January,17,,St Botolph Aldersgat•,1,0
+1665,10,January,17,,St Olave Southwark,20,0
+1665,10,January,17,,St Giles in the fields,18,0
+1665,10,January,17,,Lambeth Parish,4,0
+1665,10,January,17,,St Mary Islington,2,0
+1665,10,January,17,,Hackney Parish,3,0
+1665,10,January,17,,St Leonard Shoreditch,5,0
+1665,10,January,17,,St Mary Whitechappel,20,0
+1665,10,January,17,,St James Clerkenwel,9,0
+1665,10,January,17,,St Magdalen Bermondsey,5,0
+1665,10,January,17,,Rotho•ith Parish,0,0
+1665,10,January,17,,St Kath. near the Tower,3,0
+1665,10,January,17,,St Mary Newington,5,0
+1665,10,January,17,,Stepney Parish,38,0
+1665,10,January,17,,St Clement Danes,9,0
+1665,10,January,17,,St Martin in the fields,24,0
+1665,10,January,17,,St Margaret Westminster,18,0
+1665,10,January,17,,St Paul Covent Garden,3,0
+1665,10,January,17,,St Mary Savoy,4,0
+1665,17,January,24,,St ALbans Woodstree•,0,0
+1665,17,January,24,,St George Botolphlane,0,0
+1665,17,January,24,,St Martins Ludgate,2,0
+1665,17,January,24,,Alhallows Barking,2,0
+1665,17,January,24,,St Gregories by St Pauls,5,0
+1665,17,January,24,,St Martin Orgars,0,0
+1665,17,January,24,,Alhallows Breadstreet,1,0
+1665,17,January,24,,St Hellens,1,0
+1665,17,January,24,,St Martins Outwitch,2,0
+1665,17,January,24,,Alhallows Great,3,0
+1665,17,January,24,,St James Dukes place,0,0
+1665,17,January,24,,St Martins Vintrey,2,0
+1665,17,January,24,,Alhallows Honylane,0,0
+1665,17,January,24,,St James Garlickhithe,0,0
+1665,17,January,24,,St Mathew Fridaystreet,1,0
+1665,17,January,24,,Alhallows Lesse,1,0
+1665,17,January,24,,St John Baptist,1,0
+1665,17,January,24,,St Maudlins Milkstreet,0,0
+1665,17,January,24,,Alhallows Lumbardstr.,0,0
+1665,17,January,24,,St John Evangelist,1,0
+1665,17,January,24,,St Maudlins Oldfis•str,1,0
+1665,17,January,24,,Alhallows Stayning,0,0
+1665,17,January,24,,St John Zachary,0,0
+1665,17,January,24,,St Michael Bassishaw,2,0
+1665,17,January,24,,Alhallows the Wall,1,0
+1665,17,January,24,,St Katharine Coleman,3,0
+1665,17,January,24,,St Michael Cornhil,0,0
+1665,17,January,24,,St Alphage,2,0
+1665,17,January,24,,St Katharine crechurch,4,0
+1665,17,January,24,,St Michael Crookedla.,1,0
+1665,17,January,24,,St Andrew Hubbard,0,0
+1665,17,January,24,,St Lawrence Jewry,0,0
+1665,17,January,24,,St Michael Queenhithe,0,0
+1665,17,January,24,,St Andrew Undershaft,0,0
+1665,17,January,24,,St Lawrence Pountney,1,0
+1665,17,January,24,,St Michael Quern,2,0
+1665,17,January,24,,St Andrew Wardrobe,1,0
+1665,17,January,24,,St Leonard Eastcheap,0,0
+1665,17,January,24,,St Michael Royall,1,0
+1665,17,January,24,,St Ann Aldersgate,0,0
+1665,17,January,24,,St Leonard Fosterlane,1,0
+1665,17,January,24,,St Michael Woodstreet,0,0
+1665,17,January,24,,St Ann Blackfryers,5,0
+1665,17,January,24,,St Magnus Parish,0,0
+1665,17,January,24,,St Mildred Breadstreet,3,0
+1665,17,January,24,,St Antholins Parish,0,0
+1665,17,January,24,,St Margaret Lothbury,4,0
+1665,17,January,24,,St Mildred Poultrey,1,0
+1665,17,January,24,,St Austins Parish,1,0
+1665,17,January,24,,St Margaret Moses,0,0
+1665,17,January,24,,St Nicholas Acons,1,0
+1665,17,January,24,,St Bartholomew Excha,0,0
+1665,17,January,24,,St Margaret New fishs.,0,0
+1665,17,January,24,,St Nicholas Coleabby,1,0
+1665,17,January,24,,St Bennet Fynck,0,0
+1665,17,January,24,,St Margaret Pattons,0,0
+1665,17,January,24,,St Nicholas Olaves,2,0
+1665,17,January,24,,St Bennet Gracechurch,1,0
+1665,17,January,24,,St Mary Abchurch,0,0
+1665,17,January,24,,St Olaves Hartstreet,6,0
+1665,17,January,24,,St Bennet Paulswharfe,2,0
+1665,17,January,24,,St Mary Aldermanbury,2,0
+1665,17,January,24,,St Olaves Jewry,2,0
+1665,17,January,24,,St Sherehog,0,0
+1665,17,January,24,,St Mary Aldermary,0,0
+1665,17,January,24,,St Olaves Silverstreet,1,0
+1665,17,January,24,,St Botolph Billingsgate,1,0
+1665,17,January,24,,St Mary le Bow,0,0
+1665,17,January,24,,St Pancras Soperlane,0,0
+1665,17,January,24,,Christ Church,2,0
+1665,17,January,24,,St Mary Bothaw,1,0
+1665,17,January,24,,St Peters Cheap,2,0
+1665,17,January,24,,St Christophers,0,0
+1665,17,January,24,,St Mary Colechurch,0,0
+1665,17,January,24,,St Peters Cornhil,0,0
+1665,17,January,24,,St Clement Eastcheap,0,0
+1665,17,January,24,,St Mary Hill,1,0
+1665,17,January,24,,St Peters Paulswharf,1,0
+1665,17,January,24,,St Dionis Backchurch,1,0
+1665,17,January,24,,St Mary Mounthaw,1,0
+1665,17,January,24,,St Peters Poor,0,0
+1665,17,January,24,,St Dunstans East,3,0
+1665,17,January,24,,St Mary Sommerset,3,0
+1665,17,January,24,,St Stevens Colemanstr.,6,0
+1665,17,January,24,,St Edm. Lumbardstreet,2,0
+1665,17,January,24,,St Mary Staynings,1,0
+1665,17,January,24,,St Stevens Walbrook,1,0
+1665,17,January,24,,St Ethelborough,0,0
+1665,17,January,24,,St Mary Woolchurch,2,0
+1665,17,January,24,,St Swithins,0,0
+1665,17,January,24,,St Faiths,0,0
+1665,17,January,24,,St Mary Woolnoth,1,0
+1665,17,January,24,,St Thomas Apostles,0,0
+1665,17,January,24,,St Fostets,0,0
+1665,17,January,24,,St Martins Iremongerl,0,0
+1665,17,January,24,,Trinity Parish,1,0
+1665,17,January,24,,St Gabriel Fenchurch,0,0
+1665,17,January,24,,St Andrews Holborne,16,0
+1665,17,January,24,,St Botolph Aldgate,19,0
+1665,17,January,24,,St Saviours Southwark,20,0
+1665,17,January,24,,St Bartholomew Great,1,0
+1665,17,January,24,,St Botolph Bishopsgate,14,0
+1665,17,January,24,,St Sepulchres Parish,24,0
+1665,17,January,24,,St Bartholomew Lesse,2,0
+1665,17,January,24,,St Dunstans West,7,0
+1665,17,January,24,,St Thomas Southwark,0,0
+1665,17,January,24,,St Brides Parish,9,0
+1665,17,January,24,,St George Southwark,6,0
+1665,17,January,24,,Trinity Minories,0,0
+1665,17,January,24,,Bridewel Precinct,1,0
+1665,17,January,24,,St Giles Cripplegate,32,0
+1665,17,January,24,,At the Pesthouse,0,0
+1665,17,January,24,,St Botolph Aldersgate,9,0
+1665,17,January,24,,St Olaves Southwark,24,0
+1665,17,January,24,,St Giles in the fields,23,0
+1665,17,January,24,,Lambeth Parish,4,0
+1665,17,January,24,,St Mary Islington,0,0
+1665,17,January,24,,Hackney Parish,1,0
+1665,17,January,24,,St Leonard Shoreditch,12,0
+1665,17,January,24,,St Mary Whitechappel,7,0
+1665,17,January,24,,St James Clerkenwel,15,0
+1665,17,January,24,,St Magdalen Bermond.,5,0
+1665,17,January,24,,Redriff Parish,0,0
+1665,17,January,24,,St Kath. neer the Tower,2,0
+1665,17,January,24,,St Mary Newington,7,0
+1665,17,January,24,,Stepney Parish,42,0
+1665,17,January,24,,St Clement Danes,17,0
+1665,17,January,24,,St Martins in the field•,34,0
+1665,17,January,24,,St Margaret Westminst.,15,0
+1665,17,January,24,,S Paul Covent Garden,2,0
+1665,17,January,24,,St Mary Savoy,0,0
+1665,24,January,31,,St ALbans Woodstreet,0,0
+1665,24,January,31,,St George Botolphlane,0,0
+1665,24,January,31,,St Martins Ludgate,0,0
+1665,24,January,31,,Alhallows Barking,5,0
+1665,24,January,31,,St Gregories by St Pauls,8,0
+1665,24,January,31,,St Martins Orgars,0,0
+1665,24,January,31,,Alhallows Breadstreet,1,0
+1665,24,January,31,,St Hellens,3,0
+1665,24,January,31,,St Martins Outwitch,1,0
+1665,24,January,31,,Alhallows Great,1,0
+1665,24,January,31,,St James Dukes place,1,0
+1665,24,January,31,,St Martins Vintrey,0,0
+1665,24,January,31,,Alhallows Honylane,0,0
+1665,24,January,31,,St James Garlickhithe,1,0
+1665,24,January,31,,St Mathew Fridaystreet,0,0
+1665,24,January,31,,Alhallows Lesse,3,0
+1665,24,January,31,,St John Baptist,0,0
+1665,24,January,31,,St Maudlins Milkstreet,0,0
+1665,24,January,31,,Alhallows Lumbardstr.,2,0
+1665,24,January,31,,St John Evangelist,1,0
+1665,24,January,31,,St Maudlins Oldfishstr.,1,0
+1665,24,January,31,,Alhallows Stayning,0,0
+1665,24,January,31,,St John Zachary,0,0
+1665,24,January,31,,St Michael Bassishaw,0,0
+1665,24,January,31,,Alhallows the Wall,3,0
+1665,24,January,31,,St Katharine Coleman,2,0
+1665,24,January,31,,St Michael Cornhil,1,0
+1665,24,January,31,,St Alphage,1,0
+1665,24,January,31,,St Katharine crechurch,2,0
+1665,24,January,31,,St Michael Crookedla.,1,0
+1665,24,January,31,,St Andrew Hubbard,1,0
+1665,24,January,31,,St Lawrence Jewry,1,0
+1665,24,January,31,,St Michael Queenhiche,0,0
+1665,24,January,31,,St Andr•w Undershaft,0,0
+1665,24,January,31,,St Lawrence Pountney,1,0
+1665,24,January,31,,St Michael Quern,0,0
+1665,24,January,31,,St Andrew War••obe,2,0
+1665,24,January,31,,St Leonard Eastcheap,1,0
+1665,24,January,31,,St Michael Royall,1,0
+1665,24,January,31,,St Ann Aldersgate,3,0
+1665,24,January,31,,St Leonard Fosterlane,2,0
+1665,24,January,31,,St Michael Woodstreet,1,0
+1665,24,January,31,,St Ann Blackfryers,2,0
+1665,24,January,31,,St Magnus Pari•h,0,0
+1665,24,January,31,,St Mildred Breadstreet,1,0
+1665,24,January,31,,St Antholins Parish,1,0
+1665,24,January,31,,St Margaret Lothbury,2,0
+1665,24,January,31,,St Mildred Poultrey,0,0
+1665,24,January,31,,St Austins Parish,1,0
+1665,24,January,31,,St Margaret Moses,1,0
+1665,24,January,31,,St Nicholas Acons,0,0
+1665,24,January,31,,St Bartholomew Excha,1,0
+1665,24,January,31,,St Margaret Newfishst,1,0
+1665,24,January,31,,St Nicholas Coleabby,0,0
+1665,24,January,31,,St Bennet Fynck,0,0
+1665,24,January,31,,St Margaret Pattons,0,0
+1665,24,January,31,,St Nicholas Olaves,1,0
+1665,24,January,31,,St Bennet Gracechurch,0,0
+1665,24,January,31,,St Mary Abchurch,1,0
+1665,24,January,31,,St Olaves Hartstreet,0,0
+1665,24,January,31,,St Bennet Paulswhar•,2,0
+1665,24,January,31,,St Mary Aldermanbury,0,0
+1665,24,January,31,,St Olaves Jewry,0,0
+1665,24,January,31,,St Bennet Sherehog,2,0
+1665,24,January,31,,St Mary Aldermary,0,0
+1665,24,January,31,,St Olaves Silverstreet,1,0
+1665,24,January,31,,St Botolph Billingsgate,0,0
+1665,24,January,31,,St Mary le Bow,1,0
+1665,24,January,31,,St Pancras Soperlane,0,0
+1665,24,January,31,,Christ Church,3,0
+1665,24,January,31,,St Mary Bothaw,1,0
+1665,24,January,31,,St Pet•rs Cheap,1,0
+1665,24,January,31,,St Christophers,0,0
+1665,24,January,31,,St Mary Colechurch,0,0
+1665,24,January,31,,St Peters Cornhil,0,0
+1665,24,January,31,,St Clement Eastcheap,0,0
+1665,24,January,31,,St Mary Hill,0,0
+1665,24,January,31,,St Peters Paulswharf,0,0
+1665,24,January,31,,St Dionis Backchurch,0,0
+1665,24,January,31,,St Mary Mounthaw,1,0
+1665,24,January,31,,St Peter• Poor,3,0
+1665,24,January,31,,St Dunstans Eas•,1,0
+1665,24,January,31,,St Mary Sommerset,0,0
+1665,24,January,31,,St Stevens Colemanstr,5,0
+1665,24,January,31,,St Edm. Lumbardstreet,0,0
+1665,24,January,31,,St Mary Staynings,0,0
+1665,24,January,31,,St Stevens Walbrook,1,0
+1665,24,January,31,,St Ethelborough,1,0
+1665,24,January,31,,St Mary Woolchurch,0,0
+1665,24,January,31,,St Swithins,0,0
+1665,24,January,31,,St Faiths,0,0
+1665,24,January,31,,St Mary Woolnoth,0,0
+1665,24,January,31,,St Thomas Apostles,1,0
+1665,24,January,31,,St Fosters,1,0
+1665,24,January,31,,St Martins Iremongerl,0,0
+1665,24,January,31,,Trinity Parish,0,0
+1665,24,January,31,,St Gabriel Fenchurch,0,0
+1665,24,January,31,,〈◊〉 Andrews Holborne,15,0
+1665,24,January,31,,St Botolph Aldgate,12,0
+1665,24,January,31,,St Saviours Southwark,18,0
+1665,24,January,31,,St Bartholomew Great,3,0
+1665,24,January,31,,St Botolph Bishopsgate,10,0
+1665,24,January,31,,St Sepulchres Parish,25,0
+1665,24,January,31,,St Bartholomew Lesse,0,0
+1665,24,January,31,,St Dunstans West,6,0
+1665,24,January,31,,St Thomas Southwark,0,0
+1665,24,January,31,,St Brides Parish,8,0
+1665,24,January,31,,St George Southwark,6,0
+1665,24,January,31,,•rinity Minories,0,0
+1665,24,January,31,,Bridewel Precinct,2,0
+1665,24,January,31,,St Giles Cripplegate,23,0
+1665,24,January,31,,•t the Pesthouse,0,0
+1665,24,January,31,,St Botolph Aldersgate,3,0
+1665,24,January,31,,St Olaves Southwark,12,0
+1665,24,January,31,,St Giles in the fields,24,0
+1665,24,January,31,,Lambeth Parish,7,0
+1665,24,January,31,,St Mary Islington,0,0
+1665,24,January,31,,Hackney Parish,2,0
+1665,24,January,31,,St Leonard Shoreditch,12,0
+1665,24,January,31,,St Mary Whitechappel,11,0
+1665,24,January,31,,St James Clerkenwel,12,0
+1665,24,January,31,,St Magdalen Bermond,7,0
+1665,24,January,31,,Redriff Parish,0,0
+1665,24,January,31,,〈◊〉 Kath. neer the Tow••,1,0
+1665,24,January,31,,St Mary Newington,4,0
+1665,24,January,31,,Stepney Parish,35,0
+1665,24,January,31,,St Clement Danes,8,0
+1665,24,January,31,,St Martins in the fields,24,0
+1665,24,January,31,,St Margaret Westminst.,30,0
+1665,24,January,31,,S• Paul Covent Garden,1,0
+1665,24,January,31,,St Mary Savoy,0,0
+1665,31,January,7,February,St ALbans Woodstreet,0,0
+1665,31,January,7,February,St George Botolphlane,1,0
+1665,31,January,7,February,St Martins Ludgate,0,0
+1665,31,January,7,February,Alhallows Barking,4,0
+1665,31,January,7,February,St Gregories by St Pauls,3,0
+1665,31,January,7,February,St Martins Orgars,1,0
+1665,31,January,7,February,Alhallows Breadstreet,1,0
+1665,31,January,7,February,St Hellins,0,0
+1665,31,January,7,February,St Martins Outwitch,0,0
+1665,31,January,7,February,Alhallows Great,0,0
+1665,31,January,7,February,St James Dukes place,2,0
+1665,31,January,7,February,St Martins Vintrey,0,0
+1665,31,January,7,February,Alhallows Honylane,0,0
+1665,31,January,7,February,St James Garlickhithe,2,0
+1665,31,January,7,February,St Mathew Fridaystreet,0,0
+1665,31,January,7,February,Alhallows Lesse,3,0
+1665,31,January,7,February,St John Baptist,0,0
+1665,31,January,7,February,St Maudlins Milkstreet,0,0
+1665,31,January,7,February,Alhallows Lumbardstr,0,0
+1665,31,January,7,February,St John Evangelist,0,0
+1665,31,January,7,February,St Maudlins Oldfishst.,0,0
+1665,31,January,7,February,Alhallows Stayning,0,0
+1665,31,January,7,February,St John Zachary,0,0
+1665,31,January,7,February,St Michael Basshishaw,1,0
+1665,31,January,7,February,Alhallows the Wall,3,0
+1665,31,January,7,February,St Katharine Coleman,1,0
+1665,31,January,7,February,St Michael Cornhil,0,0
+1665,31,January,7,February,St Alphage,3,0
+1665,31,January,7,February,St Katharine crechurch,0,0
+1665,31,January,7,February,St Michael Crookedla.,2,0
+1665,31,January,7,February,St Andrew Hubbard,1,0
+1665,31,January,7,February,St Lawrence Jewry,0,0
+1665,31,January,7,February,St Michael Queenhithe,1,0
+1665,31,January,7,February,St Andrew Undershaft,0,0
+1665,31,January,7,February,St Lawrence Pountney,1,0
+1665,31,January,7,February,St Michael Quern,1,0
+1665,31,January,7,February,St Andrew Wardrobe,2,0
+1665,31,January,7,February,St Leonard Eastcheap,0,0
+1665,31,January,7,February,St Michael Royall,0,0
+1665,31,January,7,February,St Ann Aldersgate,2,0
+1665,31,January,7,February,St Leonard Fosterlane,4,0
+1665,31,January,7,February,St Michael Woodstreet,0,0
+1665,31,January,7,February,St Ann Blackfryers,2,0
+1665,31,January,7,February,St Magnus Parish,0,0
+1665,31,January,7,February,St Mildred Breadstreet,1,0
+1665,31,January,7,February,St Antholins Parish,0,0
+1665,31,January,7,February,St Margaret Lothbury,1,0
+1665,31,January,7,February,St Mildred Poultrey,0,0
+1665,31,January,7,February,St Austins Parish,1,0
+1665,31,January,7,February,St Margaret Moses,0,0
+1665,31,January,7,February,St Nicholas Acons,0,0
+1665,31,January,7,February,St Bartholomew Exch.,0,0
+1665,31,January,7,February,St Margaret Newfishst.,1,0
+1665,31,January,7,February,St Nicholas Coleabby,2,0
+1665,31,January,7,February,St Bennet Fynck,0,0
+1665,31,January,7,February,St Margaret Patrons,0,0
+1665,31,January,7,February,St Nicholas Olaves,1,0
+1665,31,January,7,February,St Bennet Gracechurch,0,0
+1665,31,January,7,February,St Mary Abchurch,1,0
+1665,31,January,7,February,St Olaves Hartstreet,3,0
+1665,31,January,7,February,St Bennet Paulswharf,3,0
+1665,31,January,7,February,St Mary Aldermanbury,0,0
+1665,31,January,7,February,St Olaves Jewry,0,0
+1665,31,January,7,February,St Bennet Sherehog,0,0
+1665,31,January,7,February,St Mary Aldermary,0,0
+1665,31,January,7,February,St Olaves Silverstreet,4,0
+1665,31,January,7,February,St Batolph Billingsgate,2,0
+1665,31,January,7,February,St Mary le Bow,1,0
+1665,31,January,7,February,St Paneras Soperlane,0,0
+1665,31,January,7,February,Christ Church,1,0
+1665,31,January,7,February,St Mary Bothaw,1,0
+1665,31,January,7,February,St Peters Cheap,1,0
+1665,31,January,7,February,St Christophers,0,0
+1665,31,January,7,February,St Mary Colechurch,0,0
+1665,31,January,7,February,St Peters Cornhil,3,0
+1665,31,January,7,February,St Clement Eastcheap,0,0
+1665,31,January,7,February,St Mary Hill,1,0
+1665,31,January,7,February,St Peters Paulswharf,0,0
+1665,31,January,7,February,St Dionis Backchurch,2,0
+1665,31,January,7,February,St Mary Mounthaw,0,0
+1665,31,January,7,February,St Peters Poor,0,0
+1665,31,January,7,February,St Dunstans East,3,0
+1665,31,January,7,February,St Mary Sommerset,2,0
+1665,31,January,7,February,St Stevens Colemanst.,2,0
+1665,31,January,7,February,St Edm. Lumbardstreet,0,0
+1665,31,January,7,February,St Mary Staynings,0,0
+1665,31,January,7,February,St Stevens Walbrook,0,0
+1665,31,January,7,February,St Ethelbourgh,0,0
+1665,31,January,7,February,St Mary Woolchurch,0,0
+1665,31,January,7,February,St Swithins,0,0
+1665,31,January,7,February,St Faiths,1,0
+1665,31,January,7,February,St Mary Wolnoth,0,0
+1665,31,January,7,February,St Thomas Apostle,0,0
+1665,31,January,7,February,St Fosters,0,0
+1665,31,January,7,February,St Martins Iremongerl.,0,0
+1665,31,January,7,February,Trinity Parish,1,0
+1665,31,January,7,February,St Gabriel Fenchurch,0,0
+1665,31,January,7,February,St Andrews Molborn,23,0
+1665,31,January,7,February,St Botolph Aldgate,14,0
+1665,31,January,7,February,St Saviours Southwark,10,0
+1665,31,January,7,February,St Bartholomew Grea•,5,0
+1665,31,January,7,February,St Botolph Bishopsgate,9,0
+1665,31,January,7,February,St Sepulchres Parish,20,0
+1665,31,January,7,February,St Bartholomew Lesse,2,0
+1665,31,January,7,February,St Dunstans West,6,0
+1665,31,January,7,February,St Thomas Southwark,1,0
+1665,31,January,7,February,St Brides Parish,13,0
+1665,31,January,7,February,St George Southwark,9,0
+1665,31,January,7,February,Trinity Minories,0,0
+1665,31,January,7,February,Bridewel Frecinet,0,0
+1665,31,January,7,February,St Giles Cripplegate,21,0
+1665,31,January,7,February,At the Pesthouse,0,0
+1665,31,January,7,February,St Botolph Aldersgate,4,0
+1665,31,January,7,February,St Olaves Southwark,13,0
+1665,31,January,7,February,St Giles in the fields,21,0
+1665,31,January,7,February,Lambeth Parish,1,0
+1665,31,January,7,February,St Mary Islington,0,0
+1665,31,January,7,February,Hackney Parish,1,0
+1665,31,January,7,February,St Leonard Shoreditch,10,0
+1665,31,January,7,February,St Mary Whitechappel,13,0
+1665,31,January,7,February,S Iames Clerkenwel,5,0
+1665,31,January,7,February,St Magdalen Bermond.,4,0
+1665,31,January,7,February,Redriff Parish,0,0
+1665,31,January,7,February,S Kath. neer the Tower,2,0
+1665,31,January,7,February,St Mary Newington,5,0
+1665,31,January,7,February,Stepney Parish,37,0
+1665,31,January,7,February,St Clement Danes,10,0
+1665,31,January,7,February,St Martins in the fields,30,0
+1665,31,January,7,February,St Margaret Westminst.,18,0
+1665,31,January,7,February,St Paul Covent Garden,3,0
+1665,31,January,7,February,St Mary Savoy,3,0
+1665,7,February,14,,St ALbans Woodstreet,0,0
+1665,7,February,14,,St George Botolphlant,0,0
+1665,7,February,14,,St Martins Ludgate,1,0
+1665,7,February,14,,Alhallows Barking,3,0
+1665,7,February,14,,St Gregories by St Pauls,2,0
+1665,7,February,14,,St Martins Orgars,0,0
+1665,7,February,14,,Alhallows Breadstreet,0,0
+1665,7,February,14,,St Hellins,0,0
+1665,7,February,14,,St Martins Outwitch,0,0
+1665,7,February,14,,Alhallows Grea•,2,0
+1665,7,February,14,,St James Dukes place,1,0
+1665,7,February,14,,St Martins Vintrey,2,0
+1665,7,February,14,,Alhallows Honylane.,0,0
+1665,7,February,14,,St James Garlickhithe,1,0
+1665,7,February,14,,St Mathew Fridaystreet,0,0
+1665,7,February,14,,Alhallows Lesse,1,0
+1665,7,February,14,,St John Baptist,2,0
+1665,7,February,14,,St Maudlins Milkstre•t,0,0
+1665,7,February,14,,Alhallows Lumbardstr,0,0
+1665,7,February,14,,St John Evangelist,0,0
+1665,7,February,14,,St Maudlins Oldfishst.,1,0
+1665,7,February,14,,Alhallows Stayning,1,0
+1665,7,February,14,,St John Zachary,4,0
+1665,7,February,14,,St Michael Ba•sishaw,2,0
+1665,7,February,14,,Alhallows the Wall,1,0
+1665,7,February,14,,St Katharine Coleman,1,0
+1665,7,February,14,,St Michael Cornhil,3,0
+1665,7,February,14,,St Alphage,2,0
+1665,7,February,14,,St Katharine crechurch,1,0
+1665,7,February,14,,St Michael Crookedla,1,0
+1665,7,February,14,,St Andrew Hubbard,0,0
+1665,7,February,14,,St Lawrence Jewry,0,0
+1665,7,February,14,,St Michael Queenhithe,2,0
+1665,7,February,14,,St Andrew Undershaft,0,0
+1665,7,February,14,,St Lawrence Pountney,3,0
+1665,7,February,14,,St Michael Quern,1,0
+1665,7,February,14,,St Andrew Wardrobe,2,0
+1665,7,February,14,,St Leonard Eastcheap,0,0
+1665,7,February,14,,St Michael Royall,2,0
+1665,7,February,14,,St Ann Aldersgate,1,0
+1665,7,February,14,,St Leonard Fosterlane,0,0
+1665,7,February,14,,St Michael Woodstreet,2,0
+1665,7,February,14,,St Ann Blackfryers,2,0
+1665,7,February,14,,St Magnus Parish,0,0
+1665,7,February,14,,St Mildred Breadstreet,1,0
+1665,7,February,14,,St Antholins Parish,2,0
+1665,7,February,14,,St Margaret Lothbury,1,0
+1665,7,February,14,,St Mildred Poultrey,0,0
+1665,7,February,14,,St Austins Parish,0,0
+1665,7,February,14,,St Margaret Moses,0,0
+1665,7,February,14,,St Nicholas Acons,1,0
+1665,7,February,14,,St Bartholomew Exch.,0,0
+1665,7,February,14,,St Margaret Newsislast,1,0
+1665,7,February,14,,St Nicholas Coloabby,1,0
+1665,7,February,14,,St Bennet Fynck,0,0
+1665,7,February,14,,St Margaret Pattons,0,0
+1665,7,February,14,,St Nicholas Olaves,0,0
+1665,7,February,14,,St Bennet Gracechurch,0,0
+1665,7,February,14,,St Mary Abchurch,0,0
+1665,7,February,14,,St Olaves Hartstreet,3,0
+1665,7,February,14,,St Bennet Paulswharf,0,0
+1665,7,February,14,,St Mary Aldermanbury,2,0
+1665,7,February,14,,St Olaves Jewry,0,0
+1665,7,February,14,,St Bennet Sherehog,0,0
+1665,7,February,14,,St Mary Aldermary,0,0
+1665,7,February,14,,St Olaves Silverstreet,1,0
+1665,7,February,14,,St B•tolph Billingsgate,0,0
+1665,7,February,14,,St Mary le Bow,1,0
+1665,7,February,14,,St Pancras Soperlane,0,0
+1665,7,February,14,,Christs Church,6,0
+1665,7,February,14,,St Mary Bothaw,0,0
+1665,7,February,14,,St Peters Cheap,1,0
+1665,7,February,14,,St Christophers,0,0
+1665,7,February,14,,St Mary Colechurch,0,0
+1665,7,February,14,,St Peters Cornhil,1,0
+1665,7,February,14,,St Clement Eastcheap,0,0
+1665,7,February,14,,St Mary Hill,1,0
+1665,7,February,14,,St Peters Paulswharf,0,0
+1665,7,February,14,,St Dionis Backchurch,0,0
+1665,7,February,14,,St Mary Mounthaw,0,0
+1665,7,February,14,,St Peters Poor,1,0
+1665,7,February,14,,St Dunstans East,3,0
+1665,7,February,14,,St Mary Sommerset,1,0
+1665,7,February,14,,St Stevens Colemanstr,4,0
+1665,7,February,14,,St Edm. Lumbardstree•,0,0
+1665,7,February,14,,St Mary Staynings,0,0
+1665,7,February,14,,St Stevens Walbrook,0,0
+1665,7,February,14,,St Ethelbourgh,0,0
+1665,7,February,14,,St Mary Woolchurch,2,0
+1665,7,February,14,,St Swithins,2,0
+1665,7,February,14,,St Faiths,0,0
+1665,7,February,14,,St Mary Wolnoth,0,0
+1665,7,February,14,,St Thomas Apostle,0,0
+1665,7,February,14,,St Fosters,1,0
+1665,7,February,14,,St Martins Iremongeri.,0,0
+1665,7,February,14,,Trinity Parish,1,0
+1665,7,February,14,,St Gabriel Fenchurch,0,0
+1665,7,February,14,,St Andrews Holborn,13,0
+1665,7,February,14,,St Botolph Aldgate,23,0
+1665,7,February,14,,St Saviours Southwark,12,0
+1665,7,February,14,,St Bartholomew Great,4,0
+1665,7,February,14,,St Botolph Bishopsgate,15,0
+1665,7,February,14,,St Sepulchres Parish,23,0
+1665,7,February,14,,St Bartholemew Lesse,2,0
+1665,7,February,14,,St Dunstans West,10,0
+1665,7,February,14,,St Thomas Southwark,1,0
+1665,7,February,14,,St Brides Parish,12,0
+1665,7,February,14,,St George Southwark,5,0
+1665,7,February,14,,Trinity Minories,1,0
+1665,7,February,14,,Bridewel Preccinet,1,0
+1665,7,February,14,,St Giles Cripplegate,32,0
+1665,7,February,14,,At the Pesthouse,0,0
+1665,7,February,14,,St Botolph Aldersgate,5,0
+1665,7,February,14,,St Olaves Southwark,21,0
+1665,7,February,14,,St Giles in the fields,24,1
+1665,7,February,14,,Lambeth Parish,7,0
+1665,7,February,14,,St Mary Islington,0,0
+1665,7,February,14,,Hackney Parish,0,0
+1665,7,February,14,,St Leonard Shoreditch,14,0
+1665,7,February,14,,St Mary Whitechappel,11,0
+1665,7,February,14,,St James Clerkenwel,6,0
+1665,7,February,14,,St Magdalen Bermond,5,0
+1665,7,February,14,,Redriff Parish,0,0
+1665,7,February,14,,St Kath. neer the Tower,3,0
+1665,7,February,14,,St Mary Newington,7,0
+1665,7,February,14,,Stepney Parish,44,0
+1665,7,February,14,,St Clement Danes,9,0
+1665,7,February,14,,St Martins in the fields,33,0
+1665,7,February,14,,St Margaret Westminst.,27,0
+1665,7,February,14,,St Paul Covent Garden,6,0
+1665,7,February,14,,St Mary Savoy,1,0
+1665,14,February,21,,St ALbans Woodstreet,3,0
+1665,14,February,21,,St George Betolphlane,0,0
+1665,14,February,21,,St Martins Ludgate,1,0
+1665,14,February,21,,Alhallows Barking,4,0
+1665,14,February,21,,St Gregories by St Pauls,0,0
+1665,14,February,21,,St Martins Orgars,0,0
+1665,14,February,21,,Alhallows Breadstreet,1,0
+1665,14,February,21,,St Hellins,1,0
+1665,14,February,21,,St Martins Outwitch,0,0
+1665,14,February,21,,Alhallows Great,3,0
+1665,14,February,21,,St James Dukes place,0,0
+1665,14,February,21,,St Martins Vintrey,0,0
+1665,14,February,21,,Alhallows Honylane,0,0
+1665,14,February,21,,St James Garlickhithe,2,0
+1665,14,February,21,,St Mathew Fridaystreet,0,0
+1665,14,February,21,,Alhallows Lesse,2,0
+1665,14,February,21,,St John Baptist,1,0
+1665,14,February,21,,St Maudlins Milkstreet,1,0
+1665,14,February,21,,Alhallows Lumbardstr,0,0
+1665,14,February,21,,St John Evangelist,1,0
+1665,14,February,21,,St Maudlins Oldfishst.,0,0
+1665,14,February,21,,Alhallows Stayning,1,0
+1665,14,February,21,,St John Zachary,0,0
+1665,14,February,21,,St Michael Bassishaw,1,0
+1665,14,February,21,,Alhallows the Wall,2,0
+1665,14,February,21,,St Katharine Coleman,0,0
+1665,14,February,21,,St Michael Cornhil,1,0
+1665,14,February,21,,St Alphage,0,0
+1665,14,February,21,,St Katharine crechurch,0,0
+1665,14,February,21,,St Michael Crookedla,2,0
+1665,14,February,21,,St Andrew Hubbard,0,0
+1665,14,February,21,,St Lawrence Jewry,0,0
+1665,14,February,21,,St Michael Queenhithe,2,0
+1665,14,February,21,,St Andrew Undershaft,4,0
+1665,14,February,21,,St Lawrence Pountney,0,0
+1665,14,February,21,,St Michael Quern,1,0
+1665,14,February,21,,St Andrew Wardrobe,1,0
+1665,14,February,21,,St Leonard Eastcheap,0,0
+1665,14,February,21,,St Michael Royall,0,0
+1665,14,February,21,,St Ann Aldersgate,1,0
+1665,14,February,21,,St Leonard Fosterlane,3,0
+1665,14,February,21,,St Michael Woodstreet,2,0
+1665,14,February,21,,St Ann Blackfryers,2,0
+1665,14,February,21,,St Magnus Parish,0,0
+1665,14,February,21,,St Mildred Breadstreet,0,0
+1665,14,February,21,,St Antholins Parish,1,0
+1665,14,February,21,,St Margaret Lothbury,0,0
+1665,14,February,21,,St Mildred Poultrey,1,0
+1665,14,February,21,,St Austins Parish,0,0
+1665,14,February,21,,St Margaret Moses,0,0
+1665,14,February,21,,St Nicholas Acons,1,0
+1665,14,February,21,,St Bartholomew Exch.,0,0
+1665,14,February,21,,St Margaret Newfishst,2,0
+1665,14,February,21,,St Nicholas Coleabby,3,0
+1665,14,February,21,,St Bennet Fynck,0,0
+1665,14,February,21,,St Margaret Pattons,0,0
+1665,14,February,21,,St Nicholas Olaves,1,0
+1665,14,February,21,,St Bennet Gracechurch,0,0
+1665,14,February,21,,St Mary Abchurch,1,0
+1665,14,February,21,,St Olaves Hartstreet,0,0
+1665,14,February,21,,St Bennet Paulswharf,2,0
+1665,14,February,21,,St Mary Aldermanbury,0,0
+1665,14,February,21,,St Olaves Jewry,0,0
+1665,14,February,21,,St B••net Sherehog,0,0
+1665,14,February,21,,St Mary Aldermary,1,0
+1665,14,February,21,,St Olaves Silverstreet,2,0
+1665,14,February,21,,St•••olph Billingsgate,0,0
+1665,14,February,21,,St Mary le Bow,1,0
+1665,14,February,21,,St Pancras Soperlane,0,0
+1665,14,February,21,,Christs Church,4,0
+1665,14,February,21,,St Mary Bothaw,1,0
+1665,14,February,21,,St Peters Cheap,1,0
+1665,14,February,21,,St Christophers,0,0
+1665,14,February,21,,St Mary Colechurch,0,0
+1665,14,February,21,,St Peters Cornhil,3,0
+1665,14,February,21,,St Clement Eastcheap,0,0
+1665,14,February,21,,St Mary Hill,1,0
+1665,14,February,21,,St Peters Paulswharf,0,0
+1665,14,February,21,,St Dionis Backchurch,0,0
+1665,14,February,21,,St Mary Mounthaw,0,0
+1665,14,February,21,,St Peters Poor,0,0
+1665,14,February,21,,St Dunstans East,2,0
+1665,14,February,21,,St Mary Sommerset,1,0
+1665,14,February,21,,St Stevens Colemanstr,5,0
+1665,14,February,21,,St Edm. Lumbardstreet,2,0
+1665,14,February,21,,St Mary Staynings,0,0
+1665,14,February,21,,St Stevens Walbrook,0,0
+1665,14,February,21,,St Ethelbourgh,1,0
+1665,14,February,21,,St Mary Woolchurch,0,0
+1665,14,February,21,,St Swithins,0,0
+1665,14,February,21,,St Faiths,0,0
+1665,14,February,21,,St Mary Wolnoth,1,0
+1665,14,February,21,,St Thomas Apostle,0,0
+1665,14,February,21,,St Fosters,0,0
+1665,14,February,21,,St Martins Iremongerl.,0,0
+1665,14,February,21,,Trinity Parish,0,0
+1665,14,February,21,,St Gabriel Fenchurch,1,0
+1665,14,February,21,,St Andrews Holborn,21,0
+1665,14,February,21,,St Botolph Aldgate,9,0
+1665,14,February,21,,St Saviours Southwark,12,0
+1665,14,February,21,,St Bartholomew Great,2,0
+1665,14,February,21,,St Botolph Bishopsgate,10,0
+1665,14,February,21,,St Sepulchres Parish,27,0
+1665,14,February,21,,St Bartholomew Lesse,0,0
+1665,14,February,21,,St Dunstans West,6,0
+1665,14,February,21,,St Thomas Southwark,3,0
+1665,14,February,21,,St Brides Parish,13,0
+1665,14,February,21,,St George Southwark,3,0
+1665,14,February,21,,Trinity Minories,0,0
+1665,14,February,21,,Bridewel Precinet,0,0
+1665,14,February,21,,St Giles Cripplegate,33,0
+1665,14,February,21,,At the Pes•house,0,0
+1665,14,February,21,,St Botolph Aldersgate,2,0
+1665,14,February,21,,St Olaves Southwark,17,0
+1665,14,February,21,,St Giles in the fields,18,0
+1665,14,February,21,,Lamoeth Parish,3,0
+1665,14,February,21,,St Mary Islington,0,0
+1665,14,February,21,,Hackney Parish,3,0
+1665,14,February,21,,St Loonard Shoreditch,10,0
+1665,14,February,21,,St Mary Whitechappel,9,0
+1665,14,February,21,,St Iames Clerkenwel,5,0
+1665,14,February,21,,St Magdalen Bermond.,2,0
+1665,14,February,21,,Redriff Parish,0,0
+1665,14,February,21,,St Kath. neer the Tower,6,0
+1665,14,February,21,,St Mary Newington,3,0
+1665,14,February,21,,Stepney Parish,30,0
+1665,14,February,21,,St Clement Danes,12,0
+1665,14,February,21,,St Martins in the ••elds,23,0
+1665,14,February,21,,St Margaret Westminst.,24,0
+1665,14,February,21,,St Paul Covent Garden,4,0
+1665,14,February,21,,St Mary Savoy,1,0
+1665,21,February,28,,St ALbans Woodstreet,1,0
+1665,21,February,28,,St George Botolphlane,0,0
+1665,21,February,28,,St Martins Ludgate,3,0
+1665,21,February,28,,Alhallows Barking,2,0
+1665,21,February,28,,St Gregories by St Pauls,3,0
+1665,21,February,28,,St Martins Orgers,1,0
+1665,21,February,28,,Alhallows Breadstreet,0,0
+1665,21,February,28,,St Hellins,1,0
+1665,21,February,28,,St Martins Outwitch,0,0
+1665,21,February,28,,Alhallows Great,1,0
+1665,21,February,28,,St James Dukes place,0,0
+1665,21,February,28,,St Martins Vintrey,0,0
+1665,21,February,28,,Alhallows Honylane,0,0
+1665,21,February,28,,St James Garlickhithe,0,0
+1665,21,February,28,,St Mathew Fridaystreet,0,0
+1665,21,February,28,,Alhallows Lesse,1,0
+1665,21,February,28,,St John Baptist,2,0
+1665,21,February,28,,St Maudlins Milkstreet,1,0
+1665,21,February,28,,Alhallows Lumbardstr,2,0
+1665,21,February,28,,St John Evangelist,0,0
+1665,21,February,28,,St Maudlins Oldfishst,3,0
+1665,21,February,28,,Alhallows Stayning,1,0
+1665,21,February,28,,St John Zachary,0,0
+1665,21,February,28,,St Michael Bassishaw,0,0
+1665,21,February,28,,Alhallows the Wall,1,0
+1665,21,February,28,,St Katharine Coleman,2,0
+1665,21,February,28,,St Michael Cornhil,0,0
+1665,21,February,28,,St Alphage,0,0
+1665,21,February,28,,St Katharine crechurch,1,0
+1665,21,February,28,,St Michael Crookedla.,2,0
+1665,21,February,28,,St Andrew Hubbard,0,0
+1665,21,February,28,,St Lawrence Jewry,1,0
+1665,21,February,28,,St Michael Queenhithe,2,0
+1665,21,February,28,,St Andrew Undershaft,0,0
+1665,21,February,28,,St Lawrence Pountney,0,0
+1665,21,February,28,,St Michael Quern,0,0
+1665,21,February,28,,St Andrew Wardrobe,3,0
+1665,21,February,28,,St Leonard Eastcheap,1,0
+1665,21,February,28,,St Michael Royall,0,0
+1665,21,February,28,,St An• Aldersgate,0,0
+1665,21,February,28,,St Leonard Fosterlane,3,0
+1665,21,February,28,,St Michael Woodstreet,0,0
+1665,21,February,28,,St Ann Blackfryers,2,0
+1665,21,February,28,,St Magnus Parish,1,0
+1665,21,February,28,,St Mildred Breadstreet,1,0
+1665,21,February,28,,St Antholins Parish,0,0
+1665,21,February,28,,St Margaret Lothbury,1,0
+1665,21,February,28,,St Mildred Poultrey,0,0
+1665,21,February,28,,St Austins Parish,1,0
+1665,21,February,28,,St Margaret Moses,1,0
+1665,21,February,28,,St Nicholas Acons,0,0
+1665,21,February,28,,St Bartholomew Exch.,1,0
+1665,21,February,28,,St Margaret Newfishst,0,0
+1665,21,February,28,,St Nicholas Coleabby,1,0
+1665,21,February,28,,St Bennet Fynck,0,0
+1665,21,February,28,,St Margaret Pattons,0,0
+1665,21,February,28,,St Nicholas Olaves,1,0
+1665,21,February,28,,St Bennet Gracechurch,0,0
+1665,21,February,28,,St Mary Abchurch,0,0
+1665,21,February,28,,St Olaves Hartstreet,0,0
+1665,21,February,28,,St Bennet Paulswharf,1,0
+1665,21,February,28,,St Mary Aldermanbury,0,0
+1665,21,February,28,,St Olaves Jewry,0,0
+1665,21,February,28,,St Bennet Sherehog,0,0
+1665,21,February,28,,St Mary Aldermary,0,0
+1665,21,February,28,,St Olaves Silverstreet,2,0
+1665,21,February,28,,St Botolph Billingsgate,0,0
+1665,21,February,28,,St Mary le Bow,2,0
+1665,21,February,28,,St Paneras Soperlane,0,0
+1665,21,February,28,,Christs Church,2,0
+1665,21,February,28,,St Mary Bothaw,0,0
+1665,21,February,28,,St Peters Cheap,1,0
+1665,21,February,28,,St Christophers,0,0
+1665,21,February,28,,St Mary Colechurch,0,0
+1665,21,February,28,,St Peters Cornhil,2,0
+1665,21,February,28,,St Clement Eastcheap,1,0
+1665,21,February,28,,St Mary Hill,0,0
+1665,21,February,28,,St Peters Paulswharf,0,0
+1665,21,February,28,,St Dionis Backchurch,1,0
+1665,21,February,28,,St Mary Mounthaw,0,0
+1665,21,February,28,,St Peters Poor,1,0
+1665,21,February,28,,St Dunstans East,1,0
+1665,21,February,28,,St Mary Sommerset,0,0
+1665,21,February,28,,St Stevens Colemanstr.,2,0
+1665,21,February,28,,St Edm. Lumbard Rrec•,0,0
+1665,21,February,28,,St Mary Staynings,0,0
+1665,21,February,28,,St Stevens Walbrook,0,0
+1665,21,February,28,,St Ethelbourgh,1,0
+1665,21,February,28,,St Mary Woolchurch,0,0
+1665,21,February,28,,St Swithins,0,0
+1665,21,February,28,,St Faiths,1,0
+1665,21,February,28,,St Mary Wolnoth,0,0
+1665,21,February,28,,St Thomas Apostle,0,0
+1665,21,February,28,,St Fosters,1,0
+1665,21,February,28,,St Martins Iremongerl.,0,0
+1665,21,February,28,,Trinity Parish,0,0
+1665,21,February,28,,St Gabriel Fenchurch,0,0
+1665,21,February,28,,St Andrews Holborn,17,0
+1665,21,February,28,,St Botolph Aldgate,16,0
+1665,21,February,28,,St Saviours Southwark,16,0
+1665,21,February,28,,St Bartholomew Great,6,0
+1665,21,February,28,,St Botolph Bishopsgate,18,0
+1665,21,February,28,,St Sepulchres Parish,6,0
+1665,21,February,28,,St Bartholomew L•sse,1,0
+1665,21,February,28,,St Dunstans West,6,0
+1665,21,February,28,,St Thomas Southwark,3,0
+1665,21,February,28,,〈◊〉 Brides Parish,11,0
+1665,21,February,28,,St George Southwark,3,0
+1665,21,February,28,,Trinity Minories,0,0
+1665,21,February,28,,Bridewel Precinet,0,0
+1665,21,February,28,,St Giles Cripplegate,35,0
+1665,21,February,28,,At the Pesthouse,0,0
+1665,21,February,28,,St Botolph Aldersgate,5,0
+1665,21,February,28,,St Olaves Southwark,13,0
+1665,21,February,28,,〈◊〉 Giles in the fields,28,0
+1665,21,February,28,,L•mbeth P•rish,5,0
+1665,21,February,28,,St Mary •slington,0,0
+1665,21,February,28,,Hackney Parish,0,0
+1665,21,February,28,,St Leonard Shorediteh,13,0
+1665,21,February,28,,St Mary Whitechappel,16,0
+1665,21,February,28,,St James Clerkenwel,10,0
+1665,21,February,28,,St Magdalen Bermond,6,0
+1665,21,February,28,,Redrin Parish,0,0
+1665,21,February,28,,S• Kath. neer the Tower,4,0
+1665,21,February,28,,St Mary Newington,0,0
+1665,21,February,28,,Stepney Parish,24,0
+1665,21,February,28,,St Clement Danes,10,0
+1665,21,February,28,,St Martins in the field,28,0
+1665,21,February,28,,St Margaret Westminst.,22,0
+1665,21,February,28,,St Paul Covent Garden,5,0
+1665,21,February,28,,St Mary Savoy,2,0
+1665,28,February,7,March,St ALbans Wood street,1,0
+1665,28,February,7,March,St George Botolphlane,1,0
+1665,28,February,7,March,St Martins Ludgate,0,0
+1665,28,February,7,March,Alhallows Barking,2,0
+1665,28,February,7,March,St Gregories by St Pauls,5,0
+1665,28,February,7,March,St Martins Orgars,1,0
+1665,28,February,7,March,Alhallows Bread street,0,0
+1665,28,February,7,March,St Hellens,2,0
+1665,28,February,7,March,St Martins Outwich,0,0
+1665,28,February,7,March,Alhallows Great,1,0
+1665,28,February,7,March,St James Dukes place,0,0
+1665,28,February,7,March,St Martins Vintrey,1,0
+1665,28,February,7,March,Alhallows Honylane,0,0
+1665,28,February,7,March,St James Garlickhithe,1,0
+1665,28,February,7,March,St Ma•hew Friday street,0,0
+1665,28,February,7,March,Alhallows Lesse,2,0
+1665,28,February,7,March,St John Baptist,2,0
+1665,28,February,7,March,St Maudlins Milkstreet,1,0
+1665,28,February,7,March,Alhallows Lumbardstr.,0,0
+1665,28,February,7,March,St John Evangelist,0,0
+1665,28,February,7,March,St Maudlins Oldfishstr.,1,0
+1665,28,February,7,March,Alhallows Stayning,1,0
+1665,28,February,7,March,St John Zachary,1,0
+1665,28,February,7,March,St Michael Bassishaw,2,0
+1665,28,February,7,March,Alhallows the Wall,3,0
+1665,28,February,7,March,St Katharine Coleman,3,0
+1665,28,February,7,March,St Michael Cornhil,6,0
+1665,28,February,7,March,St Alphage,0,0
+1665,28,February,7,March,St Katharine crechurch,3,0
+1665,28,February,7,March,St Michael Crookedla.,1,0
+1665,28,February,7,March,St Andrew Hubbard,1,0
+1665,28,February,7,March,St Lawrence Jewry,1,0
+1665,28,February,7,March,St Michael Queenhithe,0,0
+1665,28,February,7,March,St Andrew Undershaft,0,0
+1665,28,February,7,March,St Lawrence Poutney,0,0
+1665,28,February,7,March,St Michael Quern,0,0
+1665,28,February,7,March,St Andrew Wardrobe,1,0
+1665,28,February,7,March,St Leonard Eastcheap,0,0
+1665,28,February,7,March,St Michael Royall,0,0
+1665,28,February,7,March,St Ann Aldersgate,0,0
+1665,28,February,7,March,St Leonard Fosterlane,1,0
+1665,28,February,7,March,St Michael Woodstreet,0,0
+1665,28,February,7,March,St Ann Blackfryers,2,0
+1665,28,February,7,March,St Magnus Parish,6,0
+1665,28,February,7,March,St Mildred Breadstreet,1,0
+1665,28,February,7,March,St Antholins Parish,3,0
+1665,28,February,7,March,St Margaret Lothbury,0,0
+1665,28,February,7,March,St Mildred Poultrey,0,0
+1665,28,February,7,March,St Austins Parish,0,0
+1665,28,February,7,March,St Margaret Moses,0,0
+1665,28,February,7,March,St Nicholas Acons,1,0
+1665,28,February,7,March,St Bartholomew Excha,0,0
+1665,28,February,7,March,St Margaret New fishst,0,0
+1665,28,February,7,March,St Nicholas Coleabby,0,0
+1665,28,February,7,March,St Bennet Fynck,0,0
+1665,28,February,7,March,St Margaret Patrons,1,0
+1665,28,February,7,March,St Nicholas Olaves,0,0
+1665,28,February,7,March,St Bennet Graecchurc•,0,0
+1665,28,February,7,March,St Mary Abchurch,0,0
+1665,28,February,7,March,St Olaves Hartstreet,2,0
+1665,28,February,7,March,St Bennet Paulswharfe,2,0
+1665,28,February,7,March,St Mary Aldermanbury,0,0
+1665,28,February,7,March,St Olaves Jewry,0,0
+1665,28,February,7,March,St Bennet Sherchog,0,0
+1665,28,February,7,March,St Mary Aldermary,0,0
+1665,28,February,7,March,St Olaves Silverstreet,1,0
+1665,28,February,7,March,St Botolph Billingsgate,0,0
+1665,28,February,7,March,St Mary le Bow,0,0
+1665,28,February,7,March,St Pancras Soperlane,0,0
+1665,28,February,7,March,Christ Church,1,0
+1665,28,February,7,March,St Mary Bothaw,0,0
+1665,28,February,7,March,St Peters Cheap,1,0
+1665,28,February,7,March,St Christophers,0,0
+1665,28,February,7,March,St Mary Colechurch,0,0
+1665,28,February,7,March,St Peters Cornhil,1,0
+1665,28,February,7,March,St Clement Eastcheap,0,0
+1665,28,February,7,March,St Mary Hill,1,0
+1665,28,February,7,March,St Peters Paulswhars,0,0
+1665,28,February,7,March,St Dionis Backchurch,0,0
+1665,28,February,7,March,St Mary Mounthaw,0,0
+1665,28,February,7,March,St Peters Poor,2,0
+1665,28,February,7,March,St Dunstans East,1,0
+1665,28,February,7,March,St Mary Sommerset,0,0
+1665,28,February,7,March,St Stevens Colemanstr.,4,0
+1665,28,February,7,March,St Edm. Lumbardstreet,0,0
+1665,28,February,7,March,St Mary Staynings,1,0
+1665,28,February,7,March,St Stevens Walbrook,1,0
+1665,28,February,7,March,St Ethelborough,1,0
+1665,28,February,7,March,St Mary Woolchurch,1,0
+1665,28,February,7,March,St Swithins,0,0
+1665,28,February,7,March,St Faiths,0,0
+1665,28,February,7,March,St Mary Woolnoth,1,0
+1665,28,February,7,March,St Thomas Apostles,1,0
+1665,28,February,7,March,St Fosters,0,0
+1665,28,February,7,March,St Marcins Iremongerl.,1,0
+1665,28,February,7,March,Trinity Parish,1,0
+1665,28,February,7,March,St Gabriel Fenchurch,0,0
+1665,28,February,7,March,St Andrews Holborne,19,0
+1665,28,February,7,March,St Botolph Aldgate,20,0
+1665,28,February,7,March,S• Saviours Southwark,17,0
+1665,28,February,7,March,St Bartholomew Great,2,0
+1665,28,February,7,March,St Botolph Bishopsgat•,11,0
+1665,28,February,7,March,St Sepulchres Parish,26,0
+1665,28,February,7,March,St Bartholomew Lesse,0,0
+1665,28,February,7,March,St Dunstans We•t,4,0
+1665,28,February,7,March,St Thomas Southwark,1,0
+1665,28,February,7,March,St Brides Paris•,11,0
+1665,28,February,7,March,St George Southwark,3,0
+1665,28,February,7,March,Trinity Minories,0,0
+1665,28,February,7,March,Bridewel Precinet,1,0
+1665,28,February,7,March,St Giles Cripplegate,30,0
+1665,28,February,7,March,At the Pesthouse,0,0
+1665,28,February,7,March,St Botolph Aldersgate,7,0
+1665,28,February,7,March,St Olaves Southwark,24,0
+1665,28,February,7,March,St Giles in the fields,14,0
+1665,28,February,7,March,Lambeth Paris•,2,0
+1665,28,February,7,March,St Mary Islington,0,0
+1665,28,February,7,March,Rackney Parish,0,0
+1665,28,February,7,March,St Leonard Shoreditc•,7,0
+1665,28,February,7,March,St Mary Whitechappel,17,0
+1665,28,February,7,March,St•ames Clerkenwel,8,0
+1665,28,February,7,March,St Magdalen Bermond,6,0
+1665,28,February,7,March,Redriff Parish,0,0
+1665,28,February,7,March,St Kath. neer the Tower,5,0
+1665,28,February,7,March,St Mary Newington,9,0
+1665,28,February,7,March,Stepney Parish,37,0
+1665,28,February,7,March,St Clement Danes,10,0
+1665,28,February,7,March,St Martins in the fields,35,0
+1665,28,February,7,March,St Margaret Westminst.,30,0
+1665,28,February,7,March,S Paul Covent Garden,1,0
+1665,28,February,7,March,St Mary Savoy,1,0
+1665,7,March,14,,S• ALbans Woodstreet,2,0
+1665,7,March,14,,St George Botolphlane,0,0
+1665,7,March,14,,St Martins Ludgate,1,0
+1665,7,March,14,,Alhallows Barking,3,0
+1665,7,March,14,,St Gregories by St Pauls,1,0
+1665,7,March,14,,St Martins Orgars,1,0
+1665,7,March,14,,Alhallows Breadstreet,0,0
+1665,7,March,14,,St Hellens,1,0
+1665,7,March,14,,St Martins Out•itch,0,0
+1665,7,March,14,,Alhallows Great,1,0
+1665,7,March,14,,St James Dukes place,1,0
+1665,7,March,14,,St Martins Vintrey,5,0
+1665,7,March,14,,Alhallows Honylane,1,0
+1665,7,March,14,,St James Garlickhithe,0,0
+1665,7,March,14,,St Mathew Fridaystreet,0,0
+1665,7,March,14,,Alhallows Lesse,1,0
+1665,7,March,14,,St John Baptist,1,0
+1665,7,March,14,,St Maudlins Milkstreet,2,0
+1665,7,March,14,,Alhallows Lumbardst•,0,0
+1665,7,March,14,,St•ohn Evangelist,0,0
+1665,7,March,14,,St Maudlins Old fi•hstr.,1,0
+1665,7,March,14,,Alhallows Stayning,0,0
+1665,7,March,14,,St John Zachary,0,0
+1665,7,March,14,,St Michael Bassishaw,1,0
+1665,7,March,14,,Alhallows the W•ll,2,0
+1665,7,March,14,,St Katharine Coleman,1,0
+1665,7,March,14,,St Michael Cornhil,0,0
+1665,7,March,14,,St Alphage,1,0
+1665,7,March,14,,St K•tharine crechurch,0,0
+1665,7,March,14,,St Michael Crookedla.,1,0
+1665,7,March,14,,St Andrew Hubbard,0,0
+1665,7,March,14,,St La•rence J••ry,2,0
+1665,7,March,14,,St Michael Queenhithe,1,0
+1665,7,March,14,,St Andrew Undershaft,2,0
+1665,7,March,14,,St Lawrence Po•ntney,1,0
+1665,7,March,14,,St Michael Quern,1,0
+1665,7,March,14,,St Andrew Ward•obe,3,0
+1665,7,March,14,,St Leonard Eastcheap,0,0
+1665,7,March,14,,St Michael Royall,0,0
+1665,7,March,14,,St Ann Aldersgate,3,0
+1665,7,March,14,,St Leonard Fosterlane,3,0
+1665,7,March,14,,St Michael Woodstreet,0,0
+1665,7,March,14,,St Ann Blackfryers,0,0
+1665,7,March,14,,St Magnus Perish,1,0
+1665,7,March,14,,St Mildred Breadstree•,2,0
+1665,7,March,14,,St Antholins Pari••,0,0
+1665,7,March,14,,St Margaret Lothbury,2,0
+1665,7,March,14,,St Mildred Poultrey,1,0
+1665,7,March,14,,St Austins Parish,0,0
+1665,7,March,14,,St Margaret Moses,0,0
+1665,7,March,14,,St Nicholas Acons,0,0
+1665,7,March,14,,St Bartholomew Excha,1,0
+1665,7,March,14,,St Margaret •e•fishs•,0,0
+1665,7,March,14,,St Nicholas Coleabby,0,0
+1665,7,March,14,,St Bennet Fynck,0,0
+1665,7,March,14,,St Margaret Pattons,1,0
+1665,7,March,14,,St Nicholas Olaves,0,0
+1665,7,March,14,,St Bennet Gracechurc•,0,0
+1665,7,March,14,,S• Mary Abchurch,1,0
+1665,7,March,14,,St Olaves Hartstreet,0,0
+1665,7,March,14,,St Bennet Paulswharse,2,0
+1665,7,March,14,,St Mary Aldermanbury,0,0
+1665,7,March,14,,St Olaves Jewry,0,0
+1665,7,March,14,,St Bennet She•ehog,0,0
+1665,7,March,14,,St Mary Aldermary,0,0
+1665,7,March,14,,St Olaves Silverstreet,1,0
+1665,7,March,14,,St Botolph Billingsgate,0,0
+1665,7,March,14,,St Mary le Bow,0,0
+1665,7,March,14,,St Pancras Soperlan•,1,0
+1665,7,March,14,,Christ Church,1,0
+1665,7,March,14,,S• Mary Bothaw,0,0
+1665,7,March,14,,St Peters Cheap,1,0
+1665,7,March,14,,St Christophers,0,0
+1665,7,March,14,,〈◊〉 Mary Colechurch,0,0
+1665,7,March,14,,St Peters Cornhil,2,0
+1665,7,March,14,,St Clement Eastcheap,0,0
+1665,7,March,14,,St Mary Hill,0,0
+1665,7,March,14,,St Peters Paulswhars,0,0
+1665,7,March,14,,St Dionis Backchurch,0,0
+1665,7,March,14,,St Mary Mounthaw,0,0
+1665,7,March,14,,St Peters Poor,0,0
+1665,7,March,14,,S• Dunst•ns East,1,0
+1665,7,March,14,,St M•ry Sommerse•,1,0
+1665,7,March,14,,St Stevens Coleman•tr,1,0
+1665,7,March,14,,St Edm. Lumbardstreet,1,0
+1665,7,March,14,,St Mary Staynings,1,0
+1665,7,March,14,,St Stevens Walbrook,1,0
+1665,7,March,14,,St Ethelborough,1,0
+1665,7,March,14,,St Mary Woolcharen,0,0
+1665,7,March,14,,St Swithins,0,0
+1665,7,March,14,,St Faiths,2,0
+1665,7,March,14,,St Mary Woolnoth,0,0
+1665,7,March,14,,St Thomas Apostle•,1,0
+1665,7,March,14,,St Fosters,0,0
+1665,7,March,14,,St Martins Iremonger•,1,0
+1665,7,March,14,,Trinity Parish,0,0
+1665,7,March,14,,St Gabriel Fenchurch,0,0
+1665,7,March,14,,S Andrews Holborne,24,0
+1665,7,March,14,,St Botolph Aldgate,16,0
+1665,7,March,14,,S• Sa•iours So•thwark,17,0
+1665,7,March,14,,St Bartholomew Grea•,2,0
+1665,7,March,14,,St Botolph Bishopsgat•,18,0
+1665,7,March,14,,St Sepulchres Parish,22,0
+1665,7,March,14,,St Bartholomew Lesse,0,0
+1665,7,March,14,,St Dunstans West,10,0
+1665,7,March,14,,St Thomas Southwark,2,0
+1665,7,March,14,,S• Brides Paris•,14,0
+1665,7,March,14,,St George Southwark,6,0
+1665,7,March,14,,•rinity Minories,0,0
+1665,7,March,14,,Bridewel Precinct,4,0
+1665,7,March,14,,S• Giles Cripplegate,36,0
+1665,7,March,14,,•t the Pesthouse,0,0
+1665,7,March,14,,〈◊〉 Botolph Aldersgate,6,0
+1665,7,March,14,,St Olaves Southwark,20,0
+1665,7,March,14,,S• Giles in the fields,16,0
+1665,7,March,14,,Lambeth Parish,2,0
+1665,7,March,14,,S Mary I••ington,0,0
+1665,7,March,14,,Ha•kney Parish,3,0
+1665,7,March,14,,St Leonard Shoreditch,10,0
+1665,7,March,14,,〈◊〉 Mary Whitechappel,15,0
+1665,7,March,14,,S• James Clerkenwel,5,0
+1665,7,March,14,,St Magdalen Bermond,7,0
+1665,7,March,14,,••driff Parish,0,0
+1665,7,March,14,,S Kath. neer the Tower,2,0
+1665,7,March,14,,St Mary Newington,4,0
+1665,7,March,14,,St•pney Parish,41,0
+1665,7,March,14,,S• Clement Danes,10,0
+1665,7,March,14,,St Martins in the felds,30,0
+1665,7,March,14,,St Margaret Westminst.,13,0
+1665,7,March,14,,S Paul Covent Garden,3,0
+1665,7,March,14,,St Mary Savoy,3,0
+1665,14,March,21,,St ALbans Woodstreet,0,0
+1665,14,March,21,,St George Botolphlane,0,0
+1665,14,March,21,,St Martins L••••••e,1,0
+1665,14,March,21,,Alhallows Barkin•,5,0
+1665,14,March,21,,St Gregories by St Pauls,0,0
+1665,14,March,21,,St Martins Orgars,1,0
+1665,14,March,21,,Alhallows Breadstreet,2,0
+1665,14,March,21,,St Hellins,1,0
+1665,14,March,21,,St Martins O•••itch,2,0
+1665,14,March,21,,Alhallows Great,3,0
+1665,14,March,21,,St James Dukes place,0,0
+1665,14,March,21,,St Martins Vintrey,1,0
+1665,14,March,21,,Alhallows Honylane,0,0
+1665,14,March,21,,St James Garlickhithe,0,0
+1665,14,March,21,,St Mathew Friday••re••,0,0
+1665,14,March,21,,Alhallows Lesse,2,0
+1665,14,March,21,,St John Baptist,3,0
+1665,14,March,21,,St M••dlin Mil〈7 letters〉,0,0
+1665,14,March,21,,Alhallows Lumbardstr,0,0
+1665,14,March,21,,St John Evangelist,0,0
+1665,14,March,21,,St Maudlins •ld••••••,0,0
+1665,14,March,21,,Alhallows Stayning,1,0
+1665,14,March,21,,St John Zachary,0,0
+1665,14,March,21,,St Michael Ba••••haw,2,0
+1665,14,March,21,,Alhallows the Wall,1,0
+1665,14,March,21,,St Katharine Coleman,2,0
+1665,14,March,21,,St Michael Cornhil,0,0
+1665,14,March,21,,St Alphage,0,0
+1665,14,March,21,,St Katharine crechurch,1,0
+1665,14,March,21,,St Michael Crookedla.,0,0
+1665,14,March,21,,St Andrew Hubbard,2,0
+1665,14,March,21,,St Lawrence Jewry,0,0
+1665,14,March,21,,St Michael Queenhithe,1,0
+1665,14,March,21,,St Andrew Undershaft,1,0
+1665,14,March,21,,St Lawrence Pountney,0,0
+1665,14,March,21,,St Michael Quern,0,0
+1665,14,March,21,,St Andrew Wardrobe,1,0
+1665,14,March,21,,St Leonard Eastcheap,0,0
+1665,14,March,21,,St Michael Royall,1,0
+1665,14,March,21,,St Ann Aldersgate,0,0
+1665,14,March,21,,St Leonard Fosterlane,1,0
+1665,14,March,21,,St Michael Woodstreet,0,0
+1665,14,March,21,,St Ann Blackfryers,2,0
+1665,14,March,21,,St Magnus Parish,0,0
+1665,14,March,21,,St Mildred Breadstreet,2,0
+1665,14,March,21,,St Antholins Parish,1,0
+1665,14,March,21,,St Margaret Lothbury,1,0
+1665,14,March,21,,St Mildred Poultrey,0,0
+1665,14,March,21,,St Austins Parish,0,0
+1665,14,March,21,,St Margaret Moses,1,0
+1665,14,March,21,,St Nicholas Acons,1,0
+1665,14,March,21,,St Bartholomew Exch.,0,0
+1665,14,March,21,,St Margaret Newfishst,0,0
+1665,14,March,21,,St Nicholas Coleabby,0,0
+1665,14,March,21,,St Bennet Fynck,0,0
+1665,14,March,21,,St Margaret Pattons,0,0
+1665,14,March,21,,St Nicholas Olaves,1,0
+1665,14,March,21,,St Bennet Gracechurch,0,0
+1665,14,March,21,,St Mary Abchurch,0,0
+1665,14,March,21,,St Olaves Hartstreet,0,0
+1665,14,March,21,,St Bennet Paulswharf,0,0
+1665,14,March,21,,St Mary Aldermanbury,0,0
+1665,14,March,21,,St Olaves Jewry,0,0
+1665,14,March,21,,St Bennet Sherchog,0,0
+1665,14,March,21,,St Mary Aldermary,0,0
+1665,14,March,21,,St Olaves Silverstreet,0,0
+1665,14,March,21,,St Botolph Billingsgate,0,0
+1665,14,March,21,,St Mary le Bow,0,0
+1665,14,March,21,,St Pancras Soperlans,0,0
+1665,14,March,21,,Christs Church,7,0
+1665,14,March,21,,St Mary Bothaw,0,0
+1665,14,March,21,,St Peters Cheap,0,0
+1665,14,March,21,,St Christophers,0,0
+1665,14,March,21,,St Mary Colechurch,0,0
+1665,14,March,21,,St Peters Cornhil,1,0
+1665,14,March,21,,St Clement Eastcheap,0,0
+1665,14,March,21,,St Mary Hill,1,0
+1665,14,March,21,,St Peters Paulswharf,1,0
+1665,14,March,21,,St Dionis Backchurch,0,0
+1665,14,March,21,,St Mary Mounthaw,1,0
+1665,14,March,21,,St Peters Poor,1,0
+1665,14,March,21,,St Dunstans •a•t,3,0
+1665,14,March,21,,St Mary Sommerset,1,0
+1665,14,March,21,,St Stevens Colemanstr.,2,0
+1665,14,March,21,,St Edm. Lumbardstreet,1,0
+1665,14,March,21,,St Mary Staynings,0,0
+1665,14,March,21,,St Stevens Walbrook,0,0
+1665,14,March,21,,St Ethelbourgh,0,0
+1665,14,March,21,,St Mary Woolchurch,1,0
+1665,14,March,21,,St Swithins,0,0
+1665,14,March,21,,St Faiths,1,0
+1665,14,March,21,,St Mary Wolnoth,1,0
+1665,14,March,21,,St Thomas Apostle,1,0
+1665,14,March,21,,St Fosters,1,0
+1665,14,March,21,,St Martins Iremongerl.,0,0
+1665,14,March,21,,Trinity Parish,1,0
+1665,14,March,21,,St Gabriel Fenchurch,0,0
+1665,14,March,21,,St Andrews Molborn,19,0
+1665,14,March,21,,St Botolph Aldgate,13,0
+1665,14,March,21,,St Saviours Southwark,12,0
+1665,14,March,21,,St Bartholomew Grea•,2,0
+1665,14,March,21,,St Botolph Bishopsgate,7,0
+1665,14,March,21,,St Sepulchres Parish,17,0
+1665,14,March,21,,St Bartholomew Lesse,2,0
+1665,14,March,21,,St Dunstans West,1,0
+1665,14,March,21,,St Thomas Southwark,1,0
+1665,14,March,21,,St Brides Parish,9,0
+1665,14,March,21,,St George Southwark,6,0
+1665,14,March,21,,Trinity Minories,1,0
+1665,14,March,21,,Bridewel Precinet,0,0
+1665,14,March,21,,St Giles Cripplegate,19,0
+1665,14,March,21,,At the Pesthouse,0,0
+1665,14,March,21,,St Botolph Aldersgate,6,0
+1665,14,March,21,,St Olaves Southwark,18,0
+1665,14,March,21,,St Giles in the fields,17,0
+1665,14,March,21,,Lambeth Parish,6,0
+1665,14,March,21,,St Mary Islington,2,0
+1665,14,March,21,,Hackney Parish,0,0
+1665,14,March,21,,St Leonard Shoreditch,10,0
+1665,14,March,21,,St Mary Whitechappel,11,0
+1665,14,March,21,,St James Clerkenwel,10,0
+1665,14,March,21,,St Magdalen Bermond,0,0
+1665,14,March,21,,Redriff Parish,0,0
+1665,14,March,21,,St Kath. neer the Tower,3,0
+1665,14,March,21,,St Mary Newington,3,0
+1665,14,March,21,,Stepney Parish,36,0
+1665,14,March,21,,St Clement Danes,8,0
+1665,14,March,21,,St Martins in the fields,24,0
+1665,14,March,21,,St Margaret Westminst.,23,0
+1665,14,March,21,,St Paul Covent Garden,3,0
+1665,14,March,21,,St Mary Savoy,5,0
+1665,21,March,28,,St ALbans Woodstreet,2,0
+1665,21,March,28,,St George Botolphlane,0,0
+1665,21,March,28,,St Martins Ludgate,0,0
+1665,21,March,28,,Alhallows Barking,1,0
+1665,21,March,28,,St Gregories by St Pauls,0,0
+1665,21,March,28,,St Martins Orgars,1,0
+1665,21,March,28,,Alhallows Breadstreet,1,0
+1665,21,March,28,,St Hellins,2,0
+1665,21,March,28,,St Martins Outwitch,0,0
+1665,21,March,28,,Alhallows Great,0,0
+1665,21,March,28,,St James Dukes place,1,0
+1665,21,March,28,,St Martins Vintrey,2,0
+1665,21,March,28,,Alhallows Honylane,2,0
+1665,21,March,28,,St James Garlickhithe,5,0
+1665,21,March,28,,St Mathew Fridaystreet,0,0
+1665,21,March,28,,Alhallows Lesse,0,0
+1665,21,March,28,,St John Baptist,0,0
+1665,21,March,28,,St Maudlins Milkstreet,0,0
+1665,21,March,28,,Alhallows Lumbardstr,1,0
+1665,21,March,28,,St John Evangelist,0,0
+1665,21,March,28,,St Maudlins Oldfishst,1,0
+1665,21,March,28,,Alhallows Stayning,0,0
+1665,21,March,28,,St John Zachary,2,0
+1665,21,March,28,,St Michael Bassishaw,0,0
+1665,21,March,28,,Alhallows the Wall,3,0
+1665,21,March,28,,St Katharine Coleman,2,0
+1665,21,March,28,,St Michael Cornhil,0,0
+1665,21,March,28,,St Alphage,1,0
+1665,21,March,28,,St Katharine crechurch,0,0
+1665,21,March,28,,St Michael Crookedla.,0,0
+1665,21,March,28,,St Andrew Hubbard,0,0
+1665,21,March,28,,St Lawrence Jewry,0,0
+1665,21,March,28,,St Michael Queenhithe,1,0
+1665,21,March,28,,St Andrew Undershaft,1,0
+1665,21,March,28,,St Lawrence Pountney,0,0
+1665,21,March,28,,St Michael Quern,0,0
+1665,21,March,28,,St Andrew Wardrobe,5,0
+1665,21,March,28,,St Leonard Eastcheap,1,0
+1665,21,March,28,,St Michael Royall,1,0
+1665,21,March,28,,St Ann Aldersgate,1,0
+1665,21,March,28,,St Leonard Fosterlane,2,0
+1665,21,March,28,,St Michael Woodstreet,1,0
+1665,21,March,28,,St Ann Blackfryers,2,0
+1665,21,March,28,,St Magnus Parish,1,0
+1665,21,March,28,,St Mildred Breadstreet,1,0
+1665,21,March,28,,St Antholins Parish,0,0
+1665,21,March,28,,St Margaret Lothbury,0,0
+1665,21,March,28,,St Mildred Poultrey,0,0
+1665,21,March,28,,St Austins Parish,0,0
+1665,21,March,28,,St Margaret Moses,1,0
+1665,21,March,28,,St Nicholas Acons,0,0
+1665,21,March,28,,St Bartholomew Exch.,0,0
+1665,21,March,28,,St Margaret Newfishst.,0,0
+1665,21,March,28,,St Nicholas Coleabby,1,0
+1665,21,March,28,,St Bennet Fynck,1,0
+1665,21,March,28,,St Margaret Patrons,0,0
+1665,21,March,28,,St Nicholas Olaves,1,0
+1665,21,March,28,,St Bennet Gracechurch,1,0
+1665,21,March,28,,St Mary Abchurch,0,0
+1665,21,March,28,,St Olaves Hartstreet,1,0
+1665,21,March,28,,St Bennet Paulswharf,1,0
+1665,21,March,28,,St Mary Aldermanbury,2,0
+1665,21,March,28,,St Olaves Jewry,0,0
+1665,21,March,28,,St Bennet Sherchog,0,0
+1665,21,March,28,,St Mary Aldermary,0,0
+1665,21,March,28,,St Olaves Silverstreet,0,0
+1665,21,March,28,,St Botolph Billingsgate,0,0
+1665,21,March,28,,St Mary le Bow,2,0
+1665,21,March,28,,St Pancras Soperlane,0,0
+1665,21,March,28,,Christs Church,1,0
+1665,21,March,28,,St Mary Bothaw,0,0
+1665,21,March,28,,St Peters Cheap,0,0
+1665,21,March,28,,St Christophers,0,0
+1665,21,March,28,,St Mary Colechurch,1,0
+1665,21,March,28,,St Peters Cornhil,0,0
+1665,21,March,28,,St Clement Eastcheap,0,0
+1665,21,March,28,,St Mary Hill,0,0
+1665,21,March,28,,St Peters Paulswharf,1,0
+1665,21,March,28,,St Dionis Backchurch,0,0
+1665,21,March,28,,St Mary Mounthaw,0,0
+1665,21,March,28,,St Peters Poor,0,0
+1665,21,March,28,,St Dunstans East,0,0
+1665,21,March,28,,St Mary Sommerset,1,0
+1665,21,March,28,,St Stevens Colemanstr.,1,0
+1665,21,March,28,,St Edm. Lumbardstreet,1,0
+1665,21,March,28,,St Mary Staynings,0,0
+1665,21,March,28,,St Stevens Walbrook,0,0
+1665,21,March,28,,St Ethelbourgh,0,0
+1665,21,March,28,,St Mary Woolchurch,0,0
+1665,21,March,28,,St Swithins,1,0
+1665,21,March,28,,St Faiths,0,0
+1665,21,March,28,,St Mary Wolnoth,0,0
+1665,21,March,28,,St Thomas Apostle,3,0
+1665,21,March,28,,St Fosters,1,0
+1665,21,March,28,,St Martins Iremongerl.,1,0
+1665,21,March,28,,Trinity Parish,0,0
+1665,21,March,28,,St Gabriel Fenchurch,1,0
+1665,21,March,28,,St Andrews Holborn,17,0
+1665,21,March,28,,St Botolph Aldgate,16,0
+1665,21,March,28,,St Saviours Southwark,19,0
+1665,21,March,28,,St Bartholomew Great,1,0
+1665,21,March,28,,St Botolph Bishopsgate,13,0
+1665,21,March,28,,St Sepulchres Parish,11,0
+1665,21,March,28,,St Bartholomew Lesse,0,0
+1665,21,March,28,,St Dunstans West,6,0
+1665,21,March,28,,St Thomas Southwark,2,0
+1665,21,March,28,,St Brides Parish,13,0
+1665,21,March,28,,St George Southwark,4,0
+1665,21,March,28,,Trinity Minories,0,0
+1665,21,March,28,,Bridewel Precinet,1,0
+1665,21,March,28,,St Giles Cripplegate,32,0
+1665,21,March,28,,At the Pesthouse,0,0
+1665,21,March,28,,St Botolph Aldersgate,3,0
+1665,21,March,28,,St Olaves Southwark,22,0
+1665,21,March,28,,St Giles in the fields,14,0
+1665,21,March,28,,Lambeth Parish,5,0
+1665,21,March,28,,St Mary Islington,3,0
+1665,21,March,28,,Hackney Parish,2,0
+1665,21,March,28,,St Leonard Shoreditch,0,0
+1665,21,March,28,,St Mary Whitechappel,8,0
+1665,21,March,28,,St James Clerkenwel,3,0
+1665,21,March,28,,St Magdalen Bermond,9,0
+1665,21,March,28,,Redriff Parish,0,0
+1665,21,March,28,,St Kath. neer the Tower,4,0
+1665,21,March,28,,St Mary Newington,4,0
+1665,21,March,28,,Stepney Parish,22,0
+1665,21,March,28,,St Clement Danes,12,0
+1665,21,March,28,,St Martins in the fields,22,0
+1665,21,March,28,,St Margaret Westminst.,12,0
+1665,21,March,28,,St Paul Covent Garden,2,0
+1665,21,March,28,,St Mary Savoy,3,0
+1665,28,March,4,April,ALbans Woodstreet,1,0
+1665,28,March,4,April,St George Botolphlane,0,0
+1665,28,March,4,April,St Martins Ludgate,0,0
+1665,28,March,4,April,Alhallows Barking,2,0
+1665,28,March,4,April,S• Gregories by St Paul•,5,0
+1665,28,March,4,April,St Martins Orgars,0,0
+1665,28,March,4,April,•lh•llows Breadstreet,0,0
+1665,28,March,4,April,St Hellens,0,0
+1665,28,March,4,April,St Martins Outwitch,0,0
+1665,28,March,4,April,Alhallows Great,0,0
+1665,28,March,4,April,St James Dukes place,1,0
+1665,28,March,4,April,St Martins Vintrey,0,0
+1665,28,March,4,April,Alhallows Honylane,1,0
+1665,28,March,4,April,St James Garlickhithe,1,0
+1665,28,March,4,April,St Mathew Fridaystr•et,0,0
+1665,28,March,4,April,Alhallows L•sse,1,0
+1665,28,March,4,April,St John Baptist,2,0
+1665,28,March,4,April,St Maudlins Milkstreet,0,0
+1665,28,March,4,April,Alhallows Lumbardstr.,1,0
+1665,28,March,4,April,St John Evangelist,1,0
+1665,28,March,4,April,St Maudlins Oldfishstr.,1,0
+1665,28,March,4,April,Alhallows Stayning,0,0
+1665,28,March,4,April,St John Zachary,0,0
+1665,28,March,4,April,St Michael Bassishaw,4,0
+1665,28,March,4,April,Alhallows the Wall,2,0
+1665,28,March,4,April,St Katharine Coleman,0,0
+1665,28,March,4,April,St Michael Cornhil,0,0
+1665,28,March,4,April,St Alphage,0,0
+1665,28,March,4,April,St Katharine •rechurch,2,0
+1665,28,March,4,April,St Michael Crookedla,0,0
+1665,28,March,4,April,St Andrew Hubbard,0,0
+1665,28,March,4,April,St Lawrence Jewry,1,0
+1665,28,March,4,April,St Michael Queenhithe,1,0
+1665,28,March,4,April,St Andrew Undershaft,1,0
+1665,28,March,4,April,St Lawrence Pountney,1,0
+1665,28,March,4,April,St Michael Quern,0,0
+1665,28,March,4,April,St Andrew Wardrobe,1,0
+1665,28,March,4,April,St Leonard Eastcheap,0,0
+1665,28,March,4,April,St Michael Royall,0,0
+1665,28,March,4,April,St Ana Aldersgate,0,0
+1665,28,March,4,April,St Leonard Posterlane,3,0
+1665,28,March,4,April,St Michael Woodstreet,0,0
+1665,28,March,4,April,St Ann Blackfryers,4,0
+1665,28,March,4,April,St Magnus Parish,0,0
+1665,28,March,4,April,St Mildred Breadstree•,0,0
+1665,28,March,4,April,St Antholins Parish,0,0
+1665,28,March,4,April,St Margaret Lothbury,0,0
+1665,28,March,4,April,St Mildred Poultrey,0,0
+1665,28,March,4,April,St Austins Parish,0,0
+1665,28,March,4,April,St Margaret Moses,0,0
+1665,28,March,4,April,St Nicholas Acons,0,0
+1665,28,March,4,April,St Bartholomew Excha,0,0
+1665,28,March,4,April,St Margaret Newfishst,0,0
+1665,28,March,4,April,St Nicholas Coleabby,3,0
+1665,28,March,4,April,St Bennet Fynck,1,0
+1665,28,March,4,April,St Margaret Pattons,1,0
+1665,28,March,4,April,St Nicholas Olaves,0,0
+1665,28,March,4,April,St Bennet Gracechurch,1,0
+1665,28,March,4,April,St Mary Abchurch,1,0
+1665,28,March,4,April,St Olaves Hart•tr•et,0,0
+1665,28,March,4,April,St Bennet Paulswharfe,0,0
+1665,28,March,4,April,St Mary Aldermanbury,1,0
+1665,28,March,4,April,St Olaves Jewry,2,0
+1665,28,March,4,April,St Bennet Sherehog,0,0
+1665,28,March,4,April,St Mary Aldermary,0,0
+1665,28,March,4,April,St Olaves Silverstreet,3,0
+1665,28,March,4,April,St Botolph Billingsgate,2,0
+1665,28,March,4,April,St Mary le Bow,1,0
+1665,28,March,4,April,St Pancras Soperlane,1,0
+1665,28,March,4,April,Christ Church,2,0
+1665,28,March,4,April,St Mary Bothaw,0,0
+1665,28,March,4,April,St Peters Cheap,0,0
+1665,28,March,4,April,St Christophers,1,0
+1665,28,March,4,April,St Mary Colechurch,0,0
+1665,28,March,4,April,St Peters Cornhil,2,0
+1665,28,March,4,April,St Clement Eastcheap,0,0
+1665,28,March,4,April,St Mary Hill,0,0
+1665,28,March,4,April,St Peters Paulswharf,0,0
+1665,28,March,4,April,St Dionis Backchurch,1,0
+1665,28,March,4,April,St Mary Mounthaw,0,0
+1665,28,March,4,April,St Peters Poor,0,0
+1665,28,March,4,April,St Dunstans East,1,0
+1665,28,March,4,April,St Mary Sommerset,0,0
+1665,28,March,4,April,St Stevens Colemanstr.,3,0
+1665,28,March,4,April,St Edm. Lumbardstreet,1,0
+1665,28,March,4,April,St Mary Stayning•,1,0
+1665,28,March,4,April,St Stevens Walbrook,0,0
+1665,28,March,4,April,St Ethelborough,3,0
+1665,28,March,4,April,St Mary Woolchurch,0,0
+1665,28,March,4,April,St Swithins,0,0
+1665,28,March,4,April,St Faiths,3,0
+1665,28,March,4,April,St Mary Wool•oth,1,0
+1665,28,March,4,April,St Thomas Apostles,0,0
+1665,28,March,4,April,St Fosters,0,0
+1665,28,March,4,April,St Martins Iremonger•,0,0
+1665,28,March,4,April,Trinity Paris•,0,0
+1665,28,March,4,April,St Gabriel Fenchurch,1,0
+1665,28,March,4,April,S• Andrews Holborne,19,0
+1665,28,March,4,April,St Botolph Aldgate,1,0
+1665,28,March,4,April,St Saviours S•uthwark,14,0
+1665,28,March,4,April,St Bartholomew Grea•,2,0
+1665,28,March,4,April,St Botolph Bishopsgat•,8,0
+1665,28,March,4,April,St Sepulchres Parish,18,0
+1665,28,March,4,April,St Bartholomew Lesse,0,0
+1665,28,March,4,April,St Dunstans West,4,0
+1665,28,March,4,April,St Thomas Southwark,2,0
+1665,28,March,4,April,St Brides Parish,11,0
+1665,28,March,4,April,St George Southwark,5,0
+1665,28,March,4,April,Trinity Minories,0,0
+1665,28,March,4,April,Bridewel Precinct,2,0
+1665,28,March,4,April,St Giles Cripplegate,29,0
+1665,28,March,4,April,At the Pesthouse,0,0
+1665,28,March,4,April,St Botolph Aldersgate,2,0
+1665,28,March,4,April,St Olaves Southwark,11,0
+1665,28,March,4,April,St Giles in the fields,18,0
+1665,28,March,4,April,Lambeth Parish,3,0
+1665,28,March,4,April,St Mary Islington,3,0
+1665,28,March,4,April,Hackney Parish,1,0
+1665,28,March,4,April,St Leonard Shoreditc•,6,0
+1665,28,March,4,April,St Mary Whitechappel,12,0
+1665,28,March,4,April,St James Clerk•nwel,11,0
+1665,28,March,4,April,St Magdalen Bermond,3,0
+1665,28,March,4,April,Redriff Parish,0,0
+1665,28,March,4,April,S• Kath. neer the Tower,4,0
+1665,28,March,4,April,St Mary Newington,4,0
+1665,28,March,4,April,Stepney Parish,21,0
+1665,28,March,4,April,S• Clement Danes,8,0
+1665,28,March,4,April,St Martins in the fields,23,0
+1665,28,March,4,April,St Margaret Westminst.,12,0
+1665,28,March,4,April,S• Paul Covent Garden,3,0
+1665,28,March,4,April,St Mary Savoy,0,0
+1665,4,April,11,,St ALbans Woodstreet,1,0
+1665,4,April,11,,St George Botolphlane,0,0
+1665,4,April,11,,St Martins Ludgate,1,0
+1665,4,April,11,,Alhallows Barking,5,0
+1665,4,April,11,,St Gregories by St Pauls,3,0
+1665,4,April,11,,St Martins Orgars,2,0
+1665,4,April,11,,Alhallows Breadstreet,0,0
+1665,4,April,11,,St Hellens,0,0
+1665,4,April,11,,St Martins Outwitch,1,0
+1665,4,April,11,,Alhallows Great,0,0
+1665,4,April,11,,St James Dukes place,2,0
+1665,4,April,11,,St Martins Vintrey,0,0
+1665,4,April,11,,Alhallows Honylane,0,0
+1665,4,April,11,,St James Garlickhithe,0,0
+1665,4,April,11,,St Mathew Fridaystree•,0,0
+1665,4,April,11,,Alhallows Lesse,1,0
+1665,4,April,11,,St John Baptist,0,0
+1665,4,April,11,,St Maudlins Milkstree,0,0
+1665,4,April,11,,Alhallows Lumbardstr.,0,0
+1665,4,April,11,,St John Evangelist,0,0
+1665,4,April,11,,St Maudlins Oldfi•hstr,0,0
+1665,4,April,11,,Alhallows Stayning,2,0
+1665,4,April,11,,St John Zachary,2,0
+1665,4,April,11,,St Michael Bassishaw,1,0
+1665,4,April,11,,Alhallows the Wall,3,0
+1665,4,April,11,,St Katharine Coleman,1,0
+1665,4,April,11,,St Michael Cornhil,3,0
+1665,4,April,11,,St Alphage,0,0
+1665,4,April,11,,St Katharine crechurch,3,0
+1665,4,April,11,,St Michael Crookedl•,1,0
+1665,4,April,11,,S• Andrew Hubbard,1,0
+1665,4,April,11,,St Lawrence Jewry,2,0
+1665,4,April,11,,St Michael Queenhith•,4,0
+1665,4,April,11,,St Andrew Undershaft,0,0
+1665,4,April,11,,St Lawrence Pountney,0,0
+1665,4,April,11,,St Michael Quern,0,0
+1665,4,April,11,,St Andrew Wardrobe,1,0
+1665,4,April,11,,St Leonard Eastcheap,0,0
+1665,4,April,11,,St Michael Royall,1,0
+1665,4,April,11,,St Ann Aldersgate,2,0
+1665,4,April,11,,St Leonard Fosterlane,0,0
+1665,4,April,11,,St Michael Woodstre•,1,0
+1665,4,April,11,,St Ann Blackfryers,4,0
+1665,4,April,11,,St Magnus Parish,1,0
+1665,4,April,11,,St Mildred Breadstr•et,0,0
+1665,4,April,11,,St Antholins Parish,0,0
+1665,4,April,11,,St Margaret Lothbury,1,0
+1665,4,April,11,,St Mildred Poultrey,0,0
+1665,4,April,11,,St Austins Parish,0,0
+1665,4,April,11,,St Margaret Moses,1,0
+1665,4,April,11,,St Nicholas Acons,1,0
+1665,4,April,11,,St Bartholomew Excha,0,0
+1665,4,April,11,,St Margaret Ne•fishs•,1,0
+1665,4,April,11,,St Nicholas Coleabby,1,0
+1665,4,April,11,,St Bennet Fynck,1,0
+1665,4,April,11,,St Margaret Patton•,0,0
+1665,4,April,11,,St Nicholas Olaves,0,0
+1665,4,April,11,,St Bennet Gracechurch,0,0
+1665,4,April,11,,St Mary Abchurch,0,0
+1665,4,April,11,,St Olaves Hartstreet,1,0
+1665,4,April,11,,St Bennet Paulswharfe,0,0
+1665,4,April,11,,St Mary Aldermanbury,2,0
+1665,4,April,11,,St Olaves Jewry,1,0
+1665,4,April,11,,St Bennet Sherehog,0,0
+1665,4,April,11,,St Mary Aldermary,1,0
+1665,4,April,11,,St Olaves Silverstreet,1,0
+1665,4,April,11,,St Botolph Billingsgate,0,0
+1665,4,April,11,,St Mary le Bow,1,0
+1665,4,April,11,,St Pancras Soperlane,1,0
+1665,4,April,11,,Christ Church,7,0
+1665,4,April,11,,St Mary Bothaw,0,0
+1665,4,April,11,,St Peters Cheap,0,0
+1665,4,April,11,,St Christophers,0,0
+1665,4,April,11,,St Mary Colechurch,0,0
+1665,4,April,11,,St Peters Cornhil,0,0
+1665,4,April,11,,St Clement Eastcheap,0,0
+1665,4,April,11,,St Mary Hill,0,0
+1665,4,April,11,,St Peters Paulswharf,0,0
+1665,4,April,11,,St Dionis Backchurch,0,0
+1665,4,April,11,,St Mary Mounthaw,1,0
+1665,4,April,11,,St Peters Poor,1,0
+1665,4,April,11,,St Dunstans East,0,0
+1665,4,April,11,,St Mary Sommerset,0,0
+1665,4,April,11,,St Stevens Colemanstr,4,0
+1665,4,April,11,,St Edm. Lumbardstreet,0,0
+1665,4,April,11,,St Mary Stayning•,0,0
+1665,4,April,11,,St Stevens Walbrook,0,0
+1665,4,April,11,,St Ethelborough,1,0
+1665,4,April,11,,St Mary Woolchurch,0,0
+1665,4,April,11,,St Swithins,2,0
+1665,4,April,11,,St Faiths,0,0
+1665,4,April,11,,St Mary Woolnoth,0,0
+1665,4,April,11,,St Thomas Apostles,0,0
+1665,4,April,11,,St Fosters,1,0
+1665,4,April,11,,St Martins Iremonger•,0,0
+1665,4,April,11,,Trinity Parish,1,0
+1665,4,April,11,,St Gabriel Fenchurch,0,0
+1665,4,April,11,,St Andrews Holborne,16,0
+1665,4,April,11,,S• Botolph Aldgate,20,0
+1665,4,April,11,,St Saviours Southwark,13,0
+1665,4,April,11,,St Bartholomew Grea•,0,0
+1665,4,April,11,,St Botolph Bishopsgate,10,0
+1665,4,April,11,,St Sepulchres Parish,16,0
+1665,4,April,11,,St Bartholomew Lesse,0,0
+1665,4,April,11,,St Dunstans West,6,0
+1665,4,April,11,,St Thomas Southwark,1,0
+1665,4,April,11,,St Brides Parish,12,0
+1665,4,April,11,,St George Southwark,6,0
+1665,4,April,11,,Trinity Minories,0,0
+1665,4,April,11,,Bridewel Precinct,0,0
+1665,4,April,11,,St Giles Cripplegate,30,0
+1665,4,April,11,,At the Pesthouse,0,0
+1665,4,April,11,,St Botolph Aldersgate,1,0
+1665,4,April,11,,St Olaves Southwark,18,0
+1665,4,April,11,,St Giles in the fields,25,0
+1665,4,April,11,,Lambeth Paris•,4,0
+1665,4,April,11,,St Mary Islington,2,0
+1665,4,April,11,,Hackney Parish,3,0
+1665,4,April,11,,St Leonard Shoreditch,8,0
+1665,4,April,11,,St Mary Whitechappel,15,0
+1665,4,April,11,,St James Clerkenwel,12,0
+1665,4,April,11,,St Magdalen Bermond,7,0
+1665,4,April,11,,Bedriff Parish,0,0
+1665,4,April,11,,St Kath. neer the Tower,2,0
+1665,4,April,11,,St Mary Newington,4,0
+1665,4,April,11,,Stepney Parish,25,0
+1665,4,April,11,,St Clement Danes,6,0
+1665,4,April,11,,St Martins in the field•,16,0
+1665,4,April,11,,St Margaret Westminst.,20,0
+1665,4,April,11,,St Paul Covent Garden,3,0
+1665,4,April,11,,St Mary Savoy,0,0
+1665,11,April,18,,St ALbans Woodstreet,2,0
+1665,11,April,18,,St George Botolphlane,0,0
+1665,11,April,18,,St Martins Ludgate,0,0
+1665,11,April,18,,Alhallows Barking,1,0
+1665,11,April,18,,St Gregories by St Pauls,3,0
+1665,11,April,18,,St Martins Orgars,1,0
+1665,11,April,18,,A•hallows Breadstreet,0,0
+1665,11,April,18,,St Hellens,1,0
+1665,11,April,18,,St Martins Outwitch,0,0
+1665,11,April,18,,Alhallows Great,2,0
+1665,11,April,18,,St James Dukes place,1,0
+1665,11,April,18,,St Martins Vintrey,0,0
+1665,11,April,18,,Alhallows Honylane,0,0
+1665,11,April,18,,St James Garlickithe,2,0
+1665,11,April,18,,St Mathew Fridaystreet,0,0
+1665,11,April,18,,Alhallows Lesse,0,0
+1665,11,April,18,,St John Baptist,2,0
+1665,11,April,18,,St Maudlins Milk••reet,1,0
+1665,11,April,18,,Alhallows Lumbardstr,1,0
+1665,11,April,18,,St John Evangelist,0,0
+1665,11,April,18,,St Maudlins Old••••r.,2,0
+1665,11,April,18,,Alhallows Stayning,0,0
+1665,11,April,18,,St John Zachary,0,0
+1665,11,April,18,,St Michael Ba••••aw,3,0
+1665,11,April,18,,Alhallows the Wall,3,0
+1665,11,April,18,,St Katharins Coleman,1,0
+1665,11,April,18,,St Michael Cornhil,0,0
+1665,11,April,18,,St Alphage,0,0
+1665,11,April,18,,St Katharine crechurch,1,0
+1665,11,April,18,,St Michael Crookedla,1,0
+1665,11,April,18,,St Andrew Hubbard,2,0
+1665,11,April,18,,St Lawrence Jewry,0,0
+1665,11,April,18,,St Michael Queenhithe,2,0
+1665,11,April,18,,St Andrew Undershaft,2,0
+1665,11,April,18,,St Lawrence Pountney,0,0
+1665,11,April,18,,St Michael Quern,0,0
+1665,11,April,18,,St Andrew Ward-robe,3,0
+1665,11,April,18,,St Leonard Eastcheap,0,0
+1665,11,April,18,,St Michael Royall,0,0
+1665,11,April,18,,St Ann Alderigate,1,0
+1665,11,April,18,,St Leonard Fosterlane,0,0
+1665,11,April,18,,St Michael Woodstreet,1,0
+1665,11,April,18,,St Ann Blackfryers,3,0
+1665,11,April,18,,St Magnus Parish,0,0
+1665,11,April,18,,St Mildred Breadstreet,0,0
+1665,11,April,18,,St Antholins Parish,0,0
+1665,11,April,18,,St Margaret Lothbury,0,0
+1665,11,April,18,,St Mildred Poultrey,0,0
+1665,11,April,18,,St Austins Parish,0,0
+1665,11,April,18,,St Margaret Moses,0,0
+1665,11,April,18,,St Nicholas Acons,1,0
+1665,11,April,18,,St Bartholomew Excha,0,0
+1665,11,April,18,,St Margaret Ne•fis••,0,0
+1665,11,April,18,,St Nicholas Coleabby,0,0
+1665,11,April,18,,St Bennet Fynck,0,0
+1665,11,April,18,,St Margaret Pattons,0,0
+1665,11,April,18,,St Nicholas Olaves,0,0
+1665,11,April,18,,St Bennet Graeechurel,0,0
+1665,11,April,18,,St Mary Abchurch,0,0
+1665,11,April,18,,St Olaves Martstreet,0,0
+1665,11,April,18,,St Bennet Paulswharfe,1,0
+1665,11,April,18,,St Mary Aldermanbury,2,0
+1665,11,April,18,,St Olaves Jewry,0,0
+1665,11,April,18,,St Bennet Sherehog,0,0
+1665,11,April,18,,St Mary Aldermary,0,0
+1665,11,April,18,,St Olaves Silverstreet,1,0
+1665,11,April,18,,St Botolph Billingsgate,1,0
+1665,11,April,18,,St Mary le Bow,0,0
+1665,11,April,18,,St Pancras Soperlane,0,0
+1665,11,April,18,,Christ Church,7,0
+1665,11,April,18,,St Mary Bothaw,0,0
+1665,11,April,18,,St Peters Cheap,0,0
+1665,11,April,18,,St Christophers,0,0
+1665,11,April,18,,St Mary Colechurch,0,0
+1665,11,April,18,,St Peters Cornhil,1,0
+1665,11,April,18,,St Clement Eastcheap,1,0
+1665,11,April,18,,St Mary Hill,0,0
+1665,11,April,18,,St Peters Paulswharf,0,0
+1665,11,April,18,,St Dinnis Backebutch,0,0
+1665,11,April,18,,St Mary Mounthaw,0,0
+1665,11,April,18,,St Peters Poor,0,0
+1665,11,April,18,,St Dunstans East,1,0
+1665,11,April,18,,St Mary Sommerset,1,0
+1665,11,April,18,,St Stevens Colemanstr.,1,0
+1665,11,April,18,,St Edm. Lumbardstreet,2,0
+1665,11,April,18,,St Mary Staynings,0,0
+1665,11,April,18,,St Stevens Walbrook,1,0
+1665,11,April,18,,St Ethelborough,1,0
+1665,11,April,18,,St Mary Woolchurch,0,0
+1665,11,April,18,,St Swithins,0,0
+1665,11,April,18,,St Faiths,0,0
+1665,11,April,18,,St Mary Woolnoth,0,0
+1665,11,April,18,,St Thomas Apostles,0,0
+1665,11,April,18,,St Fosters,0,0
+1665,11,April,18,,St Martins Iremongerl,1,0
+1665,11,April,18,,Trinity Parish,1,0
+1665,11,April,18,,St Gabriel Fenchurch,0,0
+1665,11,April,18,,St Andrews Holborne,19,0
+1665,11,April,18,,St Botolph Aldgate,17,0
+1665,11,April,18,,St Saviours Southwark,22,0
+1665,11,April,18,,St Bartholomew Great,0,0
+1665,11,April,18,,St Botolph Bishopsgate,14,0
+1665,11,April,18,,St Sepulchres Parish,12,0
+1665,11,April,18,,St Bartholomew Losse,0,0
+1665,11,April,18,,St Dunstans West,1,0
+1665,11,April,18,,St Thomas Southwark,2,0
+1665,11,April,18,,St Brides Pari••,7,0
+1665,11,April,18,,St George Southwark,1,0
+1665,11,April,18,,Trinity Minories,0,0
+1665,11,April,18,,Bridewel Precin••,0,0
+1665,11,April,18,,St Giles Cripplegate,18,0
+1665,11,April,18,,At the Pesthouse,0,0
+1665,11,April,18,,St Botolph Aldersgate,3,0
+1665,11,April,18,,St Olaves Southwark,10,0
+1665,11,April,18,,St Giles in the field,25,0
+1665,11,April,18,,Lambeth Parish,2,0
+1665,11,April,18,,St Mary Ishagton,2,0
+1665,11,April,18,,Hackney Parish,4,0
+1665,11,April,18,,St Leonard Shoreditch,8,0
+1665,11,April,18,,St Mary Whitechapp•l,9,0
+1665,11,April,18,,St Iames Clerkenwel,10,0
+1665,11,April,18,,St Magdalen Barmond.,5,0
+1665,11,April,18,,Redriff Parish,2,0
+1665,11,April,18,,St Kath. neer the Tower,3,0
+1665,11,April,18,,St Mary Newington,4,0
+1665,11,April,18,,Stepney Parish,19,0
+1665,11,April,18,,St Clement Danes,12,0
+1665,11,April,18,,St Martins in the fields,21,0
+1665,11,April,18,,St Margaret Westminst.,21,0
+1665,11,April,18,,S Paul Covent Garden,3,0
+1665,11,April,18,,St Mary Savoy,2,0
+1665,18,April,25,,St ALbans Woodstreet,1,0
+1665,18,April,25,,St George Botolphlane,0,0
+1665,18,April,25,,St Martins Ludgate,0,0
+1665,18,April,25,,Alhallows Barking,3,0
+1665,18,April,25,,St Gregories by St Pauls,1,0
+1665,18,April,25,,St Martins O•••rs,0,0
+1665,18,April,25,,Alhallows Breadstreet,0,0
+1665,18,April,25,,St Hellens,0,0
+1665,18,April,25,,St Martins Outwitch,0,0
+1665,18,April,25,,Alhallows Great,2,0
+1665,18,April,25,,St James Dukes place,0,0
+1665,18,April,25,,St Martins Vintrey,0,0
+1665,18,April,25,,Alhallows Honylane,0,0
+1665,18,April,25,,St James Garlickhithe,1,0
+1665,18,April,25,,St Mathew Fridaystreet,1,0
+1665,18,April,25,,Alhallows Lesse,2,0
+1665,18,April,25,,St John Baptist,2,0
+1665,18,April,25,,St Maudlins Milk•treet,0,0
+1665,18,April,25,,Alhallows Lumbardstr.,0,0
+1665,18,April,25,,St John Evangelist,0,0
+1665,18,April,25,,St Maudlins Old••••r,3,0
+1665,18,April,25,,Alhallows Stayning,0,0
+1665,18,April,25,,St John Zachary,1,0
+1665,18,April,25,,St Michael Ba••s•aw,1,0
+1665,18,April,25,,Alhallows the Wall,2,0
+1665,18,April,25,,St Katharine Coleman,1,0
+1665,18,April,25,,St Michael Cornhil,0,0
+1665,18,April,25,,St Alphage,3,0
+1665,18,April,25,,St Katharine crechurch,0,0
+1665,18,April,25,,St Michael Crooke••a.,0,0
+1665,18,April,25,,St Andrew Hubbard,0,0
+1665,18,April,25,,St Lawrence Jewry,0,0
+1665,18,April,25,,St Michael Queenhithe,1,0
+1665,18,April,25,,St Andrew Undershaft,1,0
+1665,18,April,25,,St Lawrence Pountney,1,0
+1665,18,April,25,,St Michael Quern,0,0
+1665,18,April,25,,St Andrew Wardrobe,3,0
+1665,18,April,25,,St Leonard Eastcheap,1,0
+1665,18,April,25,,St Michael Royall,0,0
+1665,18,April,25,,St Ann Aldersgate,0,0
+1665,18,April,25,,St Leonard Fosterlane,3,0
+1665,18,April,25,,St Michael Woodstreet,0,0
+1665,18,April,25,,St Ann Blackfryers,0,0
+1665,18,April,25,,St Magnus Parish,1,0
+1665,18,April,25,,St Mildred Breadstreet,1,0
+1665,18,April,25,,St Antholins Parish,1,0
+1665,18,April,25,,St Margaret Lothbury,1,0
+1665,18,April,25,,St Mildred Poultrey,0,0
+1665,18,April,25,,St Austins Parish,0,0
+1665,18,April,25,,St Margaret Moses,0,0
+1665,18,April,25,,St Nicholas Acons,1,0
+1665,18,April,25,,St Bartholomew Exch•,2,0
+1665,18,April,25,,St Margaret Ne•sith••,0,0
+1665,18,April,25,,St Nicholas Coleabby,0,0
+1665,18,April,25,,St Bennet Fynck,0,0
+1665,18,April,25,,St Margaret Pattons,0,0
+1665,18,April,25,,St Nicholas Olaves,0,0
+1665,18,April,25,,St Bennet Gracechurch,0,0
+1665,18,April,25,,St Mary Abchurch,1,0
+1665,18,April,25,,St Olaves Martstreet,0,0
+1665,18,April,25,,St Bennet Paulswharfe,1,0
+1665,18,April,25,,St Mary Aldermanbury,0,0
+1665,18,April,25,,St Olaves Jewry,0,0
+1665,18,April,25,,St Bennet Sherchog,0,0
+1665,18,April,25,,St Mary Aldermary,0,0
+1665,18,April,25,,St Olaves Silverstreet,0,0
+1665,18,April,25,,St Botolph Billingsgat•,1,0
+1665,18,April,25,,St Mary le Bow,0,0
+1665,18,April,25,,St Pancras Soperlane,1,0
+1665,18,April,25,,Christ Church,1,0
+1665,18,April,25,,St Mary Bothaw,2,0
+1665,18,April,25,,St Peters Cheap,0,0
+1665,18,April,25,,St Christophers,1,0
+1665,18,April,25,,St Mary Colechurch,0,0
+1665,18,April,25,,St Peters Cornhil,1,0
+1665,18,April,25,,St Clement Eastcheap,1,0
+1665,18,April,25,,St Mary Hill,1,0
+1665,18,April,25,,St Peters Paulswarf,0,0
+1665,18,April,25,,St Dinnis Backchurch,1,0
+1665,18,April,25,,St Mary Mounthaw,0,0
+1665,18,April,25,,St Peters Poor,0,0
+1665,18,April,25,,St Dunstans East,1,0
+1665,18,April,25,,St Mary Sommerset,2,0
+1665,18,April,25,,St Stevens Colemanstr.,8,0
+1665,18,April,25,,St Edm. Lumbardstreet,0,0
+1665,18,April,25,,St Mary Staynings,0,0
+1665,18,April,25,,St Stevens Walbrook,0,0
+1665,18,April,25,,St Ethelborough,0,0
+1665,18,April,25,,St Mary Woolchurch,0,0
+1665,18,April,25,,St Swithins,0,0
+1665,18,April,25,,St Faiths,0,0
+1665,18,April,25,,St Mary Woolnoth,0,0
+1665,18,April,25,,St Thomas Apostles,0,0
+1665,18,April,25,,St Fosters,1,0
+1665,18,April,25,,St Martins Iremongerl,0,0
+1665,18,April,25,,Trinity Parish,0,0
+1665,18,April,25,,St Gabriel Fenchurch,0,0
+1665,18,April,25,,St Andrews Holborne,16,0
+1665,18,April,25,,St Botolph Aldgate,14,0
+1665,18,April,25,,St Saviours Southwark,14,0
+1665,18,April,25,,St Bartholomew Great,0,0
+1665,18,April,25,,St Botolph Bishopsgate,12,0
+1665,18,April,25,,St Sepulchres Parish,17,0
+1665,18,April,25,,St Bartholomew Losse,0,0
+1665,18,April,25,,St Dunstans West,5,0
+1665,18,April,25,,St Thomas Southwark,3,0
+1665,18,April,25,,St Brides Parish,9,0
+1665,18,April,25,,St George Southwark,5,0
+1665,18,April,25,,Trinity Minories,0,0
+1665,18,April,25,,Bridewel Precinct,1,0
+1665,18,April,25,,St Giles Cripplegate,28,0
+1665,18,April,25,,At the Pesthouse,0,0
+1665,18,April,25,,St Botolph Aldersgate,3,0
+1665,18,April,25,,St Olaves Southwark,18,0
+1665,18,April,25,,St Giles in the fields,30,2
+1665,18,April,25,,Lambeth Parish,7,0
+1665,18,April,25,,St Mary Islington,2,0
+1665,18,April,25,,Hackney Parish,3,0
+1665,18,April,25,,St Leonard Shoreditch,10,0
+1665,18,April,25,,St Mary Whitechappel,9,0
+1665,18,April,25,,St Iames Clerkenwel,6,0
+1665,18,April,25,,St Magdalen Bermond,5,0
+1665,18,April,25,,Redriff Parish,0,0
+1665,18,April,25,,St Kath. neer the Tower,6,0
+1665,18,April,25,,St Mary Newington,4,0
+1665,18,April,25,,Stepney Parish,37,0
+1665,18,April,25,,St Clement D•n•,12,0
+1665,18,April,25,,St Martins in the fields,29,0
+1665,18,April,25,,St Margaret Westminst,23,0
+1665,18,April,25,,S Paul Covent Garden,3,0
+1665,18,April,25,,St Mary Savoy,2,0
+1665,25,April,2,May,St ALbans Woodstreet,0,0
+1665,25,April,2,May,St George Botolphlane,0,0
+1665,25,April,2,May,St Martins Ludgate,0,0
+1665,25,April,2,May,Alhallows Barkin•,3,0
+1665,25,April,2,May,St Gregories by St Pauls,3,0
+1665,25,April,2,May,St Martins Orgars,0,0
+1665,25,April,2,May,Alhallows Breadstreet,0,0
+1665,25,April,2,May,St Hellins,2,0
+1665,25,April,2,May,St Martins Outwitch,1,0
+1665,25,April,2,May,Alhallows Great,1,0
+1665,25,April,2,May,St James Dukes place,1,0
+1665,25,April,2,May,St Martins Vintrey,3,0
+1665,25,April,2,May,Alhallows Honylane,0,0
+1665,25,April,2,May,St James Garlickhithe,1,0
+1665,25,April,2,May,St Mathew Fridaystreet,0,0
+1665,25,April,2,May,Alhallows Lesse,1,0
+1665,25,April,2,May,St John Baptist,0,0
+1665,25,April,2,May,St Maudlins Milkstreet,0,0
+1665,25,April,2,May,Alhallows Lumbardstr,0,0
+1665,25,April,2,May,St John Evangelist,0,0
+1665,25,April,2,May,St Maudlins Oldfishst.,0,0
+1665,25,April,2,May,Alhallows Stayning,2,0
+1665,25,April,2,May,St John Zachary,0,0
+1665,25,April,2,May,St Michael Bassishaw,1,0
+1665,25,April,2,May,Alhallows the Wall,3,0
+1665,25,April,2,May,St Katharine Coleman,2,0
+1665,25,April,2,May,St Michael Cornhil,0,0
+1665,25,April,2,May,St Alphage,0,0
+1665,25,April,2,May,St Katharine crechurch,1,0
+1665,25,April,2,May,St Michael Crookedla.,0,0
+1665,25,April,2,May,St Andrew Hubbard,1,0
+1665,25,April,2,May,St Lawrence Jewry,1,0
+1665,25,April,2,May,St Michael Queenhithe,0,0
+1665,25,April,2,May,St Andrew Undershaft,0,0
+1665,25,April,2,May,St Lawrence Pountney,1,0
+1665,25,April,2,May,St Michael Quern,0,0
+1665,25,April,2,May,St Andrew Wardrobe,5,0
+1665,25,April,2,May,St Leonard Eastcheap,0,0
+1665,25,April,2,May,St Michael Royall,0,0
+1665,25,April,2,May,St Ann Aldersgate,2,0
+1665,25,April,2,May,St Leonard Fosterlane,1,0
+1665,25,April,2,May,St Michael Woodstreet,0,0
+1665,25,April,2,May,St Ann Blackfryers,1,0
+1665,25,April,2,May,St Magnus Parish,2,0
+1665,25,April,2,May,St Mildred Breadstreet,1,0
+1665,25,April,2,May,St Antholins Parish,0,0
+1665,25,April,2,May,St Margaret Lothbury,0,0
+1665,25,April,2,May,St Mildred Poultrey,2,0
+1665,25,April,2,May,St Austins Parish,0,0
+1665,25,April,2,May,St Margaret Moses,0,0
+1665,25,April,2,May,St Nicholas Acons,0,0
+1665,25,April,2,May,St Bartholomew Exch.,0,0
+1665,25,April,2,May,St Margaret Newfishst,1,0
+1665,25,April,2,May,St Nicholas Coleabby,1,0
+1665,25,April,2,May,St Bennet Fynck,1,0
+1665,25,April,2,May,St Margaret Pattons,0,0
+1665,25,April,2,May,St Nicholas Olaves,0,0
+1665,25,April,2,May,St Bennet Gracechurch,0,0
+1665,25,April,2,May,St Mary Abchurch,0,0
+1665,25,April,2,May,St Olaves Hartstreet,0,0
+1665,25,April,2,May,St Bennet Paulswharf,0,0
+1665,25,April,2,May,St Mary Aldermanbury,0,0
+1665,25,April,2,May,St Olaves Jewry,3,0
+1665,25,April,2,May,St Bennet Sherehog,1,0
+1665,25,April,2,May,St Mary Aldermary,0,0
+1665,25,April,2,May,St Olaves Silverstreet,0,0
+1665,25,April,2,May,St Botolph Billingsgate,0,0
+1665,25,April,2,May,St Mary le Bow,0,0
+1665,25,April,2,May,St Pancras Soperlane,0,0
+1665,25,April,2,May,Christs Church,1,0
+1665,25,April,2,May,St Mary Bothaw,0,0
+1665,25,April,2,May,St Peters Cheap,0,0
+1665,25,April,2,May,St Christophers,1,0
+1665,25,April,2,May,St Mary Colechurch,0,0
+1665,25,April,2,May,St Peters Cornhil,1,0
+1665,25,April,2,May,St Clement Eastcheap,0,0
+1665,25,April,2,May,St Mary Hill,0,0
+1665,25,April,2,May,St Peters Paulswharf,1,0
+1665,25,April,2,May,St Dionis Backchurch,0,0
+1665,25,April,2,May,St Mary Mounthaw,1,0
+1665,25,April,2,May,St Peters Poor,0,0
+1665,25,April,2,May,St Dunstans East,1,0
+1665,25,April,2,May,St Mary Sommerset,2,0
+1665,25,April,2,May,St Stevens Colemanstr.,2,0
+1665,25,April,2,May,St Edm. Lumbardstreet,1,0
+1665,25,April,2,May,St Mary Staynings,1,0
+1665,25,April,2,May,St Stevens Walbrook,0,0
+1665,25,April,2,May,St Ethelbourgh,1,0
+1665,25,April,2,May,St Mary Woolchurch,2,0
+1665,25,April,2,May,St Swithins,1,0
+1665,25,April,2,May,St Faiths,0,0
+1665,25,April,2,May,St Mary Wolnoth,0,0
+1665,25,April,2,May,St Thomas Apostle,1,0
+1665,25,April,2,May,St Fosters,1,0
+1665,25,April,2,May,St Martins Iremongerl.,0,0
+1665,25,April,2,May,Trinity Parish,1,0
+1665,25,April,2,May,St Gabriel Fenchurch,2,0
+1665,25,April,2,May,St Andrews Holborn,14,0
+1665,25,April,2,May,St Botolph Aldgate,8,0
+1665,25,April,2,May,St Saviours Southwark,16,0
+1665,25,April,2,May,St Bartholomew Grea•,4,0
+1665,25,April,2,May,St Botolph Bishopsgate,11,0
+1665,25,April,2,May,St Sepulchres Parish,13,0
+1665,25,April,2,May,St Bartholomew Lesse,0,0
+1665,25,April,2,May,St Dunstans West,6,0
+1665,25,April,2,May,St Thomas Southwark,1,0
+1665,25,April,2,May,St Brides Parish,8,0
+1665,25,April,2,May,St George Southwark,5,0
+1665,25,April,2,May,Trinity Minories,0,0
+1665,25,April,2,May,Bridewel Precinct,1,0
+1665,25,April,2,May,St Giles Cripplegate,18,0
+1665,25,April,2,May,At the Pesthouse,0,0
+1665,25,April,2,May,St Botolph Aldersgate,4,0
+1665,25,April,2,May,St Olaves Southwark,16,0
+1665,25,April,2,May,St Giles in the fields,24,0
+1665,25,April,2,May,•im•e•h Parish,5,0
+1665,25,April,2,May,St Mary Islington,3,0
+1665,25,April,2,May,Hackney Parish,0,0
+1665,25,April,2,May,St Leonard Shoreditch,8,0
+1665,25,April,2,May,St Mary Whitechappel,11,0
+1665,25,April,2,May,St James Clerkenwel,13,0
+1665,25,April,2,May,St Magdalen Bermond.,15,0
+1665,25,April,2,May,Redriff Parish,3,0
+1665,25,April,2,May,St Kath. neer the Tower,5,0
+1665,25,April,2,May,St Mary Newington,4,0
+1665,25,April,2,May,Stepney Parish,36,0
+1665,25,April,2,May,St Clement Danes,13,0
+1665,25,April,2,May,St Martins in the fields,26,0
+1665,25,April,2,May,St Margaret Westminst.,20,0
+1665,25,April,2,May,St Paul Covent Garden,5,0
+1665,25,April,2,May,St Mary Savoy,2,0
+1665,2,May,9,,St ALbans Woodstreet,0,0
+1665,2,May,9,,St George Botolphlane,0,0
+1665,2,May,9,,St Martins Ludgate,0,0
+1665,2,May,9,,Alhallows Barking,3,0
+1665,2,May,9,,St Gregories by St Pauls,2,0
+1665,2,May,9,,St Martins Orgars,0,0
+1665,2,May,9,,Alhallows Breadstreet,0,0
+1665,2,May,9,,St Hellins,0,0
+1665,2,May,9,,St Martins Outwitch,0,0
+1665,2,May,9,,Alhallows Great,2,0
+1665,2,May,9,,St James Dukes place,2,0
+1665,2,May,9,,St Martins Vintrey,0,0
+1665,2,May,9,,Alhallows Honylane,0,0
+1665,2,May,9,,St James Garlickhithe,2,0
+1665,2,May,9,,St Mathew Fridaystreet,0,0
+1665,2,May,9,,Alhallows Lesse,1,0
+1665,2,May,9,,St John Baptist,0,0
+1665,2,May,9,,St Maudlins Milkstreet,0,0
+1665,2,May,9,,Alhallows Lumbardstr,0,0
+1665,2,May,9,,St John Evangelist,2,0
+1665,2,May,9,,St Maudlins Oldfishst,1,0
+1665,2,May,9,,Alhallows Stayning,0,0
+1665,2,May,9,,St John Zachary,0,0
+1665,2,May,9,,St Michael Bassishaw,2,0
+1665,2,May,9,,Alhallows the Wall,3,0
+1665,2,May,9,,St Katharine Coleman,0,0
+1665,2,May,9,,St Michael Cornhil,0,0
+1665,2,May,9,,St Alphage,0,0
+1665,2,May,9,,St Katharine crechurch,0,0
+1665,2,May,9,,St Michael Crookedla.,1,0
+1665,2,May,9,,St Andrew Hubbard,0,0
+1665,2,May,9,,St Lawrence Jewry,2,0
+1665,2,May,9,,St Michael Queenhithe,2,0
+1665,2,May,9,,St Andrew Undershaft,1,0
+1665,2,May,9,,St Lawrence Pountney,0,0
+1665,2,May,9,,St Michael Quern,0,0
+1665,2,May,9,,St Andrew Wardrobe,1,0
+1665,2,May,9,,St Leonard Eastcheap,0,0
+1665,2,May,9,,St Michael Royall,0,0
+1665,2,May,9,,St Ann Aldersgate,0,0
+1665,2,May,9,,St Leonard Fosterlane,0,0
+1665,2,May,9,,St Michael Woodstreet,1,0
+1665,2,May,9,,St Ann Blackfryers,1,0
+1665,2,May,9,,St Magnus Parish,0,0
+1665,2,May,9,,St Mildred Breadstreet,0,0
+1665,2,May,9,,St Antholins Parish,1,0
+1665,2,May,9,,St Margaret Lothbury,1,0
+1665,2,May,9,,St Mildred Poultrey,0,0
+1665,2,May,9,,St Austins Parish,0,0
+1665,2,May,9,,St Margaret Moses,0,0
+1665,2,May,9,,St Nicholas Acons,0,0
+1665,2,May,9,,St Bartholomew Exch.,1,0
+1665,2,May,9,,St Margaret Newfishst,1,0
+1665,2,May,9,,St Nicholas Coleabby,0,0
+1665,2,May,9,,St Bennet Fynck,0,0
+1665,2,May,9,,St Margaret Pattons,0,0
+1665,2,May,9,,St Nicholas Olaves,0,0
+1665,2,May,9,,St Bennet Gracechurch,0,0
+1665,2,May,9,,St Mary Abchurch,0,0
+1665,2,May,9,,St Olaves Hartstreet,1,0
+1665,2,May,9,,St Bennet Paulswharf,0,0
+1665,2,May,9,,St Mary Aldermanbury,1,0
+1665,2,May,9,,St Olaves Jewry,2,0
+1665,2,May,9,,St Bennet Sherehog,0,0
+1665,2,May,9,,St Mary Aldermary,1,0
+1665,2,May,9,,St Olaves Silverstreet,0,0
+1665,2,May,9,,St Botolph Billingsgate,0,0
+1665,2,May,9,,St Mary le Bow,0,0
+1665,2,May,9,,St Pancras Soperlane,0,0
+1665,2,May,9,,Christs Church,1,0
+1665,2,May,9,,St Mary Bothaw,0,0
+1665,2,May,9,,St Peters Cheap,0,0
+1665,2,May,9,,St Christophers,1,0
+1665,2,May,9,,St Mary Colechurch,0,0
+1665,2,May,9,,St Peters Cornhil,0,0
+1665,2,May,9,,St Clement Eastcheap,1,0
+1665,2,May,9,,St Mary Hill,0,0
+1665,2,May,9,,St Peters Paulswharf,0,0
+1665,2,May,9,,St Dionis Backchurch,2,0
+1665,2,May,9,,St Mary Mounthaw,0,0
+1665,2,May,9,,St Peters Poor,1,0
+1665,2,May,9,,St Dunstans East,0,0
+1665,2,May,9,,St Mary Sommerset,1,0
+1665,2,May,9,,St Stevens Colemanstr.,1,0
+1665,2,May,9,,St Edm. Lumbardstreet,2,0
+1665,2,May,9,,St Mary Staynings,0,0
+1665,2,May,9,,St Stevens Walbrook,0,0
+1665,2,May,9,,St Ethelbourgh,3,0
+1665,2,May,9,,St Mary Woolchurch,1,1
+1665,2,May,9,,St Swithins,0,0
+1665,2,May,9,,St Faiths,0,0
+1665,2,May,9,,St Mary Wolnoth,1,0
+1665,2,May,9,,St Tho•as Apostle,0,0
+1665,2,May,9,,St Fosters,0,0
+1665,2,May,9,,St Martins Iremongerl.,0,0
+1665,2,May,9,,Trinity Parish,0,0
+1665,2,May,9,,St Gabriel Fenchurch,1,0
+1665,2,May,9,,St Andrews Holborn,17,1
+1665,2,May,9,,St Botolph Aldgate,17,0
+1665,2,May,9,,St Saviours Southwark,14,0
+1665,2,May,9,,St Bartholomew Great,0,0
+1665,2,May,9,,St Botolph Bishopsgate,7,0
+1665,2,May,9,,St Sepulchres Parish,12,0
+1665,2,May,9,,St Barthol•mew Lesse,1,0
+1665,2,May,9,,St Dunstans West,5,0
+1665,2,May,9,,St Thomas Southwark,0,0
+1665,2,May,9,,St Brides Parish,5,0
+1665,2,May,9,,St George Southwark,3,0
+1665,2,May,9,,Trinity Minories,0,0
+1665,2,May,9,,Bridewel Precinct,0,0
+1665,2,May,9,,St Giles Cripplegate,24,0
+1665,2,May,9,,At the Pesthouse,0,0
+1665,2,May,9,,St Botolph Aldersgate,2,0
+1665,2,May,9,,St Olaves Southwark,16,0
+1665,2,May,9,,St Giles in the fields,30,3
+1665,2,May,9,,•am•eth Parish,6,0
+1665,2,May,9,,St Mary Iflington,2,0
+1665,2,May,9,,•ackney Parish,5,0
+1665,2,May,9,,St Leonard Shoreditch,9,0
+1665,2,May,9,,St Mary Whitechappel,2,0
+1665,2,May,9,,St James Clerkenwel,4,0
+1665,2,May,9,,St Magdalen Bermond.,8,0
+1665,2,May,9,,Redriff Parish,5,0
+1665,2,May,9,,St Kath. neer the Tower,5,0
+1665,2,May,9,,St Mary Newington,8,0
+1665,2,May,9,,Ste•ney Parish,30,0
+1665,2,May,9,,St Clement Danes,16,4
+1665,2,May,9,,St Martins in the field•,25,0
+1665,2,May,9,,St Margaret Westminst.,10,0
+1665,2,May,9,,St Paul Covent Garden,2,0
+1665,2,May,9,,St Mary Savoy,3,0
+1665,9,May,16,,St ALbans Woodstreet,1,0
+1665,9,May,16,,St George Botolphlane,0,0
+1665,9,May,16,,St Martins Ludgate,0,0
+1665,9,May,16,,Alhallows Barking,2,0
+1665,9,May,16,,St Gregories by St Pauls,3,0
+1665,9,May,16,,St Martins Orgars,0,0
+1665,9,May,16,,Alhallows Breadstreet,0,0
+1665,9,May,16,,St Hellens,3,0
+1665,9,May,16,,St Martins Outwitch,0,0
+1665,9,May,16,,Alhallows Great,1,0
+1665,9,May,16,,St James Dukes place,3,0
+1665,9,May,16,,St Martins Vintrey,0,0
+1665,9,May,16,,Alhallows Honylane,0,0
+1665,9,May,16,,St James Garlickhithe,0,0
+1665,9,May,16,,St Mathew Fridaystreet,2,0
+1665,9,May,16,,Alhallows Lesse,2,0
+1665,9,May,16,,St John Baptist,0,0
+1665,9,May,16,,St Maudlins Milkstreet,1,0
+1665,9,May,16,,Alhallows Lumbardstr.,0,0
+1665,9,May,16,,St John Evangelist,0,0
+1665,9,May,16,,St Maudlins Oldfishstr,0,0
+1665,9,May,16,,Alhallows Stayning,0,0
+1665,9,May,16,,St John Zachary,0,0
+1665,9,May,16,,St Michael Bassishaw,0,0
+1665,9,May,16,,Alhallows the Wall,2,0
+1665,9,May,16,,St Katharine Coleman,0,0
+1665,9,May,16,,St Michael Cornhil,0,0
+1665,9,May,16,,St Alphage,2,0
+1665,9,May,16,,St Katharine crechurch,3,0
+1665,9,May,16,,St Michael Crookedla,1,0
+1665,9,May,16,,St Andrew Hubberd,0,0
+1665,9,May,16,,St Lawrence Jewry,0,0
+1665,9,May,16,,St Michael Queenhithe,0,0
+1665,9,May,16,,St Andrew Undershaft,0,0
+1665,9,May,16,,St Lawrence Pountney,0,0
+1665,9,May,16,,St Michael Quern,0,0
+1665,9,May,16,,St Andrew Wardrobe,1,0
+1665,9,May,16,,St Leonard Eastcheap,0,0
+1665,9,May,16,,St Michael Royall,0,0
+1665,9,May,16,,St Ann Aldersgate,0,0
+1665,9,May,16,,St Leonard Fosterlane,0,0
+1665,9,May,16,,St Michael Woodstreet,1,0
+1665,9,May,16,,St Ann Blackfryers,2,0
+1665,9,May,16,,St Magnus Parish,0,0
+1665,9,May,16,,St Mildred Breadstreet,0,0
+1665,9,May,16,,St Antholins Parish,0,0
+1665,9,May,16,,St Margaret Lothbury.,0,0
+1665,9,May,16,,St Mildred Poultrey,0,0
+1665,9,May,16,,St Austins Parish,1,0
+1665,9,May,16,,St Margaret Moses,0,0
+1665,9,May,16,,St Nicholas Acons,0,0
+1665,9,May,16,,St Bartholomew Exch•,3,0
+1665,9,May,16,,St Margaret New fishst,0,0
+1665,9,May,16,,St Nicholas Coleabby,1,0
+1665,9,May,16,,St Bennet Fynck,0,0
+1665,9,May,16,,St Margaret Patrons,0,0
+1665,9,May,16,,St Nicholas Olaves,0,0
+1665,9,May,16,,St Bennet Gracechurc•,1,0
+1665,9,May,16,,St Mary Abchurch,0,0
+1665,9,May,16,,St Olaves Hartstreet,1,0
+1665,9,May,16,,St Bennet Paulswharfe,0,0
+1665,9,May,16,,St Mary Aldermanbury,0,0
+1665,9,May,16,,St Olaves Jewry,0,0
+1665,9,May,16,,St Bennet Sherehog,1,0
+1665,9,May,16,,St Mary Aldermary,1,0
+1665,9,May,16,,St Olaves Silverstreet,0,0
+1665,9,May,16,,St Botolph Billingsgate,2,0
+1665,9,May,16,,St Mary le Bow,0,0
+1665,9,May,16,,St Pancras Soperlane,0,0
+1665,9,May,16,,Christ Church,2,0
+1665,9,May,16,,St Mary Bothaw,1,0
+1665,9,May,16,,St Peters Cheap,0,0
+1665,9,May,16,,St Christophers,0,0
+1665,9,May,16,,St Mary Colechurch,0,0
+1665,9,May,16,,St Peters Cor•hil,0,0
+1665,9,May,16,,St Clement Eastcheap,1,0
+1665,9,May,16,,St Mary Hill,0,0
+1665,9,May,16,,St Peters Paulswharf,0,0
+1665,9,May,16,,St Dionis Backchurch,0,0
+1665,9,May,16,,St Mary Mounthaw,0,0
+1665,9,May,16,,St Peters Poor,0,0
+1665,9,May,16,,St Dunstans East,3,0
+1665,9,May,16,,St Mary Sommerset,2,0
+1665,9,May,16,,St Stevens Colemanstr.,1,0
+1665,9,May,16,,St Edm. Lumbardstreet,0,0
+1665,9,May,16,,St Mary Staynings,2,0
+1665,9,May,16,,St Stevens Walbrook,0,0
+1665,9,May,16,,St Ethelborough,0,0
+1665,9,May,16,,St Mary Woolchurch,0,0
+1665,9,May,16,,St Swithins,1,0
+1665,9,May,16,,St Faiths,0,0
+1665,9,May,16,,St Mary Woolnoth,0,0
+1665,9,May,16,,St Thomas Apostles,0,0
+1665,9,May,16,,St Fosters,0,0
+1665,9,May,16,,St Martins Iremongerl,0,0
+1665,9,May,16,,Trinity Parish,0,0
+1665,9,May,16,,St Gabriel Fenechurch,1,0
+1665,9,May,16,,S Andrews Holborne,15,0
+1665,9,May,16,,St Botolph Aldgate,16,0
+1665,9,May,16,,St Saviours Southwark,10,0
+1665,9,May,16,,St Bartholomew Great,0,0
+1665,9,May,16,,St Botolph Bishopsgate,9,0
+1665,9,May,16,,St Sepulchres Parish,18,0
+1665,9,May,16,,S• Bartholomew Lesse,1,0
+1665,9,May,16,,St Dunstans West,5,0
+1665,9,May,16,,St Thomas Southwark,2,0
+1665,9,May,16,,St Brides Parish,7,0
+1665,9,May,16,,St George Southwark,0,0
+1665,9,May,16,,Trinity Minories,1,0
+1665,9,May,16,,Bridewel Precinct,1,0
+1665,9,May,16,,St Giles Cripplegate,25,0
+1665,9,May,16,,At the Pesthouse,0,0
+1665,9,May,16,,St Botolph Aldersgate,3,0
+1665,9,May,16,,St Olaves Southwark,13,0
+1665,9,May,16,,S• Giles in the fields,32,1
+1665,9,May,16,,•ambeth Parish,5,0
+1665,9,May,16,,St Mary Islington,2,0
+1665,9,May,16,,Hackney Parish,3,0
+1665,9,May,16,,St Leonard Shoreditch,8,0
+1665,9,May,16,,St Mary Whitechappe,12,0
+1665,9,May,16,,〈◊〉 James Clerkenwel,4,0
+1665,9,May,16,,St Magdalen Bermond.,9,0
+1665,9,May,16,,Redriff Parish,0,0
+1665,9,May,16,,S Kath. neer the Tower,4,0
+1665,9,May,16,,St Mary Newington,4,0
+1665,9,May,16,,Stepney Parish,33,0
+1665,9,May,16,,St Clement Danes,10,2
+1665,9,May,16,,St Martins in the fields,26,0
+1665,9,May,16,,St Margaret Westminst,16,0
+1665,9,May,16,,S Paul Covent Garden,3,0
+1665,9,May,16,,St Mary Savoy,1,0
+1665,9,May,16,,•hereof at the Pesthouse,0,0
+1665,16,May,23,,St ALbans Woodstreet,1,0
+1665,16,May,23,,St George Botolphlane,0,0
+1665,16,May,23,,St Martins Ludgate,0,0
+1665,16,May,23,,Alhallows Barking,3,0
+1665,16,May,23,,St Gregories by St Pauls,0,0
+1665,16,May,23,,St Martins Orgars,1,0
+1665,16,May,23,,Alhallows Breadstreet,0,0
+1665,16,May,23,,St Hellens,0,0
+1665,16,May,23,,St Martins Outwitch,0,0
+1665,16,May,23,,Alhallows Great,1,0
+1665,16,May,23,,St James Dukes place,0,0
+1665,16,May,23,,St Martins Vintrey,0,0
+1665,16,May,23,,Alhallows Honylane,0,0
+1665,16,May,23,,St James Garlickhithe,0,0
+1665,16,May,23,,St Mathew Fridaystreet,0,0
+1665,16,May,23,,Alhallows Lesse,0,0
+1665,16,May,23,,St John Baptist,1,0
+1665,16,May,23,,St Maudlins Milkstreet,1,0
+1665,16,May,23,,Alhallows Lumbardstr.,0,0
+1665,16,May,23,,St John Evangelist,0,0
+1665,16,May,23,,St Maudlins Oldfish str.,1,0
+1665,16,May,23,,Alhallows Stayning,2,0
+1665,16,May,23,,St John Zachary,0,0
+1665,16,May,23,,St Michael Bassishaw,0,0
+1665,16,May,23,,Alhallows the Wall,0,0
+1665,16,May,23,,St Katharine Coleman,0,0
+1665,16,May,23,,St Michael Cornhil,0,0
+1665,16,May,23,,St Alphage,3,0
+1665,16,May,23,,St Katharine crechurch,1,0
+1665,16,May,23,,St Michael Crookedla,0,0
+1665,16,May,23,,St Andrew Hubbard,0,0
+1665,16,May,23,,St Lawrence Jewry,2,0
+1665,16,May,23,,St Michael Queenhithe,2,0
+1665,16,May,23,,St Andrew Unders•aft,2,0
+1665,16,May,23,,St Lawrence Pountney,0,0
+1665,16,May,23,,St Michael Quern,2,0
+1665,16,May,23,,St Andrew Wardrobe,0,0
+1665,16,May,23,,St Leonard Eastcheap,0,0
+1665,16,May,23,,St Michael Royall,0,0
+1665,16,May,23,,St Ann Aldersgate,1,0
+1665,16,May,23,,St Leonard Fosterlant,1,0
+1665,16,May,23,,St Michael Woodstreet,1,0
+1665,16,May,23,,St Ann Blackfryers,3,0
+1665,16,May,23,,St Magnus Parish,0,0
+1665,16,May,23,,St Mildred Breadstreet,0,0
+1665,16,May,23,,St Antholins Parish,1,0
+1665,16,May,23,,St Margaret Lothbury,1,0
+1665,16,May,23,,St Mildred Poultrey,1,0
+1665,16,May,23,,St Austins Parish,1,0
+1665,16,May,23,,St Margaret Moses,1,0
+1665,16,May,23,,St Nicholas Acons,0,0
+1665,16,May,23,,St Bartholomew Excha,1,0
+1665,16,May,23,,St Margaret Newfi•sh••,2,0
+1665,16,May,23,,St Nicholas Coleabby,0,0
+1665,16,May,23,,St Bennet Fynck,0,0
+1665,16,May,23,,St Margaret Pattons,1,0
+1665,16,May,23,,St Nicholas Olaves,0,0
+1665,16,May,23,,St Bennet Gracechurch,1,0
+1665,16,May,23,,St Mary Abchurch,0,0
+1665,16,May,23,,St Olaves Hartstreet,0,0
+1665,16,May,23,,St Bennet Paulswharfe,2,0
+1665,16,May,23,,St Mary Aldermanbury,0,0
+1665,16,May,23,,St Olaves Jewry,0,0
+1665,16,May,23,,St Bennet Sherchog,0,0
+1665,16,May,23,,St Mary Aldermary,1,0
+1665,16,May,23,,St Olaves Silverstreet,2,0
+1665,16,May,23,,St Botolph Billingsgate,1,0
+1665,16,May,23,,St Mary le Bow,1,0
+1665,16,May,23,,St Pancras Soperlane,0,0
+1665,16,May,23,,Christ Church,3,0
+1665,16,May,23,,St Mary Bothaw,0,0
+1665,16,May,23,,St Peters Cheap,0,0
+1665,16,May,23,,St Christophers,0,0
+1665,16,May,23,,St Mary Colechurch,0,0
+1665,16,May,23,,St Peters Cornhil,0,0
+1665,16,May,23,,St Clement Eastcheap,0,0
+1665,16,May,23,,St Mary Hill,0,0
+1665,16,May,23,,St Peters Paulswharf,0,0
+1665,16,May,23,,St Dionis Backchurch,0,0
+1665,16,May,23,,St Mary Mounthaw,0,0
+1665,16,May,23,,St Peters Poor,2,0
+1665,16,May,23,,St Dunstans East,0,0
+1665,16,May,23,,St Mary Sommerset,1,0
+1665,16,May,23,,St Stevens Colemanstr.,4,0
+1665,16,May,23,,St Edm. Lumbardstreet,0,0
+1665,16,May,23,,St Mary Staynings,0,0
+1665,16,May,23,,St Stevens Walbrook,1,0
+1665,16,May,23,,St Ethelborough,0,0
+1665,16,May,23,,St Mary Woolchurch,0,0
+1665,16,May,23,,St Swithins,0,0
+1665,16,May,23,,St Faiths,0,0
+1665,16,May,23,,St Mary Woolnoth,0,0
+1665,16,May,23,,St Thomas Apostles,0,0
+1665,16,May,23,,St Fosters,4,0
+1665,16,May,23,,St Martins Iremongerl,0,0
+1665,16,May,23,,Trinity Parish,2,0
+1665,16,May,23,,St Gabriel Fenchurch,0,0
+1665,16,May,23,,S• Andrews Holborne,16,0
+1665,16,May,23,,St Botolph Aldgate,11,0
+1665,16,May,23,,St Saviours Southwark,15,0
+1665,16,May,23,,S• Bartholomew Great,2,0
+1665,16,May,23,,St Botolph Bishopsgat•,11,0
+1665,16,May,23,,St Sepulchres Parish,18,0
+1665,16,May,23,,St Bartholomew Lesse,0,0
+1665,16,May,23,,St Dunstans West,2,1
+1665,16,May,23,,St Thomas Southwark,3,0
+1665,16,May,23,,St Brides Parish,7,0
+1665,16,May,23,,St George Southwark,2,0
+1665,16,May,23,,Trinity Minories,0,0
+1665,16,May,23,,Bridewel Precinct,0,0
+1665,16,May,23,,St Giles Cripplegate,23,0
+1665,16,May,23,,At the Pesthouse,1,1
+1665,16,May,23,,St Botolph Aldersgate,7,0
+1665,16,May,23,,St Olaves Southwark,7,0
+1665,16,May,23,,St Giles in the fields,40,7
+1665,16,May,23,,•ambeth Parish,1,0
+1665,16,May,23,,St Mary Islington,2,0
+1665,16,May,23,,Hackney Parish,3,0
+1665,16,May,23,,St Leonard Shoreditch,10,0
+1665,16,May,23,,St Mary Whitechappel,14,0
+1665,16,May,23,,St James Clerkenwel,3,0
+1665,16,May,23,,St Magdalen Bermond,7,0
+1665,16,May,23,,Redriff Parish,0,0
+1665,16,May,23,,St Kath. neer the Tower,5,0
+1665,16,May,23,,St Mary Newington,6,0
+1665,16,May,23,,Stepney Parish,38,0
+1665,16,May,23,,St Clement Dane•,19,5
+1665,16,May,23,,St Martins in the fields,22,0
+1665,16,May,23,,St Margaret Westminst.,21,0
+1665,16,May,23,,S• Paul Covent Garden,4,0
+1665,16,May,23,,St Mary Savoy,2,0
+1665,23,May,30,,St ALbans Woodstreet,2,0
+1665,23,May,30,,St George Botolphlane,1,0
+1665,23,May,30,,St Martins Ludgate,0,0
+1665,23,May,30,,Alhallows Barking,3,0
+1665,23,May,30,,St Gregories by St Pauls,0,0
+1665,23,May,30,,St Martins Orgars,0,0
+1665,23,May,30,,Alhallows Breadstreet,0,0
+1665,23,May,30,,St Hellins,0,0
+1665,23,May,30,,St Martins Outwitch,0,0
+1665,23,May,30,,Alhallows Great,2,0
+1665,23,May,30,,St James Dukes place,1,0
+1665,23,May,30,,St Martins Vintrey,0,0
+1665,23,May,30,,Alhallows Honylane,0,0
+1665,23,May,30,,St James Garlickhithe,2,0
+1665,23,May,30,,St Mathew Fridaystreet,0,0
+1665,23,May,30,,Alhallows Lesse,0,0
+1665,23,May,30,,St John Baptist,0,0
+1665,23,May,30,,St Maudlins Milkstreet,0,0
+1665,23,May,30,,Alhallows Lumbardstr,1,0
+1665,23,May,30,,St John Evangelist,0,0
+1665,23,May,30,,St Maudlins Oldfishst.,0,0
+1665,23,May,30,,Alhallows Stayning,0,0
+1665,23,May,30,,St John Zachary,1,0
+1665,23,May,30,,St Michael Bassi•haw,3,0
+1665,23,May,30,,Alhallows the Wall,2,0
+1665,23,May,30,,St Katharine Coleman,2,0
+1665,23,May,30,,St Michael Cornhil,0,0
+1665,23,May,30,,St Alphage,2,0
+1665,23,May,30,,St Katharine crechurch,2,0
+1665,23,May,30,,St Michael Crookedla.,0,0
+1665,23,May,30,,St Andrew Hubbard,1,0
+1665,23,May,30,,St Lawrence Jewry,1,0
+1665,23,May,30,,St Michael Queenhithe,0,0
+1665,23,May,30,,St Andrew Undershaft,0,0
+1665,23,May,30,,St Lawrence Pountney,1,0
+1665,23,May,30,,St Michael Quern,0,0
+1665,23,May,30,,St Andrew Wardrobe,0,0
+1665,23,May,30,,St Leonard Eastcheap,0,0
+1665,23,May,30,,St Michael Royall,0,0
+1665,23,May,30,,St Ann Aldersgate,0,0
+1665,23,May,30,,St Leonard Fosterlane,0,0
+1665,23,May,30,,St Michael Woodstreet,0,0
+1665,23,May,30,,St Ann Blackfryers,3,0
+1665,23,May,30,,St Magnus Parish,0,0
+1665,23,May,30,,St Mildred Breadstreet,1,0
+1665,23,May,30,,St Antholins Parish,0,0
+1665,23,May,30,,St Margaret Lothbury,0,0
+1665,23,May,30,,St Mildred Poultrey,0,0
+1665,23,May,30,,St Austins Parish,1,0
+1665,23,May,30,,St Margaret Moses,0,0
+1665,23,May,30,,St Nicholas Acons,1,0
+1665,23,May,30,,St Bartholomew Exch.,0,0
+1665,23,May,30,,St Margaret Newfishst,1,0
+1665,23,May,30,,St Nicholas Coleabby,1,0
+1665,23,May,30,,St Bennet Fynck,0,0
+1665,23,May,30,,St Margaret Pattons,0,0
+1665,23,May,30,,St Nicholas Olaves,0,0
+1665,23,May,30,,St Bennet Gracechurch,0,0
+1665,23,May,30,,St Mary Abchurch,0,0
+1665,23,May,30,,St Olaves Hartstreet,0,0
+1665,23,May,30,,St Bennet Paulswharf,0,0
+1665,23,May,30,,St Mary Aldermanbury,1,0
+1665,23,May,30,,St Olaves Jewry,1,0
+1665,23,May,30,,St Bennet Sherehog,0,0
+1665,23,May,30,,St Mary Aldermary,0,0
+1665,23,May,30,,St Olaves Silverstreet,2,0
+1665,23,May,30,,St Botolph Billingsgate,1,0
+1665,23,May,30,,St Mary le Bow,0,0
+1665,23,May,30,,St Pancras Soperlant,0,0
+1665,23,May,30,,Christs Church,1,0
+1665,23,May,30,,St Mary Bothaw,3,0
+1665,23,May,30,,St Peters Cheap,0,0
+1665,23,May,30,,St Christophers,0,0
+1665,23,May,30,,St Mary Colechurch,0,0
+1665,23,May,30,,St Peters Cornhil,0,0
+1665,23,May,30,,St Clement Eastcheap,0,0
+1665,23,May,30,,St Mary Hill,0,0
+1665,23,May,30,,St Peters Paulswharf,1,0
+1665,23,May,30,,St Dionis Backchurch,1,0
+1665,23,May,30,,St Mary Mounthaw,0,0
+1665,23,May,30,,St Peters Poor,0,0
+1665,23,May,30,,St Dunstans East,1,0
+1665,23,May,30,,St Mary Sommerset,4,0
+1665,23,May,30,,St Stevens Colemanstr,2,0
+1665,23,May,30,,St Edm. Lumbardstreet,0,0
+1665,23,May,30,,St Mary Staynings,0,0
+1665,23,May,30,,St Stevens Walbrook,1,0
+1665,23,May,30,,St Ethelbourgh,0,0
+1665,23,May,30,,St Mary Woolchurch,1,0
+1665,23,May,30,,St Swithins,0,0
+1665,23,May,30,,St Faiths,1,0
+1665,23,May,30,,St Mary Wolnoth,0,0
+1665,23,May,30,,St Thomas Apostle,0,0
+1665,23,May,30,,St Fosters,0,0
+1665,23,May,30,,St Martins Iremongerl.,0,0
+1665,23,May,30,,Trinity Parish,0,0
+1665,23,May,30,,St Gabriel Fenchurch,0,0
+1665,23,May,30,,St Andrews Holborn,18,1
+1665,23,May,30,,St Botolph Aldgate,11,0
+1665,23,May,30,,St Saviours Southwark,14,0
+1665,23,May,30,,St Bartholomew Great,0,0
+1665,23,May,30,,St Botolph Bishopsgate,4,1
+1665,23,May,30,,St Sepulchres Parish,18,0
+1665,23,May,30,,St Bartholomew Lesse,0,0
+1665,23,May,30,,St Dunstans West,5,0
+1665,23,May,30,,St Thomas Southwark,0,0
+1665,23,May,30,,St Brides Parish,8,0
+1665,23,May,30,,St George Southwark,2,0
+1665,23,May,30,,Trinity Minories,0,0
+1665,23,May,30,,Bridewel Precinct,2,0
+1665,23,May,30,,St Giles Cripplegate,21,0
+1665,23,May,30,,At the Pesthouse,1,1
+1665,23,May,30,,St Botolph Aldersgate,4,0
+1665,23,May,30,,St Olaves Southwark,19,1
+1665,23,May,30,,St Giles in the fields,53,9
+1665,23,May,30,,Lam•eth Parish,6,0
+1665,23,May,30,,St Mary Iflington,1,0
+1665,23,May,30,,•ackney Parish,0,0
+1665,23,May,30,,St Leonard Shoreditch,9,0
+1665,23,May,30,,St Mary Whitechappel,19,0
+1665,23,May,30,,St James Clerkenwel,9,0
+1665,23,May,30,,St Magdalen Bermond.,9,0
+1665,23,May,30,,Redriff Parish,0,0
+1665,23,May,30,,St Kath. neer the Towe•,2,0
+1665,23,May,30,,St Mary Newington,3,0
+1665,23,May,30,,Stepney Parish,34,0
+1665,23,May,30,,St Clement Danes,10,4
+1665,23,May,30,,St Martins in the fields,37,0
+1665,23,May,30,,St Margaret Westminst.,21,0
+1665,23,May,30,,St Paul Covent Garden,4,0
+1665,23,May,30,,St Mary Savoy,0,0
+1665,30,May,6,June,St ALbans Woodstreet,0,0
+1665,30,May,6,June,St George Botolphlant,0,0
+1665,30,May,6,June,St Martins Ludgate,0,0
+1665,30,May,6,June,Alhallows Barking,1,0
+1665,30,May,6,June,St Gregories by St Pauls,3,0
+1665,30,May,6,June,St Martins Orgars,0,0
+1665,30,May,6,June,Alhallows Breadstreet,2,0
+1665,30,May,6,June,St Hellins,0,0
+1665,30,May,6,June,St Martins Outwitch,0,0
+1665,30,May,6,June,Alhallows Great,3,0
+1665,30,May,6,June,St James Dukes place,2,0
+1665,30,May,6,June,St Martins Vintrey,2,0
+1665,30,May,6,June,Alhallows Honylane,0,0
+1665,30,May,6,June,St James Garlickhithe,0,0
+1665,30,May,6,June,St Mathew Fridaystreet,0,0
+1665,30,May,6,June,Alhallows Lesse,1,0
+1665,30,May,6,June,St John Baptist,2,0
+1665,30,May,6,June,St Maudlins Milkstreet,0,0
+1665,30,May,6,June,Alhallows Lumbardstr,0,0
+1665,30,May,6,June,St John Evangelist,0,0
+1665,30,May,6,June,St Maudlins Oldfishst.,0,0
+1665,30,May,6,June,Alhallows Stayning,1,0
+1665,30,May,6,June,St John Zachary,0,0
+1665,30,May,6,June,St Michael Bassishaw,0,0
+1665,30,May,6,June,Alhallows the Wall,3,0
+1665,30,May,6,June,St Katharine Coleman,2,0
+1665,30,May,6,June,St Michael Cornhil,0,0
+1665,30,May,6,June,St Alphage,0,0
+1665,30,May,6,June,St Katharine crechurch,3,0
+1665,30,May,6,June,St Michael Crookedia.,2,0
+1665,30,May,6,June,St Andrew Hubbard,0,0
+1665,30,May,6,June,St Lawrence Jewry,2,0
+1665,30,May,6,June,St Michael Queenhithe,0,0
+1665,30,May,6,June,St Andrew Undershaft,0,0
+1665,30,May,6,June,St Lawrence Pountney,2,0
+1665,30,May,6,June,St Michael Quern,0,0
+1665,30,May,6,June,St Andrew Wardrobe,3,0
+1665,30,May,6,June,St Leonard Eastcheap,0,0
+1665,30,May,6,June,St Michael Royall,0,0
+1665,30,May,6,June,St Ann Aldersgate,0,0
+1665,30,May,6,June,St Leonard Fosterlane,3,0
+1665,30,May,6,June,St Michael Woodstreet,0,0
+1665,30,May,6,June,St Ann Blackfryers,3,0
+1665,30,May,6,June,St Magnus Parish,1,0
+1665,30,May,6,June,St Mildred Breadstreet,0,0
+1665,30,May,6,June,St Antholins Parish,0,0
+1665,30,May,6,June,St Margaret Lothbury,0,0
+1665,30,May,6,June,St Mildred Poultrey,1,0
+1665,30,May,6,June,St Austins Parish,1,0
+1665,30,May,6,June,St Margaret Moses,0,0
+1665,30,May,6,June,St Nicholas Acons,0,0
+1665,30,May,6,June,St Bartholomew Exch.,0,0
+1665,30,May,6,June,St Margaret Newfishst,1,0
+1665,30,May,6,June,St Nicholas Col•abby,0,0
+1665,30,May,6,June,St Bennet Fynck,0,0
+1665,30,May,6,June,St Margaret Pattons,0,0
+1665,30,May,6,June,St Nicholas Olaves,0,0
+1665,30,May,6,June,St Bennet Gracechurch,0,0
+1665,30,May,6,June,St Mary Abchurch,0,0
+1665,30,May,6,June,St Olaves Hartstreet,0,0
+1665,30,May,6,June,St Bennet Paulswharf,4,0
+1665,30,May,6,June,St Mary Aldermanbury,1,0
+1665,30,May,6,June,St Olaves Jewry,0,0
+1665,30,May,6,June,St Bennet Sherehog,0,0
+1665,30,May,6,June,St Mary Aldermary,0,0
+1665,30,May,6,June,St Olaves Silverstreet,0,0
+1665,30,May,6,June,St Botolph Billingsgate,0,0
+1665,30,May,6,June,St Mary le Bow,0,0
+1665,30,May,6,June,St Pancras Soperlane,0,0
+1665,30,May,6,June,Christs Church,4,0
+1665,30,May,6,June,St Mary Bothaw,0,0
+1665,30,May,6,June,St Peters Cheap,0,0
+1665,30,May,6,June,St Christophers,0,0
+1665,30,May,6,June,St Mary Colechurch,0,0
+1665,30,May,6,June,St Peters Cornhil,1,0
+1665,30,May,6,June,St Clement Eastcheap,0,0
+1665,30,May,6,June,St Mary Hill,0,0
+1665,30,May,6,June,St Peters Paulswharf,1,0
+1665,30,May,6,June,St Dionis Backchurch,0,0
+1665,30,May,6,June,St Mary Mounthaw,0,0
+1665,30,May,6,June,St Peters Poor,0,0
+1665,30,May,6,June,St Dunstans East,4,0
+1665,30,May,6,June,St Mary Sommerset,3,0
+1665,30,May,6,June,St Stevens Colemanstr.,2,0
+1665,30,May,6,June,St Edm. Lumbardstreet,0,0
+1665,30,May,6,June,St Mary Staynings,0,0
+1665,30,May,6,June,St Stevens Walbrook,0,0
+1665,30,May,6,June,St Ethelbourgh,0,0
+1665,30,May,6,June,St Mary Woolchurch,0,0
+1665,30,May,6,June,St Swithins,0,0
+1665,30,May,6,June,St Faiths,0,0
+1665,30,May,6,June,St Mary Wolnoth,2,0
+1665,30,May,6,June,St Thomas Apostle,2,0
+1665,30,May,6,June,St Fosters,1,0
+1665,30,May,6,June,St Martins Iremongerl.,0,0
+1665,30,May,6,June,Trinity Parish,0,0
+1665,30,May,6,June,St Gabriel Fenchurch,0,0
+1665,30,May,6,June,St Andrews Holborn,19,1
+1665,30,May,6,June,St Botolph Aldgate,10,0
+1665,30,May,6,June,St Saviours Southwark,6,0
+1665,30,May,6,June,St Bartholomew Great,0,0
+1665,30,May,6,June,St Botolph Bishopsgate,10,0
+1665,30,May,6,June,St Sepulchres Parish,32,5
+1665,30,May,6,June,St Bartholomew Lesse,0,0
+1665,30,May,6,June,St Dunstans West,8,2
+1665,30,May,6,June,St Thomas Southwark,0,0
+1665,30,May,6,June,St Brides Parish,5,0
+1665,30,May,6,June,St George Southwark,3,0
+1665,30,May,6,June,Trinity Minories,0,0
+1665,30,May,6,June,Bridewel Precinct,0,0
+1665,30,May,6,June,St Giles Cripplegate,28,2
+1665,30,May,6,June,At the Pesthouse,0,0
+1665,30,May,6,June,S• Botolph Aldersgate,1,0
+1665,30,May,6,June,St Olaves Southwark,13,0
+1665,30,May,6,June,St Giles in the fields,74,31
+1665,30,May,6,June,Lambeth Parish,4,0
+1665,30,May,6,June,St Mary Iflington,1,0
+1665,30,May,6,June,•ackney Parish,0,0
+1665,30,May,6,June,St Leonard Shoreditch,0,0
+1665,30,May,6,June,St Mary Whitechappel,15,1
+1665,30,May,6,June,S James Clerkenwel,2,0
+1665,30,May,6,June,St Magdalen Bermond.,7,0
+1665,30,May,6,June,Redriff Parish,1,0
+1665,30,May,6,June,S Kath. neer the Tower,3,0
+1665,30,May,6,June,St Mary Newington,3,0
+1665,30,May,6,June,Ste•ney Parish,28,0
+1665,30,May,6,June,St Clement Danes,15,0
+1665,30,May,6,June,St Martins in the fields,22,1
+1665,30,May,6,June,St Margaret Westminst.,23,0
+1665,30,May,6,June,St Paul Covent Garden,2,0
+1665,30,May,6,June,St Mary Savoy,1,0
+1665,6,June,13,,St ALban Woodstreet,3,1
+1665,6,June,13,,St George Botolphlane,0,0
+1665,6,June,13,,St Martin Ludgate,1,0
+1665,6,June,13,,St Alhallows Barking,1,0
+1665,6,June,13,,St Gregory by St Pauls,3,0
+1665,6,June,13,,St Martin Orgars,0,0
+1665,6,June,13,,Alhallows Breadstreet,0,0
+1665,6,June,13,,St Hellen,0,0
+1665,6,June,13,,St Martin Outwitch,0,0
+1665,6,June,13,,Alhallows Great,3,0
+1665,6,June,13,,St James Dukes place,2,0
+1665,6,June,13,,St Martin Vintrey,1,0
+1665,6,June,13,,Alhallows Honylane,0,0
+1665,6,June,13,,St James Garlickhithe,1,0
+1665,6,June,13,,St Matthew Fridaystreet,0,0
+1665,6,June,13,,Alhallows Lesse,0,0
+1665,6,June,13,,St John Baptist,0,0
+1665,6,June,13,,St Maudlin Milkstreet,1,0
+1665,6,June,13,,Alhallows Lumbardstreet,0,0
+1665,6,June,13,,St John Evangelist,1,0
+1665,6,June,13,,St Maudlin Oldfishstreet,0,0
+1665,6,June,13,,Alhallows Staining,1,0
+1665,6,June,13,,St John Zachary,0,0
+1665,6,June,13,,St Michael Bassishaw,2,0
+1665,6,June,13,,Alhallows the Wall,4,0
+1665,6,June,13,,St Katharine Coleman,0,0
+1665,6,June,13,,St Michael Cornhil,0,0
+1665,6,June,13,,St Alphage,0,0
+1665,6,June,13,,St Katharine Crechurch,0,0
+1665,6,June,13,,St Michael Crookedlane,2,2
+1665,6,June,13,,St Andrew Hubbard,0,0
+1665,6,June,13,,St Lawrence Jewry,0,0
+1665,6,June,13,,St Michael Queenhithe,0,0
+1665,6,June,13,,St Andrew Undershaft,1,0
+1665,6,June,13,,St Lawrence Pountney,1,0
+1665,6,June,13,,St Michael Quern,0,0
+1665,6,June,13,,St Andrew Wardrobe,2,0
+1665,6,June,13,,St Leonard Eastcheap,0,0
+1665,6,June,13,,St Michael Royal,0,0
+1665,6,June,13,,St Ann Aldersgate,1,0
+1665,6,June,13,,St Leonard Fosterlane,1,0
+1665,6,June,13,,St Michael Woodstreet,2,0
+1665,6,June,13,,St Ann Blackfryers,4,0
+1665,6,June,13,,St Magnus Parish,1,0
+1665,6,June,13,,St Mildred Breadstreet,0,0
+1665,6,June,13,,St Antholins Parish,0,0
+1665,6,June,13,,St Margaret Lothbury,0,0
+1665,6,June,13,,St Mildred Poultrey,0,0
+1665,6,June,13,,St Austins Parish,0,0
+1665,6,June,13,,St Margaret Moses,0,0
+1665,6,June,13,,St Nicholas Acons,0,0
+1665,6,June,13,,St Bartholomew Exchange,0,0
+1665,6,June,13,,St Margaret Newfishstreet,0,0
+1665,6,June,13,,St Nicholas Coleabby,0,0
+1665,6,June,13,,St Bennet Fynck,0,0
+1665,6,June,13,,St Margaret Pattons,0,0
+1665,6,June,13,,St Nicholas Olaves,0,0
+1665,6,June,13,,St Bennet Gracechurch,0,0
+1665,6,June,13,,St Mary Abchurch,1,0
+1665,6,June,13,,St Olave Hartstreet,2,0
+1665,6,June,13,,St Bennet Paulswharf,3,0
+1665,6,June,13,,St Mary Aldermanbury,0,0
+1665,6,June,13,,St Olave Jewry,0,0
+1665,6,June,13,,St Bennet Sherehog,0,0
+1665,6,June,13,,St Mary Aldermary,1,0
+1665,6,June,13,,St Olave Silverstreet,1,0
+1665,6,June,13,,St Botolph Billingsgate,1,0
+1665,6,June,13,,St Mary le Bow,0,0
+1665,6,June,13,,St Pancras Soperlane,0,0
+1665,6,June,13,,Christs Church,1,0
+1665,6,June,13,,St Mary Bothaw,0,0
+1665,6,June,13,,St Peter Cheap,1,0
+1665,6,June,13,,St Christophers,0,0
+1665,6,June,13,,St Mary Colechurch,0,0
+1665,6,June,13,,St Peter Cornhil,0,0
+1665,6,June,13,,St Clement Eastcheap,0,0
+1665,6,June,13,,St Mary Hill,0,0
+1665,6,June,13,,St Peter Paulswharf,1,0
+1665,6,June,13,,St Dionis Backchurch,1,0
+1665,6,June,13,,St Mary Mounthaw,0,0
+1665,6,June,13,,St Peter Poor,0,0
+1665,6,June,13,,St Dunstan East,2,0
+1665,6,June,13,,St Mary Sommerset,3,0
+1665,6,June,13,,St Steven Colemanstreet,3,0
+1665,6,June,13,,St Edmund Lumbardstr.,1,0
+1665,6,June,13,,St Mary Stayning,0,0
+1665,6,June,13,,St Steven Walbrook,0,0
+1665,6,June,13,,St Ethelborough,0,0
+1665,6,June,13,,St Mary Woolchurch,0,0
+1665,6,June,13,,St Swithin,0,0
+1665,6,June,13,,St Faith,0,0
+1665,6,June,13,,St Mary Woolnoth,2,0
+1665,6,June,13,,St Thomas Apostle,1,0
+1665,6,June,13,,St Foster,0,0
+1665,6,June,13,,St Martin Iremongerlane,0,0
+1665,6,June,13,,Trinity Parish,0,0
+1665,6,June,13,,St Gabriel Fenchurch,2,1
+1665,6,June,13,,St Andrew Holborn,20,7
+1665,6,June,13,,St Botolph Aldgate,19,0
+1665,6,June,13,,Saviours Southwark,15,0
+1665,6,June,13,,St Bartholomew Great,2,0
+1665,6,June,13,,St Botolph Bishopsgate,15,2
+1665,6,June,13,,S. Sepulchres Parish,25,10
+1665,6,June,13,,St Bartholomew Lesse,0,0
+1665,6,June,13,,St Dunstan West,1,0
+1665,6,June,13,,St Thomas Southwark,2,0
+1665,6,June,13,,St Bridget,14,3
+1665,6,June,13,,St George Southwark,7,0
+1665,6,June,13,,Trinity Minories,0,0
+1665,6,June,13,,Bridewel Precinct,0,0
+1665,6,June,13,,St Giles Cripplegate,37,1
+1665,6,June,13,,At the Pesthouse,5,4
+1665,6,June,13,,St Botolph Aldersgate,3,0
+1665,6,June,13,,St Olave Southwark,14,0
+1665,6,June,13,,St Giles in the field•,120,68
+1665,6,June,13,,Lambeth Parish,6,0
+1665,6,June,13,,St Mary I•lington,0,0
+1665,6,June,13,,H•c•ney Parish,2,0
+1665,6,June,13,,St Leonard Shoreditch,21,0
+1665,6,June,13,,St Mary Whitechappel,23,3
+1665,6,June,13,,St James Clerkenwel,13,0
+1665,6,June,13,,St Magdalen Bermondsey,6,0
+1665,6,June,13,,Rothorith Parish,3,0
+1665,6,June,13,,St Kath. near the Tower,9,0
+1665,6,June,13,,St Mary Newington,3,0
+1665,6,June,13,,Stepney Parish,32,0
+1665,6,June,13,,St Clement Danes,14,8
+1665,6,June,13,,St Martin in the fields,34,2
+1665,6,June,13,,St Margaret Westminster,20,0
+1665,6,June,13,,St Paul Covent Garden,2,0
+1665,6,June,13,,St Mary Savoy,4,0
+1665,13,June,20,,St ALban Woodstreet,4,2
+1665,13,June,20,,St George Botolphlane,0,0
+1665,13,June,20,,St Martin Ludgate,1,0
+1665,13,June,20,,Alhallows Barking,1,0
+1665,13,June,20,,St Gregory by St Pauls,0,0
+1665,13,June,20,,St Martin Orgars,0,0
+1665,13,June,20,,Alhallows Breadstreet,0,0
+1665,13,June,20,,St Hellen,2,0
+1665,13,June,20,,St Martin Outwitch,0,0
+1665,13,June,20,,Alhallows Great,4,0
+1665,13,June,20,,St James Dukes place,1,0
+1665,13,June,20,,St Martin Vintrey,1,0
+1665,13,June,20,,Alhallows Honylane,0,0
+1665,13,June,20,,St James Garlickhithe,0,0
+1665,13,June,20,,St Matthew Fridaystreet,1,0
+1665,13,June,20,,Alhallows Lesse,3,0
+1665,13,June,20,,St John Baptist,0,0
+1665,13,June,20,,St Maudlin Milkstreet,0,0
+1665,13,June,20,,Alhallows Lumbardstreet,0,0
+1665,13,June,20,,St John Evangelist,0,0
+1665,13,June,20,,St Maudlin Oldfishstreet,0,0
+1665,13,June,20,,Alhallows Staining,0,0
+1665,13,June,20,,St John Zachary,1,0
+1665,13,June,20,,St Michael Bassishaw,3,0
+1665,13,June,20,,Alhallows the Wall,0,0
+1665,13,June,20,,St Katharine Coleman,2,0
+1665,13,June,20,,St Michael Cornhil,0,0
+1665,13,June,20,,St Alphage,1,0
+1665,13,June,20,,St Katharine Crechurch,1,0
+1665,13,June,20,,St Michael Crookedlane,2,2
+1665,13,June,20,,St Andrew Hubbard,1,0
+1665,13,June,20,,St Lawrence Jewry,1,0
+1665,13,June,20,,St Michael Queenhithe,0,0
+1665,13,June,20,,St Andrew Undershaft,0,0
+1665,13,June,20,,St Lawrence Pountney,0,0
+1665,13,June,20,,St Michael Quern,0,0
+1665,13,June,20,,St Andrew Wardrobe,1,0
+1665,13,June,20,,St Leonard Eastcheap,0,0
+1665,13,June,20,,St Michael Royal,0,0
+1665,13,June,20,,St Ann Aldersgate,0,0
+1665,13,June,20,,St Leonard Fosterlane,0,0
+1665,13,June,20,,St Michael Woodstreet,0,0
+1665,13,June,20,,St Ann Blackfryers,1,0
+1665,13,June,20,,St Magnus Parish,1,0
+1665,13,June,20,,St Mildred Breadstreet,1,0
+1665,13,June,20,,St Antholins Parish,1,0
+1665,13,June,20,,St Margaret Lothbury,0,0
+1665,13,June,20,,St Mildred Poultrey,1,0
+1665,13,June,20,,St Austins Parish,0,0
+1665,13,June,20,,St Margaret Moses,0,0
+1665,13,June,20,,St Nicholas Acons,0,0
+1665,13,June,20,,St Bartholomew Exchange,0,0
+1665,13,June,20,,St Margaret Newfishstreet,0,0
+1665,13,June,20,,St Nicholas Coleabby,0,0
+1665,13,June,20,,St Bennet Fynck,1,1
+1665,13,June,20,,St Margaret Pattons,1,0
+1665,13,June,20,,St Nicholas Olaves,0,0
+1665,13,June,20,,St Bennet Gracechurch,0,0
+1665,13,June,20,,St Mary Abchurch,0,0
+1665,13,June,20,,St Olave Hartstreet,0,0
+1665,13,June,20,,St Bennet Paulswharf,6,4
+1665,13,June,20,,St Mary Aldermanbury,0,0
+1665,13,June,20,,St Olave Jewry,0,0
+1665,13,June,20,,St Bennet Sherehog,0,0
+1665,13,June,20,,St Mary Aldermary,0,0
+1665,13,June,20,,St Olave Silverstreet,1,1
+1665,13,June,20,,St Botolph Billingsgate,2,0
+1665,13,June,20,,St Mary le Bow,0,0
+1665,13,June,20,,St Pancras Soperlane,0,0
+1665,13,June,20,,Christs Church,2,0
+1665,13,June,20,,St Mary Bothaw,0,0
+1665,13,June,20,,St Peter Cheap,1,0
+1665,13,June,20,,St Christophers,0,0
+1665,13,June,20,,St Mary Colechurch,0,0
+1665,13,June,20,,St Peter Cornhil,0,0
+1665,13,June,20,,St Clement Eastcheap,0,0
+1665,13,June,20,,St Mary Hill,2,0
+1665,13,June,20,,St Peter Paulswharf,0,0
+1665,13,June,20,,St Dionis Backchurch,0,0
+1665,13,June,20,,St Mary Mounthaw,0,0
+1665,13,June,20,,St Peter Poor,0,0
+1665,13,June,20,,St Dunstan East,3,0
+1665,13,June,20,,St Mary Sommerset,0,0
+1665,13,June,20,,St Steven Colemanstreet,3,0
+1665,13,June,20,,St Edmund Lumbardstr.,2,0
+1665,13,June,20,,St Mary Stayning,0,0
+1665,13,June,20,,St Steven Walbrook,0,0
+1665,13,June,20,,St Ethelborough,1,0
+1665,13,June,20,,St Mary Woolchurch,0,0
+1665,13,June,20,,St Swithin,0,0
+1665,13,June,20,,St Faith,0,0
+1665,13,June,20,,St Mary Woolnoth,2,0
+1665,13,June,20,,St Thomas Apostle,0,0
+1665,13,June,20,,St Foster,1,0
+1665,13,June,20,,St Martin Iremongerlane,0,0
+1665,13,June,20,,Trinity Parish,0,0
+1665,13,June,20,,St Gabriel Fenchurch,0,0
+1665,13,June,20,,St Andrew Holborn,24,10
+1665,13,June,20,,St Botolph Aldgate,10,0
+1665,13,June,20,,Saviours Southwark,16,0
+1665,13,June,20,,St Bartholomew Great,4,0
+1665,13,June,20,,St Botolph Bishopsgate,21,2
+1665,13,June,20,,S. Sepulchres Parish,32,11
+1665,13,June,20,,St Bartholomew Lesse,0,0
+1665,13,June,20,,St Dunstan West,9,0
+1665,13,June,20,,St Thomas Southwark,3,0
+1665,13,June,20,,St Bridget,7,2
+1665,13,June,20,,St George Southwark,4,0
+1665,13,June,20,,Trinity Minories,0,0
+1665,13,June,20,,Bridewel Precinct,1,1
+1665,13,June,20,,St Giles Cripplegate,36,3
+1665,13,June,20,,At the Pesthouse,4,4
+1665,13,June,20,,St Botolph Aldersgate,3,0
+1665,13,June,20,,St Olave Southwark,18,1
+1665,13,June,20,,St Giles in the fields,150,101
+1665,13,June,20,,Lambeth Parish,4,0
+1665,13,June,20,,St Mary Islington,3,1
+1665,13,June,20,,Hackney Parish,2,0
+1665,13,June,20,,St Leonard Shoreditch,10,0
+1665,13,June,20,,St Mary Whitechappel,14,0
+1665,13,June,20,,St James Clerkenwel,17,3
+1665,13,June,20,,St Magdalen Bermondsey,9,0
+1665,13,June,20,,Rothorith Parish,6,0
+1665,13,June,20,,St Kath. near the Tower,4,0
+1665,13,June,20,,St Mary Newington,1,0
+1665,13,June,20,,Stepney Parish,38,0
+1665,13,June,20,,St Clement Danes,19,7
+1665,13,June,20,,St Martin in the fields,47,4
+1665,13,June,20,,St Margaret Westminster,31,7
+1665,13,June,20,,St Paul Covent Garden,2,0
+1665,13,June,20,,St Mary Savoy,2,1
+1665,20,June,27,,St ALban Woodstreet,1,0
+1665,20,June,27,,St George Botolphlane,0,0
+1665,20,June,27,,St Martin Ludgate,0,0
+1665,20,June,27,,Alhallows Barking,2,0
+1665,20,June,27,,St Gregory by St Pauls,0,0
+1665,20,June,27,,St Martin Orgars,0,0
+1665,20,June,27,,Alhallows Breadstreet,0,0
+1665,20,June,27,,St Hellen,0,0
+1665,20,June,27,,St Martin Outwitch,0,0
+1665,20,June,27,,Alhallows Great,3,0
+1665,20,June,27,,St James Dukes place,1,0
+1665,20,June,27,,St Martin Vintrey,1,0
+1665,20,June,27,,Alhallows Honylane,0,0
+1665,20,June,27,,St James Garlickhithe,0,0
+1665,20,June,27,,St Matthew Fridaystreet,0,0
+1665,20,June,27,,Alhallows Lesse,0,0
+1665,20,June,27,,St John Baptist,0,0
+1665,20,June,27,,St Maudlin Milkstreet,1,0
+1665,20,June,27,,Alhallows Lumbardstreet,0,0
+1665,20,June,27,,St John Evangelist,0,0
+1665,20,June,27,,St Maudlin Oldfishstreet,0,0
+1665,20,June,27,,Alhallows Stayning,0,0
+1665,20,June,27,,St John Zachary,1,0
+1665,20,June,27,,St Michael Bassishaw,2,1
+1665,20,June,27,,Alhallows the Wall,1,0
+1665,20,June,27,,St Katharine Coleman,0,0
+1665,20,June,27,,St Michael Cornhil,0,0
+1665,20,June,27,,St Alphage,0,0
+1665,20,June,27,,St Katharine Crechurch,1,0
+1665,20,June,27,,St Michael Crookedlane,2,1
+1665,20,June,27,,St Andrew Hubbard,1,0
+1665,20,June,27,,St Lawrence Jewry,0,0
+1665,20,June,27,,St Michael Queenhithe,0,0
+1665,20,June,27,,St Andrew Undershaft,2,0
+1665,20,June,27,,St Lawrence Pountney,1,0
+1665,20,June,27,,St Michael Quern,0,0
+1665,20,June,27,,St Andrew Wardrobe,2,0
+1665,20,June,27,,St Leonard Eastcheap,0,0
+1665,20,June,27,,St Michael Royal,0,0
+1665,20,June,27,,St Ann Aldersgate,0,0
+1665,20,June,27,,St Leonard Fosterlane,0,0
+1665,20,June,27,,St Michael Woodstreet,0,0
+1665,20,June,27,,St Ann Blackfryers,2,0
+1665,20,June,27,,St Magnus Parish,0,0
+1665,20,June,27,,St Mildred Breadstreet,0,0
+1665,20,June,27,,St Antholins Parish,0,0
+1665,20,June,27,,St Margaret Lothbury,1,0
+1665,20,June,27,,St Mildred Poultrey,0,0
+1665,20,June,27,,St Austins Parish,1,0
+1665,20,June,27,,St Margaret Moses,0,0
+1665,20,June,27,,St Nicholas Acons,0,0
+1665,20,June,27,,St Bartholomew Exchange,1,0
+1665,20,June,27,,St Margaret Newfishstre.,0,0
+1665,20,June,27,,St Nicholas Coleabby,0,0
+1665,20,June,27,,St Bennet Fynck,1,0
+1665,20,June,27,,St Margaret Pattons,0,0
+1665,20,June,27,,St Nicholas Olaves,1,0
+1665,20,June,27,,St Bennet Gracechurch,0,0
+1665,20,June,27,,St Mary Abchurch,1,0
+1665,20,June,27,,St Olave Hartstreet,1,0
+1665,20,June,27,,St Bennet Paulswharf,1,0
+1665,20,June,27,,St Mary Aldermanbury,0,0
+1665,20,June,27,,St Olave Jewry,1,0
+1665,20,June,27,,St Bennet Sherehog,0,0
+1665,20,June,27,,St Mary Aldermary,0,0
+1665,20,June,27,,St Olave Silverstreet,0,0
+1665,20,June,27,,St Botolph Billingsgate,0,0
+1665,20,June,27,,St Mary le Bow,0,0
+1665,20,June,27,,St Pancras Soperlane,0,0
+1665,20,June,27,,Christ Church,3,0
+1665,20,June,27,,St Mary Bothaw,0,0
+1665,20,June,27,,St Peter Cheap,3,2
+1665,20,June,27,,St Christophers,0,0
+1665,20,June,27,,St Mary Colechurch,0,0
+1665,20,June,27,,St Peter Cornhil,1,0
+1665,20,June,27,,St Clement Eastcheap,0,0
+1665,20,June,27,,St Mary Hill,0,0
+1665,20,June,27,,St Peter Paulswharf,0,0
+1665,20,June,27,,St Dionis Backchurch,0,0
+1665,20,June,27,,St Mary Mounthaw,0,0
+1665,20,June,27,,St Peter Poor,0,0
+1665,20,June,27,,St Dunstan East,1,0
+1665,20,June,27,,St Mary Sommerset,3,0
+1665,20,June,27,,St Steven Colemanstreet,2,0
+1665,20,June,27,,St Edmund Lumbardstr.,0,0
+1665,20,June,27,,St Mary Stayning,0,0
+1665,20,June,27,,St Steven Walbrook,1,0
+1665,20,June,27,,St Ethelborough,0,0
+1665,20,June,27,,St Mary Woolchurch,0,0
+1665,20,June,27,,St Swithin,1,0
+1665,20,June,27,,St Faith,0,0
+1665,20,June,27,,St Mary Woolnoth,0,0
+1665,20,June,27,,St Thomas Apostles,1,0
+1665,20,June,27,,St Foster,0,0
+1665,20,June,27,,St Martin Iremongerlane,0,0
+1665,20,June,27,,Trinity Parish,0,0
+1665,20,June,27,,St Gabriel Fenchurch,0,0
+1665,20,June,27,,St Andrew Holborn,37,15
+1665,20,June,27,,St Botolph Aldgate,14,0
+1665,20,June,27,,Saviours Southwark,16,0
+1665,20,June,27,,St Bartholomew Great,1,1
+1665,20,June,27,,St Botolph Bishopsgate,11,3
+1665,20,June,27,,S Sepulchres Parish,45,18
+1665,20,June,27,,St Bartholomew Lesse,1,0
+1665,20,June,27,,St Dunstan West,5,0
+1665,20,June,27,,St Thomas Southwark,4,1
+1665,20,June,27,,St Bridget,16,3
+1665,20,June,27,,St George Southwark,7,1
+1665,20,June,27,,Trinity Minories,0,0
+1665,20,June,27,,Bri•ewel Precinct,0,0
+1665,20,June,27,,St Giles Cripplegate,42,7
+1665,20,June,27,,At the Pesthouse,3,3
+1665,20,June,27,,St Botolph Aldersgate,4,3
+1665,20,June,27,,St Olave Southwark,19,0
+1665,20,June,27,,St Gile• in the fields,185,143
+1665,20,June,27,,Lambeth Parish,4,0
+1665,20,June,27,,St Mary Islington,3,1
+1665,20,June,27,,Hackney Parish,2,0
+1665,20,June,27,,St Leonard Shoreditch,5,0
+1665,20,June,27,,St Mary Whitechappel,26,0
+1665,20,June,27,,St James Clerkenwel,13,8
+1665,20,June,27,,St Magdalen Bermondsey,6,0
+1665,20,June,27,,Rothorith Parish,1,0
+1665,20,June,27,,St Kath. near the Tower,6,0
+1665,20,June,27,,St Mary Newington,3,0
+1665,20,June,27,,Stepney Parish,37,1
+1665,20,June,27,,St Clement Danes,28,16
+1665,20,June,27,,St Martin in the fields,46,11
+1665,20,June,27,,St Margaret Westminster,38,26
+1665,20,June,27,,St Paul Covent Garden,5,2
+1665,20,June,27,,St Mary Savoy,2,0
+1665,27,June,4,July,St ALban Woodstreet,3,0
+1665,27,June,4,July,St George Botolphlane,0,0
+1665,27,June,4,July,St Martin Ludgate,1,0
+1665,27,June,4,July,Alhallows Barking,4,1
+1665,27,June,4,July,St Gregory by St Pauls,5,0
+1665,27,June,4,July,St Martin Orgars,1,0
+1665,27,June,4,July,Alhallows Breadstreet,1,0
+1665,27,June,4,July,St Hellen,0,0
+1665,27,June,4,July,St Martin Outwitch,1,0
+1665,27,June,4,July,Alhallows Great,1,0
+1665,27,June,4,July,St James Dukes place,1,0
+1665,27,June,4,July,St Martin Vintrey,0,0
+1665,27,June,4,July,Alhallows Honylane,0,0
+1665,27,June,4,July,St James Garlickhithe,1,0
+1665,27,June,4,July,St Matthew Fridaystreet,0,0
+1665,27,June,4,July,Alhallows Lesse,1,0
+1665,27,June,4,July,St John Baptist,0,0
+1665,27,June,4,July,St Maudlin Milkstreet,0,0
+1665,27,June,4,July,Alhallows Lumbardstreet,0,0
+1665,27,June,4,July,St John Evangelist,0,0
+1665,27,June,4,July,St Maudlin Oldfishstreet,1,0
+1665,27,June,4,July,Alhallows Stayning,1,0
+1665,27,June,4,July,St John Zachary,1,1
+1665,27,June,4,July,St Michael Bassishaw,8,8
+1665,27,June,4,July,Alhallows the Wall,2,0
+1665,27,June,4,July,St Katharine Coleman,1,0
+1665,27,June,4,July,St Michael Cornhil,0,0
+1665,27,June,4,July,St Alphage,0,0
+1665,27,June,4,July,St Katharine Crechurch,3,0
+1665,27,June,4,July,St Michael Crookedlane,4,2
+1665,27,June,4,July,St Andrew Hubbard,1,0
+1665,27,June,4,July,St Lawrence Jewry,0,0
+1665,27,June,4,July,St Michael Queenhithe,2,0
+1665,27,June,4,July,St Andrew Undershaft,1,0
+1665,27,June,4,July,St Lawrence Pountney,1,0
+1665,27,June,4,July,St Michael Quern,1,0
+1665,27,June,4,July,St Andrew Wardrobe,2,0
+1665,27,June,4,July,St Leonard Eastcheap,1,0
+1665,27,June,4,July,St Michael Royal,0,0
+1665,27,June,4,July,St Ann Aldersgate,0,0
+1665,27,June,4,July,St Leonard Fosterlane,0,0
+1665,27,June,4,July,St Michael Woodstreet,0,0
+1665,27,June,4,July,St Ann Blackfryers,1,0
+1665,27,June,4,July,St Magnus Parish,1,0
+1665,27,June,4,July,St Mildred Breadstreet,1,0
+1665,27,June,4,July,St Antholins Parish,0,0
+1665,27,June,4,July,St Margaret Lothbury,0,0
+1665,27,June,4,July,St Mildred Poultrey,1,0
+1665,27,June,4,July,St Austins Parish,1,0
+1665,27,June,4,July,St Margaret Moses,0,0
+1665,27,June,4,July,St Nicholas Acons,0,0
+1665,27,June,4,July,St Bartholomew Exchange,1,0
+1665,27,June,4,July,St Margaret Newfishstre.,0,0
+1665,27,June,4,July,St Nicholas Coleabby,0,0
+1665,27,June,4,July,St Bennet Fynck,1,1
+1665,27,June,4,July,St Margaret Pattons,0,0
+1665,27,June,4,July,St Nicholas Olaves,0,0
+1665,27,June,4,July,St Bennet Gracechurch,0,0
+1665,27,June,4,July,St Mary Abchurch,1,0
+1665,27,June,4,July,St Olave Hartstreet,0,0
+1665,27,June,4,July,St Bennet Paulswharf,6,2
+1665,27,June,4,July,St Mary Aldermanbury,2,2
+1665,27,June,4,July,St Olave Jewry,0,0
+1665,27,June,4,July,St Bennet Sherehog,0,0
+1665,27,June,4,July,St Mary Aldermary,0,0
+1665,27,June,4,July,St Olave Silverstreet,1,0
+1665,27,June,4,July,St Botolph Billingsgate,0,0
+1665,27,June,4,July,St Mary le Bow,0,0
+1665,27,June,4,July,St Pancras Soperlane,0,0
+1665,27,June,4,July,Christ Church,7,4
+1665,27,June,4,July,St Mary Bothaw,1,0
+1665,27,June,4,July,St Peter Cheap,0,0
+1665,27,June,4,July,St Christophers,0,0
+1665,27,June,4,July,St Mary Colechurch,0,0
+1665,27,June,4,July,St Peter Cornhil,0,0
+1665,27,June,4,July,St Clement Eastcheap,0,0
+1665,27,June,4,July,St Mary Hill,0,0
+1665,27,June,4,July,St Peter Paulswharf,0,0
+1665,27,June,4,July,St Dionis Backchurch,0,0
+1665,27,June,4,July,St Mary Mounthaw,0,0
+1665,27,June,4,July,St Peter Poor,0,0
+1665,27,June,4,July,St Dunstan East,5,0
+1665,27,June,4,July,St Mary Sommerset,0,0
+1665,27,June,4,July,St Steven Colemanstreet,4,2
+1665,27,June,4,July,St Edmund Lumbardstr.,0,0
+1665,27,June,4,July,St Mary Stayning,0,0
+1665,27,June,4,July,St Steven Walbrook,1,0
+1665,27,June,4,July,St Ethelborough,1,0
+1665,27,June,4,July,St Mary Woolchurch,0,0
+1665,27,June,4,July,St Swithin,0,0
+1665,27,June,4,July,St Faith,1,0
+1665,27,June,4,July,St Mary Woolnoth,1,0
+1665,27,June,4,July,St Thomas Apostles,1,0
+1665,27,June,4,July,St Foster,1,0
+1665,27,June,4,July,St Martin Iremongerlane,1,0
+1665,27,June,4,July,Trinity Parish,0,0
+1665,27,June,4,July,St Gabriel Fenchurch,2,0
+1665,27,June,4,July,St Andrew Holborn,48,35
+1665,27,June,4,July,St Botolph Aldgate,19,1
+1665,27,June,4,July,Saviours Southwark,7,0
+1665,27,June,4,July,St Bartholomew Great,4,4
+1665,27,June,4,July,St Botolph Bishopsgate,38,17
+1665,27,June,4,July,S Sepulchres Parish,78,48
+1665,27,June,4,July,St Bartholomew Lesse,2,0
+1665,27,June,4,July,St Dunstan West,8,5
+1665,27,June,4,July,St Thomas Southwark,5,2
+1665,27,June,4,July,St Bridget,20,7
+1665,27,June,4,July,St George Southwark,6,2
+1665,27,June,4,July,Trinity Minories,0,0
+1665,27,June,4,July,Bridewel Precinct,2,2
+1665,27,June,4,July,St Giles Cripplegate,96,32
+1665,27,June,4,July,At the Pesthouse,5,5
+1665,27,June,4,July,St Botolph Aldersgate,8,4
+1665,27,June,4,July,St Olave Southwark,14,2
+1665,27,June,4,July,St Giles in the fields,203,149
+1665,27,June,4,July,Lambeth Parish,3,0
+1665,27,June,4,July,St Mary Islington,4,2
+1665,27,June,4,July,Hackney Parish,2,0
+1665,27,June,4,July,St Leonard Shoreditch,21,7
+1665,27,June,4,July,St Mary Whitechappel,18,6
+1665,27,June,4,July,St James Clerkenwel,34,10
+1665,27,June,4,July,St Magdalen Bermondsey,11,0
+1665,27,June,4,July,Rothorith Parish,3,0
+1665,27,June,4,July,St Kath. near the Tower,1,0
+1665,27,June,4,July,St Mary Newington,4,0
+1665,27,June,4,July,Stepney Parish,41,2
+1665,27,June,4,July,St Clement Danes,33,19
+1665,27,June,4,July,St Martin in the fields,114,55
+1665,27,June,4,July,St Margaret Westminster,50,26
+1665,27,June,4,July,St Paul Covent Garden,4,1
+1665,27,June,4,July,St Mary Savoy,7,4
+1665,4,July,11,,St ALban Woodstreet,5,1
+1665,4,July,11,,St George Botolphlane,0,0
+1665,4,July,11,,St Martin Ludgate,2,1
+1665,4,July,11,,Alhallows Barking,2,0
+1665,4,July,11,,St Gregory by St Pauls,0,0
+1665,4,July,11,,St Martin Orgars,0,0
+1665,4,July,11,,Alhallows Breadstreet,0,0
+1665,4,July,11,,St Hellen,2,2
+1665,4,July,11,,St Martin Outwitch,1,0
+1665,4,July,11,,Alhallows Great,1,0
+1665,4,July,11,,St James Dukes place,1,0
+1665,4,July,11,,St Martin Vintrey,1,0
+1665,4,July,11,,Alhallows Honylane,0,0
+1665,4,July,11,,St James Garlickhithe,1,0
+1665,4,July,11,,St Matthew Fridaystreet,0,0
+1665,4,July,11,,Alhallows Lesse,1,0
+1665,4,July,11,,St John Baptist,0,0
+1665,4,July,11,,St Maudlin Milkstreet,0,0
+1665,4,July,11,,Alhallows Lumbardstreet,0,0
+1665,4,July,11,,St John Evangelist,0,0
+1665,4,July,11,,St Maudlin Oldfishstreet,0,0
+1665,4,July,11,,Alhallows Staining,1,0
+1665,4,July,11,,St John Zachary,0,0
+1665,4,July,11,,St Michael Bassishaw,5,4
+1665,4,July,11,,Alhallows the Wall,4,3
+1665,4,July,11,,St Katharine Coleman,1,0
+1665,4,July,11,,St Michael Cornhil,0,0
+1665,4,July,11,,St Alphage,1,0
+1665,4,July,11,,St Katharine Crechurch,0,0
+1665,4,July,11,,St Michael Crookedlane,4,3
+1665,4,July,11,,St Andrew Hubbard,0,0
+1665,4,July,11,,St Lawrence Jewry,0,0
+1665,4,July,11,,St Michael Queenhithe,3,0
+1665,4,July,11,,St Andrew Undershaft,3,0
+1665,4,July,11,,St Lawrence Pountney,0,0
+1665,4,July,11,,St Michael Quern,1,0
+1665,4,July,11,,St Andrew Wardrobe,1,0
+1665,4,July,11,,St Leonard Eastcheap,0,0
+1665,4,July,11,,St Michael Royal,0,0
+1665,4,July,11,,St Ann Aldersgate,1,0
+1665,4,July,11,,St Leonard Fosterlane,0,0
+1665,4,July,11,,St Michael Woodstreet,0,0
+1665,4,July,11,,St Ann Blackfryers,7,6
+1665,4,July,11,,St Magnus Parish,1,0
+1665,4,July,11,,St Mildred Breadstreet,0,0
+1665,4,July,11,,St Antholins Parish,1,0
+1665,4,July,11,,St Margaret Lothbury,0,0
+1665,4,July,11,,St Mildred Poultrey,0,0
+1665,4,July,11,,St Austins Parish,0,0
+1665,4,July,11,,St Margaret Moses,0,0
+1665,4,July,11,,St Nicholas Acons,0,0
+1665,4,July,11,,St Bartholomew Exchange,1,0
+1665,4,July,11,,St Margaret Newfishstreet,0,0
+1665,4,July,11,,St Nicholas Coleabby,0,0
+1665,4,July,11,,St Bennet Fynck,0,0
+1665,4,July,11,,St Margaret Pattons,0,0
+1665,4,July,11,,St Nicholas Olaves,0,0
+1665,4,July,11,,St Bennet Gracechurch,2,0
+1665,4,July,11,,St Mary Abchurch,1,0
+1665,4,July,11,,St Olave Hartstreet,0,0
+1665,4,July,11,,St Bennet Paulswharf,7,0
+1665,4,July,11,,St Mary Aldermanbury,0,0
+1665,4,July,11,,St Olave Jewry,0,0
+1665,4,July,11,,St Bennet Sherehog,0,0
+1665,4,July,11,,St Mary Aldermary,0,0
+1665,4,July,11,,St Olave Silverstreet,4,1
+1665,4,July,11,,St Botolph Billingsgate,0,0
+1665,4,July,11,,St Mary le Bow,0,0
+1665,4,July,11,,St Pancras Soperlane,0,0
+1665,4,July,11,,Christs Church,5,3
+1665,4,July,11,,St Mary Bothaw,0,0
+1665,4,July,11,,St Peter Cheap,0,0
+1665,4,July,11,,St Christophers,0,0
+1665,4,July,11,,St Mary Colechurch,0,0
+1665,4,July,11,,St Peter Cornhil,0,0
+1665,4,July,11,,St Clement Eastcheap,0,0
+1665,4,July,11,,St Mary Hill,0,0
+1665,4,July,11,,St Peter Paulswharf,0,0
+1665,4,July,11,,St Dionis Backchurch,1,0
+1665,4,July,11,,St Mary Mounthaw,0,0
+1665,4,July,11,,St Peter Poor,1,0
+1665,4,July,11,,St Dunstan East,2,0
+1665,4,July,11,,St Mary Sommerset,2,1
+1665,4,July,11,,St Steven Colemanstreet,2,1
+1665,4,July,11,,St Edmund Lumbardstr.,0,0
+1665,4,July,11,,St Mary Stayning,0,0
+1665,4,July,11,,St Steven Walbrook,0,0
+1665,4,July,11,,St Ethelborough,2,0
+1665,4,July,11,,St Mary Woolchurch,0,0
+1665,4,July,11,,St Swithin,2,1
+1665,4,July,11,,St Faith,1,0
+1665,4,July,11,,St Mary Woolnoth,0,0
+1665,4,July,11,,St Thomas Apostle,1,1
+1665,4,July,11,,St Foster,0,0
+1665,4,July,11,,St Martin Iremongerlane,0,0
+1665,4,July,11,,Trinity Parish,1,0
+1665,4,July,11,,St Gabriel Fenchurch,0,0
+1665,4,July,11,,St Andrew Holborn,66,40
+1665,4,July,11,,St Botolph Aldgate,24,4
+1665,4,July,11,,Saviours Southwark,21,1
+1665,4,July,11,,St Bartholomew Great,4,4
+1665,4,July,11,,St Botolph Bishopsgate,37,20
+1665,4,July,11,,S. Sepulchres Parish,117,81
+1665,4,July,11,,St Bartholomew Lesse,0,0
+1665,4,July,11,,St Dunstan West,19,9
+1665,4,July,11,,St Thomas Southwark,7,5
+1665,4,July,11,,St Bridget,24,14
+1665,4,July,11,,St George Southwark,13,4
+1665,4,July,11,,Trinity Minories,0,0
+1665,4,July,11,,•ridewel Precinct,1,1
+1665,4,July,11,,St Giles Cripplegate,103,49
+1665,4,July,11,,At the Pesthouse,6,6
+1665,4,July,11,,St Botolph Aldersgate,11,9
+1665,4,July,11,,St Olave Southwark,20,6
+1665,4,July,11,,St Giles in the fields,268,213
+1665,4,July,11,,Lambeth Parish,4,0
+1665,4,July,11,,St Mary Islington,3,2
+1665,4,July,11,,•ackney Parish,1,0
+1665,4,July,11,,St Leonard Shoreditch,21,13
+1665,4,July,11,,St Mary Whitechappel,16,3
+1665,4,July,11,,St James Clerkenwel,65,50
+1665,4,July,11,,St Magdalen Bermondsey,14,0
+1665,4,July,11,,Rotho•ith Parish,7,3
+1665,4,July,11,,St Kath. near the Tower,5,1
+1665,4,July,11,,St Mary Newington,4,0
+1665,4,July,11,,Stepney Parish,47,1
+1665,4,July,11,,St Clement Danes,29,15
+1665,4,July,11,,St Martin in the fields,153,101
+1665,4,July,11,,St Margaret Westminster,58,34
+1665,4,July,11,,•t Paul Covent Garden,6,4
+1665,4,July,11,,St Mary Savoy,8,6
+1665,11,July,18,,St ALban Woodstreet,4,2
+1665,11,July,18,,St George Botolphlane,0,0
+1665,11,July,18,,St Martin Ludgate,0,0
+1665,11,July,18,,Alhallows Barking,4,0
+1665,11,July,18,,St Gregory by St Pauls,6,3
+1665,11,July,18,,St Martin Orgars,0,0
+1665,11,July,18,,Alhallows Breadstreet,0,0
+1665,11,July,18,,St Hellen,0,0
+1665,11,July,18,,St Martin Outwitch,0,0
+1665,11,July,18,,Alhallows Great,2,1
+1665,11,July,18,,St James Dukes place,1,0
+1665,11,July,18,,St Martin Vintrey,1,1
+1665,11,July,18,,Alhallows Honylane,0,0
+1665,11,July,18,,St James Garlickhithe,1,0
+1665,11,July,18,,St Matthew Fridaystreet,0,0
+1665,11,July,18,,Alhallows Lesse,0,0
+1665,11,July,18,,St John Baptist,0,0
+1665,11,July,18,,St Maudlin Milkstreet,0,0
+1665,11,July,18,,Alhallows Lumbardstreet,0,0
+1665,11,July,18,,St John Evangelist,0,0
+1665,11,July,18,,St Maudlin Oldfishstreet,1,0
+1665,11,July,18,,Alhallows Staining,4,2
+1665,11,July,18,,St John Zachary,2,1
+1665,11,July,18,,St Michael Bassishaw,13,10
+1665,11,July,18,,Alhallows the Wall,7,5
+1665,11,July,18,,St Katharine Coleman,2,0
+1665,11,July,18,,St Michael Cornhil,1,0
+1665,11,July,18,,St Alphage,1,0
+1665,11,July,18,,St Katharine Crechurch,1,0
+1665,11,July,18,,St Michael Crookedlane,3,3
+1665,11,July,18,,St Andrew Hubbard,1,1
+1665,11,July,18,,St Lawrence Jewry,0,0
+1665,11,July,18,,St Michael Queenhithe,2,0
+1665,11,July,18,,St Andrew Undershaft,1,1
+1665,11,July,18,,St Lawrence Pountney,2,0
+1665,11,July,18,,St Michael Quern,0,0
+1665,11,July,18,,St Andrew Wardrobe,5,2
+1665,11,July,18,,St Leonard Eastcheap,0,0
+1665,11,July,18,,St Michael Royal,2,0
+1665,11,July,18,,St Ann Aldersgate,2,0
+1665,11,July,18,,St Leonard Fosterlane,2,1
+1665,11,July,18,,St Michael Woodstreet,1,0
+1665,11,July,18,,St Ann Blackfryers,10,5
+1665,11,July,18,,St Magnus Parish,0,0
+1665,11,July,18,,St Mildred Breadstreet,0,0
+1665,11,July,18,,St Antholins Parish,0,0
+1665,11,July,18,,St Margaret Lothbury,1,1
+1665,11,July,18,,St Mildred Poultrey,0,0
+1665,11,July,18,,St Austins Parish,1,1
+1665,11,July,18,,St Margaret Moses,0,0
+1665,11,July,18,,St Nicholas Acons,1,0
+1665,11,July,18,,St Bartholomew Exchange,0,0
+1665,11,July,18,,St Margaret Newfishstreet,1,0
+1665,11,July,18,,St Nicholas Coleabby,0,0
+1665,11,July,18,,St Bennet Fynck,0,0
+1665,11,July,18,,St Margaret Pattons,0,0
+1665,11,July,18,,St Nicholas Olaves,1,0
+1665,11,July,18,,St Bennet Gracechurch,0,0
+1665,11,July,18,,St Mary Abchurch,1,0
+1665,11,July,18,,St Olave Hartstreet,4,0
+1665,11,July,18,,St Bennet Paulswharf,6,1
+1665,11,July,18,,St Mary Aldermanbury,0,0
+1665,11,July,18,,St Olave Jewry,0,0
+1665,11,July,18,,St Bennet Sherehog,0,0
+1665,11,July,18,,St Mary Aldermary,1,0
+1665,11,July,18,,St Olave Silverstreet,5,1
+1665,11,July,18,,St Botolph Billingsgate,0,0
+1665,11,July,18,,St Mary le Bow,0,0
+1665,11,July,18,,St Pancras Soperlane,0,0
+1665,11,July,18,,Christs Church,12,6
+1665,11,July,18,,St Mary Bothaw,0,0
+1665,11,July,18,,St Peter Cheap,0,0
+1665,11,July,18,,St Christophers,1,1
+1665,11,July,18,,St Mary Colechurch,0,0
+1665,11,July,18,,St Peter Cornhil,2,2
+1665,11,July,18,,St Clement Eastcheap,0,0
+1665,11,July,18,,St Mary Hill,0,0
+1665,11,July,18,,St Peter Paulswharf,0,0
+1665,11,July,18,,St Dionis Backchurch,0,0
+1665,11,July,18,,St Mary Mounthaw,0,0
+1665,11,July,18,,St Peter Poor,2,1
+1665,11,July,18,,St Dunstan East,2,0
+1665,11,July,18,,St Mary Sommerset,1,1
+1665,11,July,18,,St Steven Colemanstreet,6,1
+1665,11,July,18,,St Edmund Lumbardstr.,0,0
+1665,11,July,18,,St Mary Stayning,1,1
+1665,11,July,18,,St Steven Walbrook,0,0
+1665,11,July,18,,St Ethelborough,3,0
+1665,11,July,18,,St Mary Woolchurch,0,0
+1665,11,July,18,,St Swithin,1,0
+1665,11,July,18,,St Faith,3,0
+1665,11,July,18,,St Mary Woolnoth,0,0
+1665,11,July,18,,St Thomas Apostle,3,1
+1665,11,July,18,,St Foster,0,0
+1665,11,July,18,,St Martin Iremongerlane,0,0
+1665,11,July,18,,Trinity Parish,0,0
+1665,11,July,18,,St Gabriel Fenchurch,0,0
+1665,11,July,18,,St Andrew Holborn,117,91
+1665,11,July,18,,St Botolph Aldgate,35,14
+1665,11,July,18,,Saviours Southwark,24,1
+1665,11,July,18,,St Bartholomew Great,13,9
+1665,11,July,18,,St Botolph Bishopsgate,65,39
+1665,11,July,18,,S. Sepulchres Parish,150,100
+1665,11,July,18,,St Bartholomew Lesse,5,0
+1665,11,July,18,,St Dunstan West,4,3
+1665,11,July,18,,St Thomas Southwark,3,2
+1665,11,July,18,,St Bridget,31,16
+1665,11,July,18,,St George Southwark,13,4
+1665,11,July,18,,Trinity Minories,1,1
+1665,11,July,18,,Bridewel Precinct,0,0
+1665,11,July,18,,St Giles Cripplegate,232,114
+1665,11,July,18,,At the Pesthouse,8,8
+1665,11,July,18,,St Botolph Aldersgate,8,5
+1665,11,July,18,,St Olave Southwark,26,9
+1665,11,July,18,,St Giles in the fields,268,218
+1665,11,July,18,,Lambeth Parish,8,0
+1665,11,July,18,,St Mary Islington,17,14
+1665,11,July,18,,Hackney Parish,2,0
+1665,11,July,18,,St Leonard Shoreditch,64,40
+1665,11,July,18,,St Mary Whitechappel,42,21
+1665,11,July,18,,St James Clerkenwel,89,78
+1665,11,July,18,,St Magdalen Bermondsey,12,0
+1665,11,July,18,,Rothorith Parish,9,7
+1665,11,July,18,,St Kath. near the Tower,6,2
+1665,11,July,18,,St Mary Newington,6,4
+1665,11,July,18,,Stepney Parish,72,33
+1665,11,July,18,,St Clement Danes,31,24
+1665,11,July,18,,St Martin in the fields,171,113
+1665,11,July,18,,St Margaret Westminster,79,56
+1665,11,July,18,,St Paul Covent Garden,5,3
+1665,11,July,18,,St Mary Savoy,4,4
+1665,18,July,25,,St ALban Woodstreet,2,1
+1665,18,July,25,,St George Botolphlane,0,0
+1665,18,July,25,,St Martin Ludgate,1,1
+1665,18,July,25,,Alhallows Barking,2,0
+1665,18,July,25,,St Gregory by St Pauls,12,3
+1665,18,July,25,,St Martin Orgars,0,0
+1665,18,July,25,,Alhallows Breadstreet,0,0
+1665,18,July,25,,St Hellen,2,2
+1665,18,July,25,,St Martin Outwitch,2,1
+1665,18,July,25,,Alhallows Great,6,2
+1665,18,July,25,,St James Dukes place,0,0
+1665,18,July,25,,St Martin Vintrey,6,5
+1665,18,July,25,,Alhallows Honylane,0,0
+1665,18,July,25,,St James Garlickhithe,2,0
+1665,18,July,25,,St Matthew Fridaystreet,0,0
+1665,18,July,25,,Alhallows Lesse,2,2
+1665,18,July,25,,St John Baptist,1,0
+1665,18,July,25,,St Maudlin Milkstreet,1,0
+1665,18,July,25,,Alhallows Lumbardstree•,2,0
+1665,18,July,25,,St John Evangelist,0,0
+1665,18,July,25,,St Maudlin Oldfishstreet,1,1
+1665,18,July,25,,Alhallows Stayning,1,1
+1665,18,July,25,,St John Zachary,2,2
+1665,18,July,25,,St Michael Bassishaw,24,22
+1665,18,July,25,,Alhallows the Wall,8,5
+1665,18,July,25,,St Katharine Coleman,2,0
+1665,18,July,25,,St Michael Cornhil,1,0
+1665,18,July,25,,St Alphage,4,0
+1665,18,July,25,,St Katharine Crechurch,1,0
+1665,18,July,25,,St Michael Crookedlane,0,0
+1665,18,July,25,,St Andrew Hubbard,4,3
+1665,18,July,25,,St Lawrence Jewry,1,0
+1665,18,July,25,,St Michael Queenhithe,2,2
+1665,18,July,25,,St Andrew Undershaft,6,4
+1665,18,July,25,,St Lawrence Pountney,0,0
+1665,18,July,25,,St Michael Quern,1,0
+1665,18,July,25,,St Andrew Wardrobe,6,2
+1665,18,July,25,,St Leonard Eastcheap,2,0
+1665,18,July,25,,St Michael Royal,0,0
+1665,18,July,25,,St Ann Aldersgate,0,0
+1665,18,July,25,,St Leonard Fosterlane,2,1
+1665,18,July,25,,St Michael Woodstreet,1,0
+1665,18,July,25,,St Ann Blackfryers,19,5
+1665,18,July,25,,St Magnus Parish,3,1
+1665,18,July,25,,St Mildred Breadstreet,0,0
+1665,18,July,25,,St Antholins Parish,0,0
+1665,18,July,25,,St Margaret Lothbury,1,0
+1665,18,July,25,,St Mildred Poultrey,2,2
+1665,18,July,25,,St Austins Parish,1,0
+1665,18,July,25,,St Margaret Moses,0,0
+1665,18,July,25,,St Nicholas Acons,0,0
+1665,18,July,25,,St Bartholomew Exchange,0,0
+1665,18,July,25,,St Margaret Newfishstre.,2,0
+1665,18,July,25,,St Nicholas Coleabby,1,0
+1665,18,July,25,,St Bennet Fynck,0,0
+1665,18,July,25,,St Margaret Pattons,0,0
+1665,18,July,25,,St Nicholas Olaves,0,0
+1665,18,July,25,,St Bennet Gracechurch,0,0
+1665,18,July,25,,St Mary Abchurch,0,0
+1665,18,July,25,,St Olave Hartstreet,4,1
+1665,18,July,25,,St Bennet Paulswharf,10,2
+1665,18,July,25,,St Mary Aldermanbury,5,1
+1665,18,July,25,,St Olave Jewry,0,0
+1665,18,July,25,,St Bennet Sherehog,0,0
+1665,18,July,25,,St Mary Aldermary,1,1
+1665,18,July,25,,St Olave Silverstreet,6,0
+1665,18,July,25,,St Botolph Billingsgate,0,0
+1665,18,July,25,,St Ma•• le Bow,0,0
+1665,18,July,25,,St Pancras Soperlane,0,0
+1665,18,July,25,,Christ Church,16,12
+1665,18,July,25,,St Mary Bothaw,0,0
+1665,18,July,25,,St Peter Cheap,0,0
+1665,18,July,25,,St Christophers,1,1
+1665,18,July,25,,St Mary Colechurch,0,0
+1665,18,July,25,,St Peter Cornhil,4,3
+1665,18,July,25,,St Clement Eastcheap,1,1
+1665,18,July,25,,St Mary Hill,0,0
+1665,18,July,25,,St Peter Paulswharf,1,0
+1665,18,July,25,,St Dionis Backchurch,0,0
+1665,18,July,25,,St Mary Mounthaw,1,1
+1665,18,July,25,,St Peter Poor,2,2
+1665,18,July,25,,St Dunstan East,1,0
+1665,18,July,25,,St Mary Sommerset,1,0
+1665,18,July,25,,St Steven Colemanstreet,7,4
+1665,18,July,25,,St Edmund Lumbardstr.,0,0
+1665,18,July,25,,St Mary Stayning,1,0
+1665,18,July,25,,St Steven Walbrook,0,0
+1665,18,July,25,,St Ethelborough,17,14
+1665,18,July,25,,St Mary Woolchurch,0,0
+1665,18,July,25,,St Swithin,9,7
+1665,18,July,25,,St Faith,0,0
+1665,18,July,25,,St Mary Woolnoth,1,0
+1665,18,July,25,,St Thomas Apostles,9,7
+1665,18,July,25,,St Foster,3,3
+1665,18,July,25,,St Martin Iremongerlane,1,0
+1665,18,July,25,,Trinity Parish,0,0
+1665,18,July,25,,St Gabriel Fenchurch,0,0
+1665,18,July,25,,St Andrew Holborn,163,142
+1665,18,July,25,,St Botolph Aldgate,57,34
+1665,18,July,25,,Saviours Southwark,30,15
+1665,18,July,25,,St Bartholomew Great,15,7
+1665,18,July,25,,St Botolph Bishopsgate,105,77
+1665,18,July,25,,S Sepulchres Parish,207,141
+1665,18,July,25,,St Bartholomew Lesse,2,0
+1665,18,July,25,,St Dunstan West,17,11
+1665,18,July,25,,St Thomas Southwark,8,6
+1665,18,July,25,,St Bridget,59,39
+1665,18,July,25,,St George Southwark,28,20
+1665,18,July,25,,Trinity Minories,1,1
+1665,18,July,25,,Bridewel Precinct,7,4
+1665,18,July,25,,St Giles Cripplegate,421,208
+1665,18,July,25,,At the Pesthouse,9,8
+1665,18,July,25,,St Botolph Aldersgate,35,17
+1665,18,July,25,,St Olave Southwark,46,25
+1665,18,July,25,,"Buri•d n the 16 Parishes without the Walls, and at the Pesthouse",1210,755
+1665,18,July,25,,St Giles in the fields,370,323
+1665,18,July,25,,Lambeth Parish,8,2
+1665,18,July,25,,St Mary Islington,12,7
+1665,18,July,25,,Hackney Parish,7,5
+1665,18,July,25,,St Leonard Shoreditch,84,50
+1665,18,July,25,,St Mary Whitechappel,84,48
+1665,18,July,25,,St James Clerkenwel,143,121
+1665,18,July,25,,St Magdalen Bermondsey,11,2
+1665,18,July,25,,Rothorith Parish,6,4
+1665,18,July,25,,St Kath. near the Tower,11,4
+1665,18,July,25,,St Mary Newington,11,4
+1665,18,July,25,,Stepney Parish,110,58
+1665,18,July,25,,St Clement Danes,62,45
+1665,18,July,25,,St Martin in the fields,270,176
+1665,18,July,25,,St Margaret Westminster,120,98
+1665,18,July,25,,St Paul Covent Garden,13,5
+1665,18,July,25,,St Mary Savoy,12,8
+1665,18,July,25,,Where•• at the Pesthouse,4,4
+1665,25,July,1,August,St ALban Woodstreet,1,0
+1665,25,July,1,August,St George Botolphlane,0,0
+1665,25,July,1,August,St Martin Ludgate,1,0
+1665,25,July,1,August,Alhallows Barking,4,0
+1665,25,July,1,August,St Gregory by St Pauls,9,5
+1665,25,July,1,August,St Martin Orgars,2,0
+1665,25,July,1,August,Alh•llows Breadstreet,0,0
+1665,25,July,1,August,St Hellen,1,1
+1665,25,July,1,August,St Martin Outwitch,2,0
+1665,25,July,1,August,A•••llows Great,5,2
+1665,25,July,1,August,St James Dukes place,6,4
+1665,25,July,1,August,St Martin Vintrey,6,4
+1665,25,July,1,August,Alhallows Honylane,0,0
+1665,25,July,1,August,St James Garlickhithe,1,1
+1665,25,July,1,August,St Matthew Fridaystreet,2,0
+1665,25,July,1,August,Alhallows Lesse,3,1
+1665,25,July,1,August,St John Baptist,1,1
+1665,25,July,1,August,St Maudlin Milkstreet,0,0
+1665,25,July,1,August,Alhallows Lumbardstreet,2,1
+1665,25,July,1,August,St John Evangelist,0,0
+1665,25,July,1,August,St Maudlin Oldfishstreet,0,0
+1665,25,July,1,August,Alhallows Stayning,5,0
+1665,25,July,1,August,St John Zachary,1,1
+1665,25,July,1,August,St Michael Bassishaw,8,6
+1665,25,July,1,August,Alhallows the Wall,6,3
+1665,25,July,1,August,St Katharine Coleman,0,0
+1665,25,July,1,August,St Michael Cornhil,0,0
+1665,25,July,1,August,St Alphage,3,3
+1665,25,July,1,August,St Katharine Crechurch,0,0
+1665,25,July,1,August,St Michael Crookedlane,2,2
+1665,25,July,1,August,St Andrew Hubbard,1,0
+1665,25,July,1,August,St Lawrence Jewry,0,0
+1665,25,July,1,August,St Michael Queenhithe,3,0
+1665,25,July,1,August,St Andrew Undershaft,10,6
+1665,25,July,1,August,St Lawrence Pountney,1,0
+1665,25,July,1,August,St Michael Quern,2,2
+1665,25,July,1,August,St Andrew Wardrobe,2,0
+1665,25,July,1,August,St Leonard Eastcheap,0,0
+1665,25,July,1,August,St Michael Royal,1,0
+1665,25,July,1,August,St Ann Aldersgate,5,0
+1665,25,July,1,August,St Leonard Fosterlane,6,5
+1665,25,July,1,August,St Michael Woodstreet,3,3
+1665,25,July,1,August,St Ann Blackfryers,10,6
+1665,25,July,1,August,St Magnus Parish,2,1
+1665,25,July,1,August,St Mildred Breadstreet,0,0
+1665,25,July,1,August,St Antholins Parish,0,0
+1665,25,July,1,August,St Margaret Lothbury,0,0
+1665,25,July,1,August,St Mildred Poultrey,2,1
+1665,25,July,1,August,St Austins Parish,0,0
+1665,25,July,1,August,St Margaret Moses,0,0
+1665,25,July,1,August,St Nicholas Acons,1,1
+1665,25,July,1,August,St Bartholomew Exchange,0,0
+1665,25,July,1,August,St Margaret Newfishstre.,0,0
+1665,25,July,1,August,St Nicholas Coleabby,2,1
+1665,25,July,1,August,St Bennet Fynck,0,0
+1665,25,July,1,August,St Margaret Pattons,0,0
+1665,25,July,1,August,St Nicholas Olaves,0,0
+1665,25,July,1,August,St Bennet Gracechurch,1,1
+1665,25,July,1,August,St Mary Abchurch,1,0
+1665,25,July,1,August,St Olave Hartstreet,9,3
+1665,25,July,1,August,St Bennet Paulswharf,6,4
+1665,25,July,1,August,St Mary Aldermanbury,6,2
+1665,25,July,1,August,St Olave Jewry,0,0
+1665,25,July,1,August,St Bennet Sherehog,0,0
+1665,25,July,1,August,St Mary Aldermary,1,0
+1665,25,July,1,August,St Olave Silverstreet,15,3
+1665,25,July,1,August,St Botolph Billingsgate,0,0
+1665,25,July,1,August,St Mary le Bow,1,1
+1665,25,July,1,August,St Pancras Soperlane,0,0
+1665,25,July,1,August,Christ Church,17,13
+1665,25,July,1,August,St Mary Bothaw,0,0
+1665,25,July,1,August,St Peter Cheap,0,0
+1665,25,July,1,August,St Christophers,3,2
+1665,25,July,1,August,St Mary Colechurch,0,0
+1665,25,July,1,August,St Peter Cornhil,3,2
+1665,25,July,1,August,St Clement Eastcheap,0,0
+1665,25,July,1,August,St Mary Hill,2,0
+1665,25,July,1,August,St Peter Paulswharf,1,0
+1665,25,July,1,August,St Dionis Backchurch,2,0
+1665,25,July,1,August,St Mary Mounthaw,2,2
+1665,25,July,1,August,St Peter Poor,0,0
+1665,25,July,1,August,St Dunstan East,2,0
+1665,25,July,1,August,St Mary Sommerset,3,2
+1665,25,July,1,August,St Steven Colemanstreet,11,7
+1665,25,July,1,August,St Edmund Lumbardstr.,0,0
+1665,25,July,1,August,St Mary Stayning,0,0
+1665,25,July,1,August,St Steven Walbrook,1,0
+1665,25,July,1,August,St Ethelborough,4,2
+1665,25,July,1,August,St Mary Woolchurch,1,0
+1665,25,July,1,August,St Swithin,4,2
+1665,25,July,1,August,St Faith,0,0
+1665,25,July,1,August,St Mary Woolnoth,1,0
+1665,25,July,1,August,St Thomas Apostles,4,2
+1665,25,July,1,August,St Foster,2,1
+1665,25,July,1,August,St Martin Iremongerlane,1,1
+1665,25,July,1,August,Trinity Parish,1,0
+1665,25,July,1,August,St Gabriel Fenchurch,1,0
+1665,25,July,1,August,St Andrew Holborn,216,193
+1665,25,July,1,August,St Botolph Aldgate,92,65
+1665,25,July,1,August,Saviours Southwark,52,29
+1665,25,July,1,August,St Bartholomew Great,14,10
+1665,25,July,1,August,St Botolph Bishopsgate,116,80
+1665,25,July,1,August,S Sepulchres Parish,250,160
+1665,25,July,1,August,St Bartholomew Lesse,5,2
+1665,25,July,1,August,St Dunstan West,15,10
+1665,25,July,1,August,St Thomas Southwark,5,2
+1665,25,July,1,August,St Bridget,53,36
+1665,25,July,1,August,St George Southwark,36,26
+1665,25,July,1,August,Trinity Minories,5,4
+1665,25,July,1,August,Bridewel Precinct,2,2
+1665,25,July,1,August,St Giles Cripplegate,554,302
+1665,25,July,1,August,At the Pesthouse,10,10
+1665,25,July,1,August,St Botolph Aldersgate,37,23
+1665,25,July,1,August,St Olave Southwark,77,36
+1665,25,July,1,August,St Giles in the fields,282,229
+1665,25,July,1,August,Lambeth Parish,4,2
+1665,25,July,1,August,St Mary Islington,27,23
+1665,25,July,1,August,Hackney Parish,6,5
+1665,25,July,1,August,St Leonard Shoreditch,110,65
+1665,25,July,1,August,St Mary Whitechappel,104,79
+1665,25,July,1,August,St James Clerkenwel,103,92
+1665,25,July,1,August,St Magdalen Bermondsey,14,2
+1665,25,July,1,August,Rothorith Parish,7,4
+1665,25,July,1,August,St Kath. near the Tower,10,4
+1665,25,July,1,August,St Mary Newington,10,6
+1665,25,July,1,August,Stepney Parish,127,76
+1665,25,July,1,August,St Clement Danes,60,42
+1665,25,July,1,August,St Martin in the fields,226,160
+1665,25,July,1,August,St Margaret Westminster,133,101
+1665,25,July,1,August,St Paul Covent Garden,13,12
+1665,25,July,1,August,St Mary Savoy,11,7
+1665,1,August,8,,St ALban Woodstreet,9,8
+1665,1,August,8,,St George Botolphlane,0,0
+1665,1,August,8,,St Martin Ludgate,2,2
+1665,1,August,8,,Alhallows Barking,8,3
+1665,1,August,8,,St Gregory by St Pauls,12,6
+1665,1,August,8,,St Martin Orgars,2,1
+1665,1,August,8,,•lhallows Breadstreet,3,1
+1665,1,August,8,,St Hellen,3,2
+1665,1,August,8,,St Martin Outwitch,2,2
+1665,1,August,8,,Alhallows Great,2,0
+1665,1,August,8,,St James Dukes place,7,6
+1665,1,August,8,,St Martin Vintrey,7,4
+1665,1,August,8,,Alhallows Honylane,0,0
+1665,1,August,8,,St James Garlickhithe,0,0
+1665,1,August,8,,St Matthew Fridaystreet,1,0
+1665,1,August,8,,Alhallows Lesse,2,1
+1665,1,August,8,,St John Baptist,2,2
+1665,1,August,8,,St Maudlin Milkstreet,1,1
+1665,1,August,8,,Alhallows Lumbardstreet,4,3
+1665,1,August,8,,St John Evangelist,0,0
+1665,1,August,8,,St Maudlin Oldfishstreet,2,2
+1665,1,August,8,,Alhallows Staining,3,1
+1665,1,August,8,,St John Zachary,1,1
+1665,1,August,8,,St Michael Bassishaw,11,7
+1665,1,August,8,,Alhallows the Wall,15,13
+1665,1,August,8,,St Katharine Coleman,0,0
+1665,1,August,8,,St Michael Cornhil,2,0
+1665,1,August,8,,St Alphage,14,5
+1665,1,August,8,,St Katharine Crechurch,2,1
+1665,1,August,8,,St Michael Crookedlane,1,0
+1665,1,August,8,,St Andrew Hubbard,1,0
+1665,1,August,8,,St Lawrence Jewry,3,1
+1665,1,August,8,,St Michael Queenhithe,2,1
+1665,1,August,8,,St Andrew Undershaft,9,9
+1665,1,August,8,,St Lawrence Pountney,1,0
+1665,1,August,8,,St Michael Quern,0,0
+1665,1,August,8,,St Andrew Wardrobe,11,8
+1665,1,August,8,,St Leonard Eastcheap,0,0
+1665,1,August,8,,St Michael Royal,1,1
+1665,1,August,8,,St Ann Aldersgate,5,1
+1665,1,August,8,,St Leonard Fosterlane,11,11
+1665,1,August,8,,St Michael Woodstreet,3,1
+1665,1,August,8,,St Ann Blackfryers,21,15
+1665,1,August,8,,St Magnus Parish,3,2
+1665,1,August,8,,St Mildred Breadstreet,1,0
+1665,1,August,8,,St Antholins Parish,0,0
+1665,1,August,8,,St Margaret Lothbury,9,6
+1665,1,August,8,,St Mildred Poultrey,3,2
+1665,1,August,8,,St Austins Parish,0,0
+1665,1,August,8,,St Margaret Moses,0,0
+1665,1,August,8,,St Nicholas Acons,0,0
+1665,1,August,8,,St Bartholomew Exchange,2,0
+1665,1,August,8,,St Margaret Newfishstreet,0,0
+1665,1,August,8,,St Nicholas Coleabby,1,1
+1665,1,August,8,,St Bennet Fynck,1,0
+1665,1,August,8,,St Margaret Pattons,1,0
+1665,1,August,8,,St Nicholas Olaves,2,1
+1665,1,August,8,,St Bennet Gracechurch,0,0
+1665,1,August,8,,St Mary Abchurch,2,0
+1665,1,August,8,,St Olave Hartstreet,4,2
+1665,1,August,8,,St Bennet Paulswharf,9,2
+1665,1,August,8,,St Mary Aldermanbury,5,1
+1665,1,August,8,,St Olave Jewry,0,0
+1665,1,August,8,,St Bennet Sherehog,0,0
+1665,1,August,8,,St Mary Aldermary,5,3
+1665,1,August,8,,St Olave Silverstreet,17,8
+1665,1,August,8,,St Botolph Billingsgate,0,0
+1665,1,August,8,,St Mary le Bow,3,1
+1665,1,August,8,,St Pancras Soperlane,0,0
+1665,1,August,8,,Christs Church,22,15
+1665,1,August,8,,St Mary Bothaw,1,0
+1665,1,August,8,,St Peter Cheap,0,0
+1665,1,August,8,,St Christophers,0,0
+1665,1,August,8,,St Mary Colechurch,0,0
+1665,1,August,8,,St Peter Cornhil,3,3
+1665,1,August,8,,St Clement Eastcheap,1,0
+1665,1,August,8,,St Mary Hill,0,0
+1665,1,August,8,,St Peter Paulswharf,1,1
+1665,1,August,8,,St Dionis Backchurch,2,1
+1665,1,August,8,,St Mary Mounthaw,0,0
+1665,1,August,8,,St Peter Poor,1,1
+1665,1,August,8,,St Dunstan East,0,0
+1665,1,August,8,,St Mary Sommerset,4,4
+1665,1,August,8,,St Steven Colemanstreet,15,10
+1665,1,August,8,,St Edmund Lumbardstr.,0,0
+1665,1,August,8,,St Mary Stayning,1,0
+1665,1,August,8,,St Steven Walbrook,0,0
+1665,1,August,8,,St Ethelborough,10,9
+1665,1,August,8,,St Mary Woolchurch,2,0
+1665,1,August,8,,St Swithin,3,1
+1665,1,August,8,,St Faith,2,1
+1665,1,August,8,,St Mary Woolnoth,0,0
+1665,1,August,8,,St Thomas Apostle,10,8
+1665,1,August,8,,St Foster,7,4
+1665,1,August,8,,St Martin Iremongerlane,0,0
+1665,1,August,8,,Trinity Parish,2,1
+1665,1,August,8,,St Gabriel Fenchurch,0,0
+1665,1,August,8,,St Andrew Holborn,198,183
+1665,1,August,8,,St Botolph Aldgate,103,81
+1665,1,August,8,,Saviours Southwark,61,41
+1665,1,August,8,,St Bartholomew Great,30,17
+1665,1,August,8,,St Botolph Bishopsgate,180,133
+1665,1,August,8,,S. Sepulchres Parish,325,205
+1665,1,August,8,,St Bartholomew Lesse,12,6
+1665,1,August,8,,St Dunstan West,26,20
+1665,1,August,8,,St Thomas Southwark,9,8
+1665,1,August,8,,St Bridget,81,66
+1665,1,August,8,,St George Southwark,60,39
+1665,1,August,8,,Trinity Minories,0,0
+1665,1,August,8,,Bridewel Precinct,7,5
+1665,1,August,8,,St Giles Cripplegate,691,356
+1665,1,August,8,,At the Pesthouse,10,10
+1665,1,August,8,,St Botolph Aldersgate,57,46
+1665,1,August,8,,St Olave Southwark,142,64
+1665,1,August,8,,St Gile• in the fields,290,259
+1665,1,August,8,,Lambeth Parish,9,1
+1665,1,August,8,,St Mary Islington,28,24
+1665,1,August,8,,Hackney Parish,10,6
+1665,1,August,8,,St Leonard Shoreditch,183,122
+1665,1,August,8,,St Mary Whitechappel,177,158
+1665,1,August,8,,St James Clerkenwel,148,136
+1665,1,August,8,,St Magdalen Bermondsey,14,7
+1665,1,August,8,,Rothorith Parish,3,2
+1665,1,August,8,,St Kath. near the Tower,16,12
+1665,1,August,8,,St Mary Newington,23,16
+1665,1,August,8,,Stepney Parish,204,136
+1665,1,August,8,,Christ•e• in the 12 out Parishes in Middlesex and Surry 53 Buried,1105,879
+1665,1,August,8,,St Clement Danes,61,42
+1665,1,August,8,,St Martin in the field•,304,213
+1665,1,August,8,,St Margaret Westminste•,199,173
+1665,1,August,8,,St Paul Covent Garden,20,16
+1665,1,August,8,,St Mary Savoy,8,6
+1665,8,August,15,,St ALban Woodstreet,8,5
+1665,8,August,15,,St George Botolphlane,0,0
+1665,8,August,15,,St Martin Ludgate,5,4
+1665,8,August,15,,Alhallows Barking,10,7
+1665,8,August,15,,St Gregory by St Pauls,15,11
+1665,8,August,15,,St Martin Orgars,3,0
+1665,8,August,15,,Alhallows Breadstreet,2,1
+1665,8,August,15,,St Hellen,11,10
+1665,8,August,15,,St Martin Outwitch,1,1
+1665,8,August,15,,Alhallows Great,8,5
+1665,8,August,15,,St James Dukes place,9,6
+1665,8,August,15,,St Martin Vintrey,10,7
+1665,8,August,15,,Alhallows Honylane,1,1
+1665,8,August,15,,St James Garlickhithe,3,3
+1665,8,August,15,,St Matthew Fridaystreet,0,0
+1665,8,August,15,,Alhallows Lesse,2,0
+1665,8,August,15,,St John Baptist,1,1
+1665,8,August,15,,St Maudlin Milkstreet,0,0
+1665,8,August,15,,Alhallows Lumbardstreet,5,4
+1665,8,August,15,,St John Evangelist,0,0
+1665,8,August,15,,St Maudlin Oldfishstreet,3,1
+1665,8,August,15,,Alhallows Staining,5,2
+1665,8,August,15,,St John Zachary,2,1
+1665,8,August,15,,St Michael Bassishaw,11,7
+1665,8,August,15,,Alhallows the Wall,22,18
+1665,8,August,15,,St Katharine Coleman,0,0
+1665,8,August,15,,St Michael Cornhil,0,0
+1665,8,August,15,,St Alphage,16,9
+1665,8,August,15,,St Katharine Crechurch,3,2
+1665,8,August,15,,St Michael Crookedlane,2,0
+1665,8,August,15,,St Andrew Hubbard,0,0
+1665,8,August,15,,St Lawrence Jewry,7,3
+1665,8,August,15,,St Michael Queenhithe,8,0
+1665,8,August,15,,St Andrew Undershaft,13,11
+1665,8,August,15,,St Lawrence Pountney,6,3
+1665,8,August,15,,St Michael Quern,1,0
+1665,8,August,15,,St Andrew Wardrobe,24,16
+1665,8,August,15,,St Leonard Eastcheap,0,0
+1665,8,August,15,,St Michael Royal,7,5
+1665,8,August,15,,St Ann Aldersgate,15,6
+1665,8,August,15,,St Leonard Fosterlane,13,9
+1665,8,August,15,,St Michael Woodstreet,11,4
+1665,8,August,15,,St Ann Blackfryers,11,10
+1665,8,August,15,,St Magnus Parish,8,4
+1665,8,August,15,,St Mildred Breadstreet,0,0
+1665,8,August,15,,St Antholins Parish,1,1
+1665,8,August,15,,St Margaret Lothbury,3,2
+1665,8,August,15,,St Mildred Poultrey,1,1
+1665,8,August,15,,St Austins Parish,2,1
+1665,8,August,15,,St Margaret Moses,1,1
+1665,8,August,15,,St Nicholas Acons,0,0
+1665,8,August,15,,St Bartholomew Exchange,1,1
+1665,8,August,15,,St Margaret Newfishstreet,0,0
+1665,8,August,15,,St Nicholas Coleabby,7,5
+1665,8,August,15,,St Bennet Fynck,1,0
+1665,8,August,15,,St Margaret Pattons,0,0
+1665,8,August,15,,St Nicholas Olaves,2,0
+1665,8,August,15,,St Bennet Gracechurch,3,3
+1665,8,August,15,,St Mary Abchurch,1,0
+1665,8,August,15,,St Olave Hartstreet,7,6
+1665,8,August,15,,St Bennet Paulswharf,13,7
+1665,8,August,15,,St Mary Aldermanbury,9,2
+1665,8,August,15,,St Olave Jewry,1,1
+1665,8,August,15,,St Bennet Sherehog,0,0
+1665,8,August,15,,St Mary Aldermary,2,1
+1665,8,August,15,,St Olave Silverstreet,21,12
+1665,8,August,15,,St Botolph Billingsgate,1,0
+1665,8,August,15,,St Mary le Bow,6,3
+1665,8,August,15,,St Pancras Soperlane,0,0
+1665,8,August,15,,Christs Church,31,20
+1665,8,August,15,,St Mary Bothaw,0,0
+1665,8,August,15,,St Peter Cheap,1,0
+1665,8,August,15,,St Christophers,4,2
+1665,8,August,15,,St Mary Colechurch,1,1
+1665,8,August,15,,St Peter Cornhil,5,4
+1665,8,August,15,,St Clement Eastcheap,1,0
+1665,8,August,15,,St Mary Hill,1,0
+1665,8,August,15,,St Peter Paulswharf,1,1
+1665,8,August,15,,St Dionis Backchurch,2,1
+1665,8,August,15,,St Mary Mounthaw,4,2
+1665,8,August,15,,St Peter Poor,2,1
+1665,8,August,15,,St Dunstan East,3,1
+1665,8,August,15,,St Mary Sommerset,12,10
+1665,8,August,15,,St Steven Colemanstreet,14,10
+1665,8,August,15,,St Edmund Lumbardstr.,1,0
+1665,8,August,15,,St Mary Stayning,2,1
+1665,8,August,15,,St Steven Walbrook,0,0
+1665,8,August,15,,St Ethelborough,17,8
+1665,8,August,15,,St Mary Woolchurch,2,0
+1665,8,August,15,,St Swithin,3,2
+1665,8,August,15,,St Faith,0,0
+1665,8,August,15,,St Mary Woolnoth,1,1
+1665,8,August,15,,St Thomas Apostle,9,6
+1665,8,August,15,,St Foster,10,8
+1665,8,August,15,,St Martin Iremongerlane,0,0
+1665,8,August,15,,Trinity Parish,2,1
+1665,8,August,15,,St Gabriel Fenchurch,2,0
+1665,8,August,15,,St Andrew Holborn,287,272
+1665,8,August,15,,St Botolph Aldgate,207,173
+1665,8,August,15,,Saviours Southwark,132,100
+1665,8,August,15,,St Bartholomew Great,64,48
+1665,8,August,15,,St Botolph Bishopsgate,259,196
+1665,8,August,15,,S. Sepulchres Parish,365,241
+1665,8,August,15,,St Bartholomew Lesse,9,8
+1665,8,August,15,,St Dunstan West,35,25
+1665,8,August,15,,St Thomas Southwark,5,4
+1665,8,August,15,,St Bridget,103,90
+1665,8,August,15,,St George Southwark,99,71
+1665,8,August,15,,Trinity Minories,1,0
+1665,8,August,15,,Bridewel Precinct,4,2
+1665,8,August,15,,St Giles Cripplegate,886,521
+1665,8,August,15,,At the Pesthouse,12,12
+1665,8,August,15,,St Botolph Aldersgate,61,47
+1665,8,August,15,,St Olave Southwark,218,114
+1665,8,August,15,,St Giles in the fields,277,242
+1665,8,August,15,,Lambeth Parish,18,10
+1665,8,August,15,,St Mary Islington,42,36
+1665,8,August,15,,Hackney Parish,5,4
+1665,8,August,15,,St Leonard Shoreditch,207,163
+1665,8,August,15,,St Mary Whitechappel,285,240
+1665,8,August,15,,St James Clerkenwel,155,145
+1665,8,August,15,,St Magdalen Bermondsey,44,24
+1665,8,August,15,,Rothorith Parish,7,3
+1665,8,August,15,,St Kath. near the Tower,24,18
+1665,8,August,15,,St Mary Newington,47,37
+1665,8,August,15,,Stepney Parish,293,197
+1665,8,August,15,,St Clement Danes,74,57
+1665,8,August,15,,St Martin in the fields,301,229
+1665,8,August,15,,St Margaret Westminster,269,228
+1665,8,August,15,,St Paul Covent Garden,13,7
+1665,8,August,15,,St Mary Savoy,15,12
+1665,15,August,22,,St ALban Woodstreet,11,8
+1665,15,August,22,,St George Botolphlane,0,0
+1665,15,August,22,,St Martin Ludgate,4,4
+1665,15,August,22,,Alhallows Barking,13,11
+1665,15,August,22,,St Gregory by St Pauls,9,5
+1665,15,August,22,,St Marti• Org••,8,6
+1665,15,August,22,,Alhallows Breadstree•,1,1
+1665,15,August,22,,St Hellen,11,11
+1665,15,August,22,,St Martin Outwitch,1,0
+1665,15,August,22,,Alhallows Great,6,5
+1665,15,August,22,,St James Dukes place,7,5
+1665,15,August,22,,St Martin Vintrey,17,17
+1665,15,August,22,,Alhallows Honyl•ne,0,0
+1665,15,August,22,,St James Garlickhithe,3,1
+1665,15,August,22,,St Matthew Fridaystreet,1,0
+1665,15,August,22,,Alhallows Lesse,3,2
+1665,15,August,22,,St John Baptist,7,4
+1665,15,August,22,,St Maudlin Milkstreet,2,2
+1665,15,August,22,,Alhallows Lumbardstreet,6,4
+1665,15,August,22,,St John Evangelist,0,0
+1665,15,August,22,,St Maudlin Oldfishstreet,8,4
+1665,15,August,22,,Alhallows Stayning,7,5
+1665,15,August,22,,St John Zachary,1,1
+1665,15,August,22,,St Michael Bassishaw,12,11
+1665,15,August,22,,Alhallows the Wall,23,11
+1665,15,August,22,,St Katharine Coleman,5,1
+1665,15,August,22,,St Michael Cornhil,3,1
+1665,15,August,22,,St Alphage,18,10
+1665,15,August,22,,St Katharine Crechurch,7,4
+1665,15,August,22,,St Michael Crookedlane,7,4
+1665,15,August,22,,St Andrew Hubbard,1,0
+1665,15,August,22,,St Lawrence Jewry,2,1
+1665,15,August,22,,St Michael Queenhithe,7,6
+1665,15,August,22,,St Andrew Undershaft,14,9
+1665,15,August,22,,St Lawrence Pountney,6,5
+1665,15,August,22,,St Michael Quern,1,0
+1665,15,August,22,,St Andrew Wardrobe,21,16
+1665,15,August,22,,St Leonard Eastcheap,1,1
+1665,15,August,22,,St Michael Royal,2,1
+1665,15,August,22,,St Ann Aldersgate,18,11
+1665,15,August,22,,St Leonard Fosterlane,17,13
+1665,15,August,22,,St Michael Woodstreet,2,1
+1665,15,August,22,,St Ann Blackfryers,22,17
+1665,15,August,22,,St Magnus Parish,2,2
+1665,15,August,22,,St Mildred Breadstreet,2,1
+1665,15,August,22,,St Antholins Parish,0,0
+1665,15,August,22,,St Margaret Lothbury,2,1
+1665,15,August,22,,St Mildred Poultrey,4,3
+1665,15,August,22,,St Austins Parish,0,0
+1665,15,August,22,,St Margaret Moses,1,0
+1665,15,August,22,,St Nicholas Acons,0,0
+1665,15,August,22,,St Bartholomew Exchange,2,2
+1665,15,August,22,,St Margaret Newfishstreet,1,0
+1665,15,August,22,,St Nicholas Coleabby,1,0
+1665,15,August,22,,St Bennet Fynck,2,2
+1665,15,August,22,,St Margaret Pattons,1,0
+1665,15,August,22,,St Nicholas Olaves,3,1
+1665,15,August,22,,St Bennet Gracechurch,0,0
+1665,15,August,22,,St Mary Abchurch,1,0
+1665,15,August,22,,St Olave Hartstreet,7,4
+1665,15,August,22,,St Bennet Paulswharf,16,8
+1665,15,August,22,,St Mary Aldermanbury,11,5
+1665,15,August,22,,St Olave Jewry,1,1
+1665,15,August,22,,St Bennet Sherehog,0,0
+1665,15,August,22,,St Mary Aldermary,2,1
+1665,15,August,22,,St Olave Silverstreet,23,15
+1665,15,August,22,,St Botolph Billingsgate,2,0
+1665,15,August,22,,St Mary le Bow,6,6
+1665,15,August,22,,St Pancras Soperlane,0,0
+1665,15,August,22,,Christs Church,27,22
+1665,15,August,22,,St Mary Bothaw,1,1
+1665,15,August,22,,St Peter Cheap,1,1
+1665,15,August,22,,St Christophers,1,0
+1665,15,August,22,,St Mary Colechurch,0,0
+1665,15,August,22,,St Peter Cornhil,7,6
+1665,15,August,22,,St Clement Eastcheap,2,2
+1665,15,August,22,,St Mary Hill,2,1
+1665,15,August,22,,St Peter Paulswharf,5,2
+1665,15,August,22,,St Dionis Backchurch,2,1
+1665,15,August,22,,St Mary Mounthaw,1,0
+1665,15,August,22,,St Peter Poor,3,2
+1665,15,August,22,,St Dunstan East,7,2
+1665,15,August,22,,St Mary Sommerset,6,5
+1665,15,August,22,,St Steven Colemanstreet,15,11
+1665,15,August,22,,St Edmund Lumbardstr.,2,2
+1665,15,August,22,,St Mary Stayning,1,0
+1665,15,August,22,,St Steven Walbrook,0,0
+1665,15,August,22,,St Ethelborough,13,7
+1665,15,August,22,,St Mary Woolchurch,1,0
+1665,15,August,22,,St Swithin,2,2
+1665,15,August,22,,St Faith,6,6
+1665,15,August,22,,St Mary Woolnoth,1,1
+1665,15,August,22,,St Thomas Apostles,8,7
+1665,15,August,22,,St Foster,13,11
+1665,15,August,22,,St Martin Iremongerlane,0,0
+1665,15,August,22,,Trinity Parish,5,3
+1665,15,August,22,,St Gabriel Fenchurch,1,0
+1665,15,August,22,,St Andrew Hol••rn,232,220
+1665,15,August,22,,St Botolph Aldgate,238,212
+1665,15,August,22,,Saviours Southwark,160,120
+1665,15,August,22,,St Bartholomew Great,58,50
+1665,15,August,22,,St Botolph Bishopsgate,288,236
+1665,15,August,22,,S Sepulchres Parish,403,274
+1665,15,August,22,,St Bartholomew Lesse,19,15
+1665,15,August,22,,St Dunstan West,36,29
+1665,15,August,22,,St Thomas Southwark,24,21
+1665,15,August,22,,St Bridge•,147,119
+1665,15,August,22,,St George Southwark,80,60
+1665,15,August,22,,Trinity Minories,8,5
+1665,15,August,22,,Bridewel Precinct,7,5
+1665,15,August,22,,St Giles Cripplegate,847,572
+1665,15,August,22,,At the Pesthouse,9,9
+1665,15,August,22,,St Botolph Aldersgate,76,61
+1665,15,August,22,,St Olave Southwark,235,131
+1665,15,August,22,,St Giles in the fields,204,175
+1665,15,August,22,,Lambeth Parish,13,9
+1665,15,August,22,,St Mary Islington,50,45
+1665,15,August,22,,Hackney Parish,12,8
+1665,15,August,22,,St Leonard Shoreditch,252,168
+1665,15,August,22,,St Mary Whitechappel,319,270
+1665,15,August,22,,St James Clerkenwel,172,172
+1665,15,August,22,,St Magdalen Bermondsey,57,36
+1665,15,August,22,,Rothorith Parish,7,2
+1665,15,August,22,,St Kath. near the Tower,40,34
+1665,15,August,22,,St Mary Newington,74,52
+1665,15,August,22,,Stepney Parish,371,273
+1665,15,August,22,,St Clement Danes,94,78
+1665,15,August,22,,St Martin in the fields,255,193
+1665,15,August,22,,St Margaret Westminster,220,191
+1665,15,August,22,,St Paul Covent Garden,18,16
+1665,15,August,22,,St Mary Savoy,11,10
+1665,22,August,29,,St ALban Woodstreet,16,12
+1665,22,August,29,,St George Botolphlane,0,0
+1665,22,August,29,,St Martin Ludgate,9,6
+1665,22,August,29,,Alhallows Barking,25,21
+1665,22,August,29,,St Gregory by St Pauls,32,25
+1665,22,August,29,,St Martin Orgars,10,9
+1665,22,August,29,,Alhallows Breadstreet,2,0
+1665,22,August,29,,St Hellen,7,6
+1665,22,August,29,,St Martin Outwitch,5,4
+1665,22,August,29,,Alhallows Great,21,10
+1665,22,August,29,,St James Dukes place,9,6
+1665,22,August,29,,St Martin Vintrey,23,21
+1665,22,August,29,,Alhallows Honylane,1,1
+1665,22,August,29,,St James Garlickhithe,6,4
+1665,22,August,29,,St Matthew Fridaystreet,1,1
+1665,22,August,29,,Alhallows Lesse,11,9
+1665,22,August,29,,St John Baptist,6,5
+1665,22,August,29,,St Maudlin Milkstreet,8,7
+1665,22,August,29,,Alhallows Lumbardstreet,8,7
+1665,22,August,29,,St John Evangelist,0,0
+1665,22,August,29,,St Maudlin Oldfishstreet,6,5
+1665,22,August,29,,Alhallows Stayning,7,5
+1665,22,August,29,,St John Zachary,1,1
+1665,22,August,29,,St Michael B••si•haw,19,18
+1665,22,August,29,,Alhallows the Wall,44,40
+1665,22,August,29,,St Katharine Coleman,9,5
+1665,22,August,29,,St Michael Co••hil,3,1
+1665,22,August,29,,St Alphage,38,22
+1665,22,August,29,,St Katharine Crechurch,8,5
+1665,22,August,29,,St Michael Crookedlane,6,3
+1665,22,August,29,,St Andrew Hubbard,1,0
+1665,22,August,29,,St Lawrence Jewry,12,8
+1665,22,August,29,,St Michael Queenhithe,18,11
+1665,22,August,29,,St Andrew Undershaft,18,14
+1665,22,August,29,,St Lawrence Pountney,18,9
+1665,22,August,29,,St Michael Quern,0,0
+1665,22,August,29,,St Andrew Wardrobe,35,29
+1665,22,August,29,,St Leonard Eastcheap,0,0
+1665,22,August,29,,St Michael Royal,14,11
+1665,22,August,29,,St Ann Aldersgate,21,13
+1665,22,August,29,,St Leonard Fosterlane,34,30
+1665,22,August,29,,St Michael Woodstreet,8,6
+1665,22,August,29,,St Ann Blackfryers,41,31
+1665,22,August,29,,St Magnus Parish,4,4
+1665,22,August,29,,St Mildred Breadstreet,2,2
+1665,22,August,29,,St Antholins Parish,4,2
+1665,22,August,29,,St Margaret Lothbury,1,0
+1665,22,August,29,,St Mildred Poultrey,4,4
+1665,22,August,29,,St Austins Parish,3,3
+1665,22,August,29,,St Margaret Moses,3,3
+1665,22,August,29,,St Nicholas Acons,1,1
+1665,22,August,29,,St Bartholomew Exchange,4,3
+1665,22,August,29,,St Margaret Newfishstre.,2,1
+1665,22,August,29,,St Nicholas Coleabby,5,3
+1665,22,August,29,,St Bennet Fynck,2,2
+1665,22,August,29,,St Margaret Pattons,1,0
+1665,22,August,29,,St Nicholas Olaves,6,6
+1665,22,August,29,,St Bennet Gracechurch,1,1
+1665,22,August,29,,St Mary Abchurch,5,4
+1665,22,August,29,,St Olave Hartstreet,9,6
+1665,22,August,29,,St Bennet Paulswharf,41,29
+1665,22,August,29,,St Mary Aldermanbury,11,7
+1665,22,August,29,,St Olave Jewry,8,4
+1665,22,August,29,,St Bennet Sherehog,0,0
+1665,22,August,29,,St Mary Aldermary,8,6
+1665,22,August,29,,St Olave Silverstreet,23,17
+1665,22,August,29,,St Botolph Billingsgate,2,2
+1665,22,August,29,,St Mary le Bow,6,4
+1665,22,August,29,,St Pancras Soperlane,2,2
+1665,22,August,29,,Christs Church,43,37
+1665,22,August,29,,St Mary Bothaw,5,5
+1665,22,August,29,,St Peter Cheap,1,0
+1665,22,August,29,,St Christophers,0,0
+1665,22,August,29,,St Mary Colechurch,1,0
+1665,22,August,29,,St Peter Cornhil,4,1
+1665,22,August,29,,St Clement Eastcheap,1,1
+1665,22,August,29,,St Mary Hill,2,1
+1665,22,August,29,,St Peter Paulswharf,10,7
+1665,22,August,29,,St Dionis Backchurch,3,2
+1665,22,August,29,,St Mary Mounthaw,5,3
+1665,22,August,29,,St Peter Poor,1,1
+1665,22,August,29,,St Dunstan East,9,5
+1665,22,August,29,,St Mary Sommerset,22,18
+1665,22,August,29,,St Steven Colemanstreet,36,29
+1665,22,August,29,,St Edmund Lumbardstr.,2,1
+1665,22,August,29,,St Mary Stayning,5,4
+1665,22,August,29,,St Steven Walbrook,1,0
+1665,22,August,29,,St Ethelborough,23,18
+1665,22,August,29,,St Mary Woolchurch,1,0
+1665,22,August,29,,St Swithin,4,2
+1665,22,August,29,,St Faith,1,0
+1665,22,August,29,,St Mary Woolnoth,2,1
+1665,22,August,29,,St Thomas Apostles,12,10
+1665,22,August,29,,St Foster,14,13
+1665,22,August,29,,St Martin Iremongerlane,2,0
+1665,22,August,29,,Trinity Parish,4,3
+1665,22,August,29,,St Gabriel Fenchurch,0,0
+1665,22,August,29,,Ch istned in the 97 Parishes within the Walls 29 Buried,933,700
+1665,22,August,29,,St Andrew Holborn,399,380
+1665,22,August,29,,St Botolph Aldgate,374,46
+1665,22,August,29,,Saviours Southwark,319,261
+1665,22,August,29,,St Bartholomew Great,72,65
+1665,22,August,29,,St Botolph Bishopsgate,316,280
+1665,22,August,29,,S. Sepulchres Parish,447,336
+1665,22,August,29,,St Bartholomew Lesse,12,8
+1665,22,August,29,,St Dunstan West,53,42
+1665,22,August,29,,St Thomas Southwark,27,22
+1665,22,August,29,,St Bridget,181,152
+1665,22,August,29,,St George Southwark,147,120
+1665,22,August,29,,Trinity Minories,5,4
+1665,22,August,29,,Bridewel Precinct,12,9
+1665,22,August,29,,St Giles Cripplegate,842,602
+1665,22,August,29,,At the Pesthouse,9,9
+1665,22,August,29,,St Botolph Aldersgate,91,80
+1665,22,August,29,,St Olave Southwark,321,209
+1665,22,August,29,,St Giles in the fields,170,146
+1665,22,August,29,,Lambeth Parish,25,17
+1665,22,August,29,,St Mary Islington,69,66
+1665,22,August,29,,Hackney Parish,10,7
+1665,22,August,29,,St Leonard Shoreditch,280,238
+1665,22,August,29,,St Mary Whitechappel,496,462
+1665,22,August,29,,St James Clerkenwel,142,122
+1665,22,August,29,,St Magdalen Bermondsey,108,78
+1665,22,August,29,,Rothorith Parish,7,6
+1665,22,August,29,,St Kath. near the To•••,87,71
+1665,22,August,29,,St Mary Newington,121,104
+1665,22,August,29,,Stepney Parish,530,442
+1665,22,August,29,,Ch•istned •n •he 12 out •a •hes in Middlesex and Surrey 58 Buried,2045,1759
+1665,22,August,29,,St Clement Danes,110,82
+1665,22,August,29,,St Martin in the fields,387,287
+1665,22,August,29,,St Margaret Westminster,345,309
+1665,22,August,29,,St Paul Covent Garden,24,21
+1665,22,August,29,,St Mary Savoy,25,16
+1665,29,August,5,September,St ALban Woodstreet,12,9
+1665,29,August,5,September,St George Botolphlane,1,0
+1665,29,August,5,September,St Martin Ludgate,16,14
+1665,29,August,5,September,Alhallows Barking,31,23
+1665,29,August,5,September,St Gregory by St Pauls,22,20
+1665,29,August,5,September,St Martin Orgars,16,15
+1665,29,August,5,September,Alhallows Breadstreet,2,1
+1665,29,August,5,September,St Hellen,10,10
+1665,29,August,5,September,St Martin Outwitch,6,4
+1665,29,August,5,September,Alhallows Great,21,9
+1665,29,August,5,September,St James Dukes place,8,5
+1665,29,August,5,September,St Martin Vintrey,25,23
+1665,29,August,5,September,Alhallows Honylane,0,0
+1665,29,August,5,September,St James Garlickhithe,7,4
+1665,29,August,5,September,St Matthew Fridaystreet,0,0
+1665,29,August,5,September,Alhallows Lesse,17,16
+1665,29,August,5,September,St John Baptist,10,9
+1665,29,August,5,September,St Maudlin Milkstreet,5,3
+1665,29,August,5,September,Alhallows Lumbardstreet,7,6
+1665,29,August,5,September,St John Evangelist,0,0
+1665,29,August,5,September,St Maudlin Oldfishstreet,24,21
+1665,29,August,5,September,Alhallows Staining,14,11
+1665,29,August,5,September,St John Zachary,8,7
+1665,29,August,5,September,St Michael Bassishaw,19,11
+1665,29,August,5,September,Alhallows the Wall,46,40
+1665,29,August,5,September,St Katharine Coleman,17,10
+1665,29,August,5,September,St Michael Cornhil,11,7
+1665,29,August,5,September,St Alphage,40,22
+1665,29,August,5,September,St Katharine Crechurch,23,19
+1665,29,August,5,September,St Michael Crookedlane,5,5
+1665,29,August,5,September,St Andrew Hubbard,6,3
+1665,29,August,5,September,St Lawrence Jewry,6,4
+1665,29,August,5,September,St Michael Queenhithe,17,12
+1665,29,August,5,September,St Andrew Undershaft,30,24
+1665,29,August,5,September,St Lawrence Pountney,20,14
+1665,29,August,5,September,St Michael Quern,1,1
+1665,29,August,5,September,St Andrew Wardrobe,48,37
+1665,29,August,5,September,St Leonard Eastcheap,2,0
+1665,29,August,5,September,St Michael Royal,4,4
+1665,29,August,5,September,St Ann Aldersgate,30,24
+1665,29,August,5,September,St Leonard Fosterlane,35,33
+1665,29,August,5,September,St Michael Woodstreet,10,8
+1665,29,August,5,September,St Ann Blackfryers,47,36
+1665,29,August,5,September,St Magnus Parish,8,6
+1665,29,August,5,September,St Mildred Breadstreet,3,2
+1665,29,August,5,September,St Antholins Parish,10,9
+1665,29,August,5,September,St Margaret Lothbury,10,8
+1665,29,August,5,September,St Mildred Poultrey,1,1
+1665,29,August,5,September,St Austins Parish,1,1
+1665,29,August,5,September,St Margaret Moses,3,3
+1665,29,August,5,September,St Nicholas Acons,0,0
+1665,29,August,5,September,St Bartholomew Exchange,2,2
+1665,29,August,5,September,St Margaret Newfishstreet,9,3
+1665,29,August,5,September,St Nicholas Coleabby,8,8
+1665,29,August,5,September,St Bennet Fynck,5,2
+1665,29,August,5,September,St Margaret Pattons,0,0
+1665,29,August,5,September,St Nicholas Olaves,8,7
+1665,29,August,5,September,St Bennet Gracechurch,1,1
+1665,29,August,5,September,St Mary Abchurch,5,2
+1665,29,August,5,September,St Olave Hartstreet,12,10
+1665,29,August,5,September,St Bennet Paulswharf,30,21
+1665,29,August,5,September,St Mary Aldermanbury,15,15
+1665,29,August,5,September,St Olave Jewry,5,4
+1665,29,August,5,September,St Bennet Sherehog,0,0
+1665,29,August,5,September,St Mary Aldermary,7,7
+1665,29,August,5,September,St Olave Silverstreet,23,18
+1665,29,August,5,September,St Botolph Billingsgate,3,1
+1665,29,August,5,September,St Mary le Bow,9,8
+1665,29,August,5,September,St Pancras Soperlane,4,1
+1665,29,August,5,September,Christs Church,68,61
+1665,29,August,5,September,St Mary Bothaw,7,4
+1665,29,August,5,September,St Peter Cheap,6,3
+1665,29,August,5,September,St Christophers,8,7
+1665,29,August,5,September,St Mary Colechurch,0,0
+1665,29,August,5,September,St Peter Cornhil,4,2
+1665,29,August,5,September,St Clement Eastcheap,3,1
+1665,29,August,5,September,St Mary Hill,7,5
+1665,29,August,5,September,St Peter Paulswharf,8,7
+1665,29,August,5,September,St Dionis Backchurch,1,1
+1665,29,August,5,September,St Mary Mounthaw,3,2
+1665,29,August,5,September,St Peter Poor,2,2
+1665,29,August,5,September,St Dunstan East,11,6
+1665,29,August,5,September,St Mary Sommerset,14,12
+1665,29,August,5,September,St Steven Colemanstreat,47,38
+1665,29,August,5,September,St Edmund Lumbardstr.,1,0
+1665,29,August,5,September,St Mary Stayning,5,5
+1665,29,August,5,September,St Steven Walbrook,2,1
+1665,29,August,5,September,St Ethelborough,13,9
+1665,29,August,5,September,St Mary Woolchurch,1,0
+1665,29,August,5,September,St Swithin,4,2
+1665,29,August,5,September,St Faith,7,4
+1665,29,August,5,September,St Mary Woolnoth,3,2
+1665,29,August,5,September,St Thomas Apostle,11,7
+1665,29,August,5,September,St Foster,14,12
+1665,29,August,5,September,St Martin Iremongerlane,0,0
+1665,29,August,5,September,Trinity Parish,3,3
+1665,29,August,5,September,St Gabriel Fenchurch,4,4
+1665,29,August,5,September,St Andrew Holborn,356,345
+1665,29,August,5,September,St Botolph Aldgate,443,439
+1665,29,August,5,September,Saviours Southwark,374,339
+1665,29,August,5,September,St Bartholomew Great,48,42
+1665,29,August,5,September,St Botolph Bishopgate,368,299
+1665,29,August,5,September,S. Sepulchres Parish,344,264
+1665,29,August,5,September,St Bartholomew Lesse,23,21
+1665,29,August,5,September,St Dunstan West,86,74
+1665,29,August,5,September,St Thomas Southwark,40,33
+1665,29,August,5,September,St Bridget,219,189
+1665,29,August,5,September,St George Southwark,162,150
+1665,29,August,5,September,Trinity Minories,23,19
+1665,29,August,5,September,Bridewel Precinct,18,17
+1665,29,August,5,September,St Giles Cripplegate,690,567
+1665,29,August,5,September,At the Pesthouse,10,10
+1665,29,August,5,September,St Botolph Aldersgate,93,79
+1665,29,August,5,September,St Olave Southwark,439,264
+1665,29,August,5,September,"•hristned in the 16 Parishes without the Walls 64 Buried, and at the Pesthouse",3736,3151
+1665,29,August,5,September,St Giles in the fields,202,178
+1665,29,August,5,September,Lambeth Parish,31,21
+1665,29,August,5,September,St Mary •slington,94,94
+1665,29,August,5,September,Fackney Parish,13,10
+1665,29,August,5,September,St Leonard Shoreditch,300,276
+1665,29,August,5,September,St Mary Whitechappel,586,540
+1665,29,August,5,September,St James Clerkenwel,137,119
+1665,29,August,5,September,St Magdalen Bermondsey,146,116
+1665,29,August,5,September,Rothorith Parish,11,8
+1665,29,August,5,September,St Kath. near the Tower,117,87
+1665,29,August,5,September,St Mary Newington,171,146
+1665,29,August,5,September,Stepney Parish,741,666
+1665,29,August,5,September,St Clement Danes,142,114
+1665,29,August,5,September,St Martin in the fields,303,230
+1665,29,August,5,September,St Margaret Westminster,348,321
+1665,29,August,5,September,St Paul Covent Garden,32,16
+1665,29,August,5,September,St Mary Savoy,24,21
+1665,5,September,12,,St ALban Woodstreet,12,7
+1665,5,September,12,,St George Botolphlane,0,0
+1665,5,September,12,,St Martin Ludgate,14,10
+1665,5,September,12,,Alhallows Barking,42,32
+1665,5,September,12,,St Gregory by St Pauls,28,19
+1665,5,September,12,,St Martin Orgars,12,11
+1665,5,September,12,,Alhallows Breadstreet,0,0
+1665,5,September,12,,St Hellen,8,6
+1665,5,September,12,,St Martin Outwitch,4,4
+1665,5,September,12,,Alhallows Great,41,32
+1665,5,September,12,,St James Dukes place,22,20
+1665,5,September,12,,St Martin Vintrey,36,35
+1665,5,September,12,,Alhallows Honylane,1,1
+1665,5,September,12,,St James Garlickhithe,12,8
+1665,5,September,12,,St Matthew Fridaystreet,0,0
+1665,5,September,12,,Alhallows Lesse,19,17
+1665,5,September,12,,St John Baptist,3,3
+1665,5,September,12,,St Maudlin Milkstreet,1,0
+1665,5,September,12,,Alhallows Lumbardstreet,7,5
+1665,5,September,12,,St John Evangelist,0,0
+1665,5,September,12,,St Maudlin Oldfishstreet,16,13
+1665,5,September,12,,Alhallows Staining,13,8
+1665,5,September,12,,St John Zachary,3,1
+1665,5,September,12,,St Michael Bassishaw,13,9
+1665,5,September,12,,Alhallows the Wall,45,40
+1665,5,September,12,,St Katharine Coleman,26,22
+1665,5,September,12,,St Michael Cornhil,12,8
+1665,5,September,12,,St Alphage,31,13
+1665,5,September,12,,St Katharine Crechurch,42,33
+1665,5,September,12,,St Michael Crookedlane,13,11
+1665,5,September,12,,St Andrew Hubbard,2,1
+1665,5,September,12,,St Lawrence Jewry,3,1
+1665,5,September,12,,St Michael Queenhithe,11,9
+1665,5,September,12,,St Andrew Undershaft,25,19
+1665,5,September,12,,St Lawrence Pountney,17,13
+1665,5,September,12,,St Michael Quern,3,2
+1665,5,September,12,,St Andrew Wardrobe,46,35
+1665,5,September,12,,St Leonard Eastcheap,2,1
+1665,5,September,12,,St Michael Royal,11,10
+1665,5,September,12,,St Ann Aldersgate,31,25
+1665,5,September,12,,St Leonard Fosterlane,23,20
+1665,5,September,12,,St Michael Woodstreet,7,2
+1665,5,September,12,,St Ann Blackfryers,64,56
+1665,5,September,12,,St Magnus Parish,9,8
+1665,5,September,12,,St Mildred Breadstreet,9,7
+1665,5,September,12,,St Antholins Parish,2,1
+1665,5,September,12,,St Margaret Lothbury,7,6
+1665,5,September,12,,St Mildred Poultrey,8,7
+1665,5,September,12,,St Austins Parish,4,3
+1665,5,September,12,,St Margaret Moses,3,2
+1665,5,September,12,,St Nicholas Acons,3,2
+1665,5,September,12,,St Bartholomew Exchange,6,5
+1665,5,September,12,,St Margaret Newfishstreet,9,6
+1665,5,September,12,,St Nicholas Coleabby,7,6
+1665,5,September,12,,St Bennet Fynck,5,3
+1665,5,September,12,,St Margaret Pattons,8,4
+1665,5,September,12,,St Nicholas Olaves,3,3
+1665,5,September,12,,St Bennet Gracechurch,5,4
+1665,5,September,12,,St Mary Abchurch,5,4
+1665,5,September,12,,St Olave Hartstreet,14,13
+1665,5,September,12,,St Bennet Paulswharf,30,19
+1665,5,September,12,,St Mary Aldermanbury,12,7
+1665,5,September,12,,St Olave Jewry,4,3
+1665,5,September,12,,St Bennet Sherehog,0,0
+1665,5,September,12,,St Mary Aldermary,9,7
+1665,5,September,12,,St Olave Silverstreet,19,12
+1665,5,September,12,,St Botolph Billingsgate,5,2
+1665,5,September,12,,St Mary le Bow,2,1
+1665,5,September,12,,St Pancras Soperlane,0,0
+1665,5,September,12,,Christs Church,43,39
+1665,5,September,12,,St Mary Bothaw,1,0
+1665,5,September,12,,St Peter Cheap,5,4
+1665,5,September,12,,St Christophers,4,4
+1665,5,September,12,,St Mary Colechurch,2,0
+1665,5,September,12,,St Peter Cornhil,8,3
+1665,5,September,12,,St Clement Eastcheap,3,3
+1665,5,September,12,,St Mary Hill,5,4
+1665,5,September,12,,St Peter Paulswharf,10,9
+1665,5,September,12,,St Dionis Backchurch,2,2
+1665,5,September,12,,St Mary Mounthaw,8,7
+1665,5,September,12,,St Peter Poor,7,6
+1665,5,September,12,,St Dunstan East,13,12
+1665,5,September,12,,St Mary Sommerset,19,18
+1665,5,September,12,,St Steven Colemanstreet,36,31
+1665,5,September,12,,St Edmund Lumbardstr.,2,2
+1665,5,September,12,,St Mary Stayning,6,5
+1665,5,September,12,,St Steven Walbrook,2,1
+1665,5,September,12,,St Ethelborough,18,10
+1665,5,September,12,,St Mary Woolchurch,3,1
+1665,5,September,12,,St Swithin,2,2
+1665,5,September,12,,St Faith,11,8
+1665,5,September,12,,St Mary Woolnoth,3,2
+1665,5,September,12,,St Thomas Apostle,10,8
+1665,5,September,12,,St Foster,9,7
+1665,5,September,12,,St Martin Iremongerlane,0,0
+1665,5,September,12,,Trinity Parish,12,11
+1665,5,September,12,,St Gabriel Fenchurch,1,0
+1665,5,September,12,,St Andrew Holb•rn,255,235
+1665,5,September,12,,St Botolph Aldgate,584,570
+1665,5,September,12,,Saviours Southwark,419,394
+1665,5,September,12,,St Barthol•mew Great,32,21
+1665,5,September,12,,St Botolph Bishopsgate,354,298
+1665,5,September,12,,S. Sepulchres Parish,284,206
+1665,5,September,12,,St Bartholomew Lesse,19,19
+1665,5,September,12,,St Dunstan West,60,50
+1665,5,September,12,,St Thomas Southwark,50,44
+1665,5,September,12,,St Bridget,177,149
+1665,5,September,12,,St George Southwark,154,140
+1665,5,September,12,,Trinity Minories,14,10
+1665,5,September,12,,Bridewel Precinct,22,19
+1665,5,September,12,,St Giles Cripplegate,504,401
+1665,5,September,12,,At the Pesthouse,12,12
+1665,5,September,12,,St Botolph Aldersgate,70,61
+1665,5,September,12,,St Olave Southwark,478,307
+1665,5,September,12,,"•h•istned in the 16 Parishes without the Walls 58 Buried, and at the Pesthouse",3488,2936
+1665,5,September,12,,St Giles in the fields,167,156
+1665,5,September,12,,Lambeth Parish,46,37
+1665,5,September,12,,St Mary Islington,66,62
+1665,5,September,12,,Hackney Parish,11,9
+1665,5,September,12,,St Leonard Shoreditch,235,210
+1665,5,September,12,,St Mary Whitechappel,428,400
+1665,5,September,12,,St James Clerkenwel,94,73
+1665,5,September,12,,St Magdalen Bermondsey,190,172
+1665,5,September,12,,Rothorith Parish,18,16
+1665,5,September,12,,St Kath. near the Tower,97,61
+1665,5,September,12,,St Mary Newington,156,149
+1665,5,September,12,,Stepney Parish,742,685
+1665,5,September,12,,Ch•istned in the 12 out Parishes in Middlesex and Surry 43 Buried,2250,2030
+1665,5,September,12,,St Clement Danes,124,98
+1665,5,September,12,,St Martin in the fields,277,214
+1665,5,September,12,,St Margaret Westminster,349,331
+1665,5,September,12,,St Paul Covent Garden,29,26
+1665,5,September,12,,St Mary Savoy,19,13
+1665,12,September,19,,St ALban Woodstreet,23,19
+1665,12,September,19,,St George Botolphlane,5,3
+1665,12,September,19,,St Martin Ludgate,21,11
+1665,12,September,19,,Alhallows Barking,41,32
+1665,12,September,19,,St Gregory by St Pauls,32,23
+1665,12,September,19,,St Martin Orgars,9,7
+1665,12,September,19,,Alhallows Breadstreet,4,3
+1665,12,September,19,,St Hellen,8,8
+1665,12,September,19,,St Martin Outwitch,8,3
+1665,12,September,19,,Alhallows Great,59,53
+1665,12,September,19,,St James Dukes place,29,26
+1665,12,September,19,,St Martin Vintrey,64,61
+1665,12,September,19,,Alhallows Honylane,1,0
+1665,12,September,19,,St James Garlickhithe,13,11
+1665,12,September,19,,St Matthew Fridaystreet,1,1
+1665,12,September,19,,Alhallows Lesse,29,26
+1665,12,September,19,,St John Baptist,7,6
+1665,12,September,19,,St Maudlin Milkstreet,5,3
+1665,12,September,19,,Alhallows Lumbardstreet,8,7
+1665,12,September,19,,St John Evangelist,0,0
+1665,12,September,19,,St Maudlin Oldfishstreet,16,11
+1665,12,September,19,,Alhallows Stayning,16,10
+1665,12,September,19,,St John Zachary,3,2
+1665,12,September,19,,St Michael Bassishaw,17,12
+1665,12,September,19,,Alhallows the Wall,41,30
+1665,12,September,19,,St Katharine Coleman,44,36
+1665,12,September,19,,St Michael Cornhil,14,11
+1665,12,September,19,,St Alphage,25,13
+1665,12,September,19,,St Katharine Crechurch,35,31
+1665,12,September,19,,St Michael Crookedlane,10,10
+1665,12,September,19,,St Andrew Hubbard,6,5
+1665,12,September,19,,St Lawrence Jewry,8,6
+1665,12,September,19,,St Michael Queenhithe,11,6
+1665,12,September,19,,St Andrew Undershaft,25,22
+1665,12,September,19,,St Lawrence Pountney,22,17
+1665,12,September,19,,St Michael Quern,4,3
+1665,12,September,19,,St Andrew Wardrobe,63,54
+1665,12,September,19,,St Leonard Eastcheap,5,4
+1665,12,September,19,,St Michael Royal,20,17
+1665,12,September,19,,St Ann Aldersgate,33,28
+1665,12,September,19,,St Leonard Fosterlane,34,32
+1665,12,September,19,,St Michael Woodstreet,6,2
+1665,12,September,19,,St Ann Blackfryers,79,65
+1665,12,September,19,,St Magnus Parish,7,6
+1665,12,September,19,,St Mildred Breadstreet,6,3
+1665,12,September,19,,St Antholins Parish,6,5
+1665,12,September,19,,St Margaret Lothbury,8,8
+1665,12,September,19,,St Mildred Poultrey,4,2
+1665,12,September,19,,St Austins Parish,2,2
+1665,12,September,19,,St Margaret Moses,5,5
+1665,12,September,19,,St Nicholas Acons,8,7
+1665,12,September,19,,St Bartholomew Exchange,3,3
+1665,12,September,19,,St Margaret Newfishstre.,17,13
+1665,12,September,19,,St Nicholas Coleabby,14,13
+1665,12,September,19,,St Bennet Fynck,1,0
+1665,12,September,19,,St Margaret Pattons,5,3
+1665,12,September,19,,St Nicholas Olaves,12,9
+1665,12,September,19,,St Bennet Gracechurch,5,4
+1665,12,September,19,,St Mary Abchurch,13,9
+1665,12,September,19,,St Olave Hartstreet,20,18
+1665,12,September,19,,St Bennet Paulswharf,35,15
+1665,12,September,19,,St Mary Aldermanbury,20,16
+1665,12,September,19,,St Olave Jewry,7,5
+1665,12,September,19,,St Bennet Sherehog,1,0
+1665,12,September,19,,St Mary Aldermary,11,10
+1665,12,September,19,,St Olave Silverstreet,23,17
+1665,12,September,19,,St Botolph Billingsgate,4,4
+1665,12,September,19,,St Mary le Bow,4,2
+1665,12,September,19,,St Pancras Soperlane,2,2
+1665,12,September,19,,Christ Church,55,48
+1665,12,September,19,,St Mary Bothaw,9,8
+1665,12,September,19,,St Peter Cheap,4,3
+1665,12,September,19,,St Christophers,6,5
+1665,12,September,19,,St Mary Colechurch,2,1
+1665,12,September,19,,St Peter Cornhil,10,6
+1665,12,September,19,,St Clement Eastcheap,3,3
+1665,12,September,19,,St Mary Hill,12,8
+1665,12,September,19,,St Peter Paulswharf,12,12
+1665,12,September,19,,St Dionis Backchurch,10,3
+1665,12,September,19,,St Mary Mounthaw,9,9
+1665,12,September,19,,St Peter Poor,6,6
+1665,12,September,19,,St Dunstan East,20,10
+1665,12,September,19,,St Mary Sommerset,36,34
+1665,12,September,19,,St Steven Colemanstreet,47,40
+1665,12,September,19,,St Edmund Lumbardstr.,4,4
+1665,12,September,19,,St Mary Stayning,2,1
+1665,12,September,19,,St Steven Walbrook,5,5
+1665,12,September,19,,St Ethelborough,16,6
+1665,12,September,19,,St Mary Woolchurch,2,2
+1665,12,September,19,,St Swithin,11,9
+1665,12,September,19,,St Faith,7,6
+1665,12,September,19,,St Mary Woolnoth,9,6
+1665,12,September,19,,St Thomas Apostles,19,17
+1665,12,September,19,,St Foster,10,9
+1665,12,September,19,,St Martin Iremongerlane,1,1
+1665,12,September,19,,Trinity Parish,13,13
+1665,12,September,19,,St Gabriel Fenchurch,6,3
+1665,12,September,19,,Ch•istn•d in the 97 Parishes within the Walls 40 Buried,1493,1189
+1665,12,September,19,,St Andrew Holborn,271,247
+1665,12,September,19,,St Botolph Aldgate,623,589
+1665,12,September,19,,Saviours Southwark,427,403
+1665,12,September,19,,St Bartholomew Great,21,17
+1665,12,September,19,,St Botolph Bishopsgate,294,256
+1665,12,September,19,,S Sepulchres Parish,301,214
+1665,12,September,19,,St Bartholomew Lesse,14,12
+1665,12,September,19,,St Dunstan West,88,79
+1665,12,September,19,,St Thomas Southwark,57,52
+1665,12,September,19,,St Bridget,236,180
+1665,12,September,19,,St George Southwark,195,176
+1665,12,September,19,,Trinity Minories,12,10
+1665,12,September,19,,Bridewel Precinct,32,31
+1665,12,September,19,,St Giles Cripplegate,456,373
+1665,12,September,19,,At the Pesthouse,6,6
+1665,12,September,19,,St Botolph Aldersgate,68,62
+1665,12,September,19,,St Olave Southwark,530,363
+1665,12,September,19,,St Giles in the field•,140,125
+1665,12,September,19,,Lambeth Parish,48,43
+1665,12,September,19,,St Mary Islington,68,66
+1665,12,September,19,,Hac•ney Parish,22,18
+1665,12,September,19,,St Leonard Shoreditch,183,173
+1665,12,September,19,,St Mary Whitechappel,532,502
+1665,12,September,19,,St James Clerkenwel,77,67
+1665,12,September,19,,St Magdalen Bermondsey,207,180
+1665,12,September,19,,Rothorith Parish,17,13
+1665,12,September,19,,St Kath. near the Tower,93,66
+1665,12,September,19,,St Mary Newington,155,152
+1665,12,September,19,,Stepney Parish,716,686
+1665,12,September,19,,St Clement Danes,168,140
+1665,12,September,19,,St Martin in the fields,286,228
+1665,12,September,19,,St Margaret Westminster,411,399
+1665,12,September,19,,St Paul Covent Garden,30,29
+1665,12,September,19,,St Mary Savoy,20,19
+1665,19,September,26,,St ALban Woodstreet,10,5
+1665,19,September,26,,St George Botolphlane,2,0
+1665,19,September,26,,St Martin Ludgate,27,20
+1665,19,September,26,,Alhallows Barking,52,41
+1665,19,September,26,,St Gregory by St Pauls,31,26
+1665,19,September,26,,St Martin Orgars,8,3
+1665,19,September,26,,Alhallows Breadstreet,3,3
+1665,19,September,26,,St Hellen,4,3
+1665,19,September,26,,St Martin Outwitch,5,5
+1665,19,September,26,,Alhallows Grea•,64,59
+1665,19,September,26,,St James Dukes place,24,21
+1665,19,September,26,,St Martin Vintrey,38,36
+1665,19,September,26,,Alh•llows Honylane,1,1
+1665,19,September,26,,St James Garlickhithe,14,10
+1665,19,September,26,,St Matthew Fridaystreet,1,0
+1665,19,September,26,,Alhallows Lesse,25,24
+1665,19,September,26,,St John Baptist,10,7
+1665,19,September,26,,St Maudlin Milkstreet,2,1
+1665,19,September,26,,Alhallows Lumbardstreet,11,10
+1665,19,September,26,,St John Evangelist,0,0
+1665,19,September,26,,St Maudlin Oldfishstreet,10,8
+1665,19,September,26,,Alhallows Stayning,16,11
+1665,19,September,26,,St John Zachary,9,7
+1665,19,September,26,,St Michael Bassishaw,18,16
+1665,19,September,26,,Alhallows the Wall,41,35
+1665,19,September,26,,St Katharine Coleman,36,35
+1665,19,September,26,,St Michael Cornhil,7,5
+1665,19,September,26,,St Alphage,11,3
+1665,19,September,26,,St Katharine Crechurch,30,20
+1665,19,September,26,,St Michael Crookedlan•,15,13
+1665,19,September,26,,St Andrew Hubbard,3,0
+1665,19,September,26,,St Lawrence Jewry,7,5
+1665,19,September,26,,St Michael Queenhithe,12,10
+1665,19,September,26,,St Andrew Undershaft,26,22
+1665,19,September,26,,St Lawrence Pountney,17,14
+1665,19,September,26,,St Michael Quern,4,3
+1665,19,September,26,,St Andrew Wardrobe,50,37
+1665,19,September,26,,St Leonard Eastcheap,3,2
+1665,19,September,26,,St Michael Royal,14,12
+1665,19,September,26,,St Ann Aldersgate,20,16
+1665,19,September,26,,St Leonard Fosterlane,30,27
+1665,19,September,26,,St Michael Woodstreet,9,5
+1665,19,September,26,,St Ann Blackfryers,39,31
+1665,19,September,26,,St Magnus Parish,3,1
+1665,19,September,26,,St Mildred Breadstreet,1,1
+1665,19,September,26,,St Antholins Parish,8,7
+1665,19,September,26,,St Margaret Lothbury,6,5
+1665,19,September,26,,St Mildred Poultrey,4,4
+1665,19,September,26,,St Austins Parish,5,3
+1665,19,September,26,,St Margaret Moses,3,3
+1665,19,September,26,,St Nicholas Acons,7,5
+1665,19,September,26,,St Bartholomew Exchange,6,6
+1665,19,September,26,,St Margaret Newfishstre.,7,7
+1665,19,September,26,,St Nicholas Coleabby,14,14
+1665,19,September,26,,St Bennet Fynck,2,0
+1665,19,September,26,,St Margaret Pattons,5,4
+1665,19,September,26,,St Nicholas Olaves,7,4
+1665,19,September,26,,St Bennet Gracechurch,3,2
+1665,19,September,26,,St Mary Abchurch,6,4
+1665,19,September,26,,St Olave Hartstreet,20,19
+1665,19,September,26,,St Bennet Paulswharf,30,19
+1665,19,September,26,,St Mary Aldermanbury,19,15
+1665,19,September,26,,St Olave Jewry,1,1
+1665,19,September,26,,St Bennet Sherehog,1,0
+1665,19,September,26,,St Mary Aldermary,13,12
+1665,19,September,26,,St Olave Silverstreet,9,7
+1665,19,September,26,,St Botolph Billingsgate,3,2
+1665,19,September,26,,St Mary le Bow,3,1
+1665,19,September,26,,St Pancras Soperlane,4,3
+1665,19,September,26,,Christ Church,49,43
+1665,19,September,26,,St Mary Bothaw,1,0
+1665,19,September,26,,St Peter Cheap,6,5
+1665,19,September,26,,St Christophers,6,6
+1665,19,September,26,,St Mary Colechurch,3,2
+1665,19,September,26,,St Peter Cornhil,10,10
+1665,19,September,26,,St Clement Eastcheap,1,1
+1665,19,September,26,,St Mary Hill,5,4
+1665,19,September,26,,St Peter Paulswharf,15,11
+1665,19,September,26,,St Dionis Backchurch,5,2
+1665,19,September,26,,St Mary Mounthaw,3,3
+1665,19,September,26,,St Peter Poor,8,6
+1665,19,September,26,,St Dunstan East,21,17
+1665,19,September,26,,St Mary Sommerset,30,26
+1665,19,September,26,,St Steven Colemanstreet,56,51
+1665,19,September,26,,St Edmund Lumbardstr.,5,3
+1665,19,September,26,,St Mary Stayning,8,6
+1665,19,September,26,,St Steven Walbrook,3,2
+1665,19,September,26,,St Ethelborough,11,7
+1665,19,September,26,,St Mary Woolchurch,6,6
+1665,19,September,26,,St Swithin,7,6
+1665,19,September,26,,St Faith,13,10
+1665,19,September,26,,St Mary Woolnoth,11,6
+1665,19,September,26,,St Thomas Apostles,7,5
+1665,19,September,26,,St Foster,10,9
+1665,19,September,26,,St Martin Iremongerlan•,2,2
+1665,19,September,26,,Trinity Parish,10,9
+1665,19,September,26,,St Gabriel Fenchurch,7,6
+1665,19,September,26,,Ch•istn•d in the 97 Parishes within the Walls 38 Buried,1268,1025
+1665,19,September,26,,St Andrew Holborn,202,184
+1665,19,September,26,,St Botolph Aldgate,469,433
+1665,19,September,26,,Saviours Southwark,356,341
+1665,19,September,26,,St Bartholomew Great,20,16
+1665,19,September,26,,St Botolph Bishopsgate,186,145
+1665,19,September,26,,S Sepulchres Parish,193,138
+1665,19,September,26,,St Bartholomew Lesse,11,11
+1665,19,September,26,,St Dunstan West,72,58
+1665,19,September,26,,St Thomas Southwark,39,36
+1665,19,September,26,,St Bridget,117,91
+1665,19,September,26,,St George Southwark,153,137
+1665,19,September,26,,Trinity Minories,21,18
+1665,19,September,26,,Bridewel Precinct,26,24
+1665,19,September,26,,St Giles Cripplegate,277,225
+1665,19,September,26,,At the Pesthouse,7,7
+1665,19,September,26,,St Botolph Aldersgate,67,64
+1665,19,September,26,,St Olave Southwark,472,324
+1665,19,September,26,,St Giles in the fields,119,107
+1665,19,September,26,,Lambeth Parish,46,40
+1665,19,September,26,,St Mary Islington,44,41
+1665,19,September,26,,Hackney Parish,8,6
+1665,19,September,26,,St Leonard Shoreditch,146,138
+1665,19,September,26,,St Mary Whitechappel,346,320
+1665,19,September,26,,St James Clerkenwel,76,64
+1665,19,September,26,,St Magdalen Bermondsey,201,174
+1665,19,September,26,,Rothorith Parish,20,18
+1665,19,September,26,,St Kath. near the Tower,78,62
+1665,19,September,26,,St Mary Newington,94,94
+1665,19,September,26,,Stepney Parish,616,579
+1665,19,September,26,,St Clement Danes,152,128
+1665,19,September,26,,St Martin in the fields,219,171
+1665,19,September,26,,St Margaret Westmins er,300,283
+1665,19,September,26,,St Paul Covent Garden,19,18
+1665,19,September,26,,St Mary Savoy,20,13
+1665,26,September,3,October,St ALban Woodstreet,16,12
+1665,26,September,3,October,St George Botolphlane,1,1
+1665,26,September,3,October,St Martin Ludgate,12,10
+1665,26,September,3,October,Alhallows Barking,46,34
+1665,26,September,3,October,St Gregory by St Pauls,26,25
+1665,26,September,3,October,St Martin Orgars,8,5
+1665,26,September,3,October,Alhallows Breadstreet,1,1
+1665,26,September,3,October,St Hellen,6,5
+1665,26,September,3,October,St Martin Outwitch,6,5
+1665,26,September,3,October,Alhallows Great,42,41
+1665,26,September,3,October,St James Dukes place,27,23
+1665,26,September,3,October,St Martin Vintrey,44,44
+1665,26,September,3,October,Alhallows Honylane,0,0
+1665,26,September,3,October,St James Garlickhithe,16,12
+1665,26,September,3,October,St Matthew Fridaystre••,0,0
+1665,26,September,3,October,Alhallows Lesse,17,17
+1665,26,September,3,October,St John Baptist,11,10
+1665,26,September,3,October,St Maudlin M•lks•r•et,4,4
+1665,26,September,3,October,Alhallows Lumbardstreet,5,5
+1665,26,September,3,October,St John Evangelist,0,0
+1665,26,September,3,October,St Ma•dlin Oldfishs•reet,8,6
+1665,26,September,3,October,Alhallows Staining,21,18
+1665,26,September,3,October,St John Zachary,12,9
+1665,26,September,3,October,St Michael Bass•shaw,10,7
+1665,26,September,3,October,Alhallows the Wall,33,28
+1665,26,September,3,October,St Katharine Coleman,20,16
+1665,26,September,3,October,St Michael Cornhil,4,3
+1665,26,September,3,October,St Alphage,13,5
+1665,26,September,3,October,St Katharine Crechurch,34,29
+1665,26,September,3,October,St Michael Crookedlane,15,12
+1665,26,September,3,October,St Andrew Hubbard,4,0
+1665,26,September,3,October,St Lawrence Jewry,6,5
+1665,26,September,3,October,St Michael Queenhithe,25,23
+1665,26,September,3,October,St Andrew Undershaft,16,14
+1665,26,September,3,October,St Lawrence Pountney,14,10
+1665,26,September,3,October,St Michael Quern,4,3
+1665,26,September,3,October,St Andrew Wardrobe,30,24
+1665,26,September,3,October,St Leonard Eastcheap,3,3
+1665,26,September,3,October,St Michael Royal,20,17
+1665,26,September,3,October,St Ann Aldersgate,28,27
+1665,26,September,3,October,St Leonard Fosterlane,16,13
+1665,26,September,3,October,St Michael Woodstreet,6,3
+1665,26,September,3,October,St Ann Blackfryers,57,50
+1665,26,September,3,October,St Magnus Parish,5,4
+1665,26,September,3,October,St Mildred Breadstreet,4,4
+1665,26,September,3,October,St Antholins Parish,7,4
+1665,26,September,3,October,St Margaret Lothbury,7,6
+1665,26,September,3,October,St Mildred Poultrey,4,2
+1665,26,September,3,October,St Austins Parish,4,3
+1665,26,September,3,October,St Margaret Moses,0,0
+1665,26,September,3,October,St Nicholas Acons,4,3
+1665,26,September,3,October,St Bartholomew Exchange,7,7
+1665,26,September,3,October,St Margaret Newfishstreet,18,13
+1665,26,September,3,October,St Nicholas Coleabby,8,8
+1665,26,September,3,October,St Bennet Fynck,4,2
+1665,26,September,3,October,St Margaret Pattons,4,3
+1665,26,September,3,October,St Nicholas Olaves,8,8
+1665,26,September,3,October,St Bennet Gracechurch,4,2
+1665,26,September,3,October,St Mary Abchurch,7,5
+1665,26,September,3,October,St Olave Hartstreet,13,11
+1665,26,September,3,October,St Bennet Paulswharf,15,7
+1665,26,September,3,October,St Mary Aldermanbury,14,14
+1665,26,September,3,October,St Olave Jewry,5,4
+1665,26,September,3,October,St Bennet Sherehog,2,0
+1665,26,September,3,October,St Mary Aldermary,4,4
+1665,26,September,3,October,St Olave Silverstreet,4,4
+1665,26,September,3,October,St Botolph Billingsgate,8,8
+1665,26,September,3,October,St Mary le Bow,1,1
+1665,26,September,3,October,St Pancras Soperlane,1,1
+1665,26,September,3,October,Christs Church,44,39
+1665,26,September,3,October,St Mary Bothaw,6,4
+1665,26,September,3,October,St Peter Cheap,3,3
+1665,26,September,3,October,St Christophers,4,4
+1665,26,September,3,October,St Mary Colechurch,3,1
+1665,26,September,3,October,St Peter Cornhil,8,6
+1665,26,September,3,October,St Clement Eastcheap,1,1
+1665,26,September,3,October,St Mary Hill,11,8
+1665,26,September,3,October,St Peter Paulswharf,10,10
+1665,26,September,3,October,St Dionis Backchurch,9,2
+1665,26,September,3,October,St Mary Mounthaw,4,3
+1665,26,September,3,October,St Peter Poor,8,7
+1665,26,September,3,October,St Dunstan East,28,24
+1665,26,September,3,October,St Mary Sommerset,44,38
+1665,26,September,3,October,St Steven Colemanstreet,43,38
+1665,26,September,3,October,St Edmund Lumbardstr.,3,1
+1665,26,September,3,October,St Mary Stayning,3,2
+1665,26,September,3,October,St Steven Walbrook,2,2
+1665,26,September,3,October,St Ethelborough,7,4
+1665,26,September,3,October,St Mary Woolchurch,7,4
+1665,26,September,3,October,St Swithin,6,51
+1665,26,September,3,October,St Faith,8,6
+1665,26,September,3,October,St Mary Woolnoth,7,5
+1665,26,September,3,October,St Thomas Apostle,8,4
+1665,26,September,3,October,St Foster,8,6
+1665,26,September,3,October,St Martin Iremongerlane,2,2
+1665,26,September,3,October,Trinity Parish,10,9
+1665,26,September,3,October,St Gabriel Fenchurch,3,3
+1665,26,September,3,October,St Andrew Holborn,173,151
+1665,26,September,3,October,St Botolph Aldgate,372,338
+1665,26,September,3,October,Saviours Southwark,364,352
+1665,26,September,3,October,St Bartholomew Great,17,15
+1665,26,September,3,October,St Botolph Bishopsgate,153,121
+1665,26,September,3,October,S. Sepulchres Parish,137,95
+1665,26,September,3,October,St Bartholomew Lesse,7,7
+1665,26,September,3,October,St Dunstan West,63,59
+1665,26,September,3,October,St Thomas Southwark,40,36
+1665,26,September,3,October,St Bridget,92,67
+1665,26,September,3,October,St George Southwark,140,133
+1665,26,September,3,October,Trinity Minories,24,21
+1665,26,September,3,October,Bridewel Precinct,23,23
+1665,26,September,3,October,St Giles Cripplegate,196,151
+1665,26,September,3,October,At the Pesthouse,8,8
+1665,26,September,3,October,St Botolph Aldersgate,71,64
+1665,26,September,3,October,St Olave Southwark,378,281
+1665,26,September,3,October,St Giles in the fields,95,78
+1665,26,September,3,October,Lambeth Parish,49,39
+1665,26,September,3,October,St Mary ••lington,35,31
+1665,26,September,3,October,Hackney Parish,14,12
+1665,26,September,3,October,St Leonard Shoreditch,95,91
+1665,26,September,3,October,St Mary Whitechappel,328,301
+1665,26,September,3,October,St James Clerkenwel,48,42
+1665,26,September,3,October,St Magdalen Bermondsey,128,106
+1665,26,September,3,October,Rothorith Parish,21,18
+1665,26,September,3,October,St Kath. near the Tower,55,39
+1665,26,September,3,October,St Mary Newington,81,81
+1665,26,September,3,October,Stepney Parish,674,631
+1665,26,September,3,October,St Clement Danes,128,110
+1665,26,September,3,October,St Martin in the fields,209,143
+1665,26,September,3,October,St Margaret Westminster,309,297
+1665,26,September,3,October,St Paul Covent Garden,25,24
+1665,26,September,3,October,St Mary Savoy,19,16
+1665,3,October,10,,St ALban Woodstreet,17,15
+1665,3,October,10,,St George Botolphlane,5,4
+1665,3,October,10,,St Martin Ludgate,17,16
+1665,3,October,10,,Alhallows Barking,39,26
+1665,3,October,10,,St Gregory by St Pauls,22,21
+1665,3,October,10,,St Martin Orgars,5,5
+1665,3,October,10,,Alhallows Breadstreet,2,2
+1665,3,October,10,,St Hellen,2,2
+1665,3,October,10,,St Martin Outwitch,7,5
+1665,3,October,10,,Alhallows Great,38,34
+1665,3,October,10,,St James Dukes place,30,25
+1665,3,October,10,,St Martin Vintrey,38,34
+1665,3,October,10,,Alhallows Honylane,1,1
+1665,3,October,10,,St James Garlickhithe,12,11
+1665,3,October,10,,St Matthew Fridaystreet,3,2
+1665,3,October,10,,Alhallows Lesse,21,21
+1665,3,October,10,,St John Baptist,11,7
+1665,3,October,10,,St Maudlin Milkstreet,2,1
+1665,3,October,10,,Alhallows Lumbardstreet,5,5
+1665,3,October,10,,St John Evangelist,0,0
+1665,3,October,10,,St Maudlin Oldfishstreet,12,8
+1665,3,October,10,,Alhallows Staining,12,8
+1665,3,October,10,,St John Zachary,5,5
+1665,3,October,10,,St Michael Bassishaw,11,7
+1665,3,October,10,,Alhallows the Wall,31,28
+1665,3,October,10,,St Katharine Coleman,34,30
+1665,3,October,10,,St Michael Cornhil,8,4
+1665,3,October,10,,St Alphage,8,4
+1665,3,October,10,,St Katharine Crechurch,24,23
+1665,3,October,10,,St Michael Crookedlane,17,17
+1665,3,October,10,,St Andrew Hubbard,4,2
+1665,3,October,10,,St Lawrence Jewry,4,4
+1665,3,October,10,,St Michael Queenhithe,4,3
+1665,3,October,10,,St Andrew Undershaft,10,6
+1665,3,October,10,,St Lawrence Pountney,17,15
+1665,3,October,10,,St Michael Quern,3,2
+1665,3,October,10,,St Andrew Wardrobe,23,15
+1665,3,October,10,,St Leonard Eastcheap,5,5
+1665,3,October,10,,St Michael Royal,15,14
+1665,3,October,10,,St Ann Aldersgate,15,15
+1665,3,October,10,,St Leonard Fosterlane,36,33
+1665,3,October,10,,St Michael Woodstreet,14,13
+1665,3,October,10,,St Ann Blackfryers,61,52
+1665,3,October,10,,St Magnus Parish,5,4
+1665,3,October,10,,St Mildred Breadstreet,3,1
+1665,3,October,10,,St Antholins Parish,1,1
+1665,3,October,10,,St Margaret Lothbury,6,5
+1665,3,October,10,,St Mildred Poultrey,9,8
+1665,3,October,10,,St Austins Parish,5,3
+1665,3,October,10,,St Margaret Moses,0,0
+1665,3,October,10,,St Nicholas Acons,2,1
+1665,3,October,10,,St Bartholomew Exchange,4,4
+1665,3,October,10,,St Margaret Newfishstreet,8,6
+1665,3,October,10,,St Nicholas Coleabby,11,10
+1665,3,October,10,,St Bennet Fynck,2,1
+1665,3,October,10,,St Margaret Pattons,8,4
+1665,3,October,10,,St Nicholas Olaves,7,7
+1665,3,October,10,,St Bennet Gracechurch,11,10
+1665,3,October,10,,St Mary Abchurch,5,2
+1665,3,October,10,,St Olave Hartstreet,23,21
+1665,3,October,10,,St Bennet Paulswharf,22,9
+1665,3,October,10,,St Mary Aldermanbury,7,6
+1665,3,October,10,,St Olave Jewry,3,2
+1665,3,October,10,,St Bennet Sherehog,0,0
+1665,3,October,10,,St Mary Aldermary,8,6
+1665,3,October,10,,St Olave Silverstreet,6,5
+1665,3,October,10,,St Botolph Billingsgate,4,4
+1665,3,October,10,,St Mary le Bow,2,2
+1665,3,October,10,,St Pancras Soperlane,4,4
+1665,3,October,10,,Christs Church,34,30
+1665,3,October,10,,St Mary Bothaw,2,2
+1665,3,October,10,,St Peter Cheap,6,4
+1665,3,October,10,,St Christophers,6,4
+1665,3,October,10,,St Mary Colechurch,2,0
+1665,3,October,10,,St Peter Cornhil,9,5
+1665,3,October,10,,St Clement Eastcheap,2,1
+1665,3,October,10,,St Mary Hill,6,6
+1665,3,October,10,,St Peter Paulswharf,12,11
+1665,3,October,10,,St Dionis Backchurch,7,5
+1665,3,October,10,,St Mary Mounthaw,4,2
+1665,3,October,10,,St Peter Poor,4,2
+1665,3,October,10,,St Dunstan East,28,20
+1665,3,October,10,,St Mary Sommerset,30,26
+1665,3,October,10,,St Steven Colemanstreet,44,41
+1665,3,October,10,,St Edmund Lumbardstr.,12,10
+1665,3,October,10,,St Mary Stayning,3,2
+1665,3,October,10,,St Steven Walbrook,1,1
+1665,3,October,10,,St Ethelborough,10,7
+1665,3,October,10,,St Mary Woolchurch,6,5
+1665,3,October,10,,St Swithin,6,4
+1665,3,October,10,,St Faith,13,12
+1665,3,October,10,,St Mary Woolnoth,8,5
+1665,3,October,10,,St Thomas Apostle,11,10
+1665,3,October,10,,St Foster,7,6
+1665,3,October,10,,St Martin Iremongerlane,3,3
+1665,3,October,10,,Trinity Parish,12,12
+1665,3,October,10,,St Gabriel Fenchurch,5,4
+1665,3,October,10,,St Andrew Holborn,147,127
+1665,3,October,10,,St Botolph Aldgate,305,284
+1665,3,October,10,,Saviours Southwark,321,315
+1665,3,October,10,,St Bartholomew Great,6,3
+1665,3,October,10,,St Botolph Bishopsgate,145,119
+1665,3,October,10,,S. Sepulchres Parish,123,84
+1665,3,October,10,,St Bartholomew Lesse,7,7
+1665,3,October,10,,St Dunstan West,62,56
+1665,3,October,10,,St Thomas Southwark,38,32
+1665,3,October,10,,St Bridget,110,88
+1665,3,October,10,,St George Southwark,65,61
+1665,3,October,10,,Trinity Minories,15,15
+1665,3,October,10,,Bridewel Precinct,20,14
+1665,3,October,10,,St Giles Cripplegate,162,138
+1665,3,October,10,,At the Pesthouse,8,8
+1665,3,October,10,,St Botolph Aldersgate,42,42
+1665,3,October,10,,St Olave Southwark,274,177
+1665,3,October,10,,St Giles in the fields,87,74
+1665,3,October,10,,Lambeth Parish,66,62
+1665,3,October,10,,St Mary Islington,26,21
+1665,3,October,10,,Hackney Parish,8,6
+1665,3,October,10,,St Leonard Shoreditch,76,72
+1665,3,October,10,,St Mary Whitechappel,227,203
+1665,3,October,10,,St James Clerkenwel,43,31
+1665,3,October,10,,St Magdalen Bermondsey,169,146
+1665,3,October,10,,Rothorith Parish,30,27
+1665,3,October,10,,St Kath. near the Tower,63,45
+1665,3,October,10,,St Mary Newington,69,60
+1665,3,October,10,,Stepney Parish,648,593
+1665,3,October,10,,St Clement Danes,118,104
+1665,3,October,10,,St Martin in the fields,167,108
+1665,3,October,10,,St Margaret Westminster,282,261
+1665,3,October,10,,St Paul Covent Garden,15,14
+1665,3,October,10,,St Mary Savoy,15,14
+1665,10,October,17,,St ALban Woodstreet,5,2
+1665,10,October,17,,St George Botolphlane,7,7
+1665,10,October,17,,St Martin Ludgate,13,12
+1665,10,October,17,,Alhallows Barking,31,26
+1665,10,October,17,,St Gregory by St Pauls,13,12
+1665,10,October,17,,St Martin Orgars,2,1
+1665,10,October,17,,Alhallows Breadstreet,1,1
+1665,10,October,17,,St Hellen,4,4
+1665,10,October,17,,St Martin Outwitch,0,0
+1665,10,October,17,,Alhallows Great,32,30
+1665,10,October,17,,St James Dukes place,21,18
+1665,10,October,17,,St Martin Vintrey,24,19
+1665,10,October,17,,Alhallows Honylane,0,0
+1665,10,October,17,,St James Garlickhithe,19,15
+1665,10,October,17,,St Matthew Fridaystreet,1,0
+1665,10,October,17,,Alhallows Lesse,18,16
+1665,10,October,17,,St John Baptist,7,6
+1665,10,October,17,,St Maudlin Milkstreet,1,0
+1665,10,October,17,,Alhallows Lumbardstreet,2,2
+1665,10,October,17,,St John Evangelist,0,0
+1665,10,October,17,,St Maudlin Oldfishstre•t,14,12
+1665,10,October,17,,Alhallows Stayning,10,9
+1665,10,October,17,,St John Zachary,7,6
+1665,10,October,17,,St Michael B•••ishaw,6,5
+1665,10,October,17,,Alhallows the Wall,15,13
+1665,10,October,17,,St Katharine Coleman,28,24
+1665,10,October,17,,St Michael Co•nhil,4,4
+1665,10,October,17,,St Alphage,5,1
+1665,10,October,17,,St Katharine Crechurch,14,11
+1665,10,October,17,,St Michael Crookedlane,11,10
+1665,10,October,17,,St Andrew Hubbard,2,2
+1665,10,October,17,,St Lawrence Jewry,4,3
+1665,10,October,17,,St Michael Queenhithe,19,16
+1665,10,October,17,,St Andrew Undershaft,11,7
+1665,10,October,17,,St Lawrence Pountney,18,14
+1665,10,October,17,,St Michael Quern,2,0
+1665,10,October,17,,St Andrew Wardrobe,13,11
+1665,10,October,17,,St Leonard Eastcheap,4,3
+1665,10,October,17,,St Michael Royal,10,9
+1665,10,October,17,,St Ann Aldersgate,10,10
+1665,10,October,17,,St Leonard Fosterlane,6,6
+1665,10,October,17,,St Michael Woodstreet,5,3
+1665,10,October,17,,St Ann Blackfryers,30,28
+1665,10,October,17,,St Magnus Parish,6,5
+1665,10,October,17,,St Mildred Breadstreet,3,3
+1665,10,October,17,,St Antholins Parish,2,2
+1665,10,October,17,,St Margaret Lothbury,3,3
+1665,10,October,17,,St Mildred Poultrey,4,4
+1665,10,October,17,,St Austins Parish,1,0
+1665,10,October,17,,St Margaret Moses,3,3
+1665,10,October,17,,St Nicholas Acons,1,1
+1665,10,October,17,,St Bartholomew Exchange,4,3
+1665,10,October,17,,St Margaret Newfishstre.,8,5
+1665,10,October,17,,St Nicholas Coleabby,9,7
+1665,10,October,17,,St Bennet Fynck,5,5
+1665,10,October,17,,St Margaret Pattons,4,3
+1665,10,October,17,,St Nicholas Olaves,4,4
+1665,10,October,17,,St Bennet Gracechurch,4,4
+1665,10,October,17,,St Mary Abchurch,13,6
+1665,10,October,17,,St Olave Hartstreet,16,14
+1665,10,October,17,,St Bennet Paulswharf,10,8
+1665,10,October,17,,St Mary Aldermanbury,7,6
+1665,10,October,17,,St Olave Jewry,0,0
+1665,10,October,17,,St Bennet Sherehog,0,0
+1665,10,October,17,,St Mary Aldermary,4,3
+1665,10,October,17,,St Olave Silverstreet,6,5
+1665,10,October,17,,St Botolph Billingsgate,7,7
+1665,10,October,17,,St Mary le Bow,2,2
+1665,10,October,17,,St Pancras Soperlane,0,0
+1665,10,October,17,,Christ Church,27,24
+1665,10,October,17,,St Mary Bothaw,3,3
+1665,10,October,17,,St Peter Cheap,7,7
+1665,10,October,17,,St Christophers,3,3
+1665,10,October,17,,St Mary Colechurch,0,0
+1665,10,October,17,,St Peter Cornhil,11,9
+1665,10,October,17,,St Clement Eastcheap,0,0
+1665,10,October,17,,St Mary Hill,7,6
+1665,10,October,17,,St Peter Paulswharf,5,4
+1665,10,October,17,,St Dionis Backchurch,3,1
+1665,10,October,17,,St Mary Mounthaw,0,0
+1665,10,October,17,,St Peter Poor,6,6
+1665,10,October,17,,St Dunstan East,21,17
+1665,10,October,17,,St Mary Sommerset,22,18
+1665,10,October,17,,St Steven Colemanstreet,35,28
+1665,10,October,17,,St Edmund Lumbardstr.,4,4
+1665,10,October,17,,St Mary Stayning,1,0
+1665,10,October,17,,St Steven Walbrook,1,0
+1665,10,October,17,,St Ethelborough,2,1
+1665,10,October,17,,St Mary Woolchurch,6,5
+1665,10,October,17,,St Swithin,5,4
+1665,10,October,17,,St Faith,6,6
+1665,10,October,17,,St Mary Woolnoth,4,3
+1665,10,October,17,,St Thomas Apostles,4,4
+1665,10,October,17,,St Foster,6,5
+1665,10,October,17,,St Martin Iremongerlane,1,0
+1665,10,October,17,,Trinity Parish,3,2
+1665,10,October,17,,St Gabriel Fenchurch,6,5
+1665,10,October,17,,St Andrew Holborn,68,55
+1665,10,October,17,,St Botolph Aldgate,169,155
+1665,10,October,17,,Saviours Southwark,233,227
+1665,10,October,17,,St Bartholomew Great,9,5
+1665,10,October,17,,St Botolph Bishopsgate,71,53
+1665,10,October,17,,S Sepulchres Parish,67,40
+1665,10,October,17,,St Bartholomew Lesse,5,3
+1665,10,October,17,,St Dunstan West,44,35
+1665,10,October,17,,St Thomas Southwark,27,23
+1665,10,October,17,,St Bridget,63,43
+1665,10,October,17,,St George Southwark,37,34
+1665,10,October,17,,Trinity Minories,14,12
+1665,10,October,17,,Bridewel Precinct,6,4
+1665,10,October,17,,St Giles Cripplegate,88,67
+1665,10,October,17,,At the Pesthouse,4,4
+1665,10,October,17,,St Botolph Aldersgate,33,28
+1665,10,October,17,,St Olave Southwark,212,141
+1665,10,October,17,,St Giles in the fields,57,43
+1665,10,October,17,,Lambeth Parish,47,42
+1665,10,October,17,,St Mary Islington,22,18
+1665,10,October,17,,Hackney Parish,14,10
+1665,10,October,17,,St Leonard Shoreditch,50,42
+1665,10,October,17,,St Mary Whitechappel,124,103
+1665,10,October,17,,St James Clerkenwel,25,16
+1665,10,October,17,,St Magdalen Bermondsey,101,77
+1665,10,October,17,,Rothorith Parish,18,13
+1665,10,October,17,,St Kath. near the Tower,38,25
+1665,10,October,17,,St Mary Newington,43,36
+1665,10,October,17,,Stepney Parish,396,366
+1665,10,October,17,,St Clement Danes,75,55
+1665,10,October,17,,St Martin in the fields,81,60
+1665,10,October,17,,St Margaret Westminste•,185,172
+1665,10,October,17,,St Paul Covent Garden,16,9
+1665,10,October,17,,St Mary Savoy,3,3
+1665,17,October,24,,St ALban Woodstreet,5,3
+1665,17,October,24,,St George Botolphlane,0,0
+1665,17,October,24,,St Martin Ludgate,4,3
+1665,17,October,24,,Alhallows Barking,17,16
+1665,17,October,24,,St Gregory by St Pauls,5,4
+1665,17,October,24,,St Martin Orgars,2,1
+1665,17,October,24,,Alhallows Breadstreet,0,0
+1665,17,October,24,,St Hellen,0,0
+1665,17,October,24,,St Martin Outwitch,0,0
+1665,17,October,24,,Alhallows Great,15,14
+1665,17,October,24,,St James Dukes place,10,8
+1665,17,October,24,,St Martin Vintrey,8,6
+1665,17,October,24,,Alhallows Honylane,0,0
+1665,17,October,24,,St James Garlickhithe,9,8
+1665,17,October,24,,St Matthew Fridaystreet,0,0
+1665,17,October,24,,Alhallows Lesse,4,4
+1665,17,October,24,,St John Baptist,4,2
+1665,17,October,24,,St Maudlin Milkstreet,1,0
+1665,17,October,24,,Alhallows Lumbardstreet,1,1
+1665,17,October,24,,St John Evangelist,0,0
+1665,17,October,24,,St Maudlin Oldfishstreet,2,1
+1665,17,October,24,,Alhallows Stayning,4,2
+1665,17,October,24,,St John Zachary,6,5
+1665,17,October,24,,St Michael Bassishaw,2,1
+1665,17,October,24,,Alhallows the Wall,7,5
+1665,17,October,24,,St Katharine Coleman,10,8
+1665,17,October,24,,St Michael Cornhil,4,4
+1665,17,October,24,,St Alphage,5,0
+1665,17,October,24,,St Katharine Crechurch,13,10
+1665,17,October,24,,St Michael Crookedlark,8,8
+1665,17,October,24,,St Andrew Hubbard,2,0
+1665,17,October,24,,St Lawrence Jewry,1,0
+1665,17,October,24,,St Michael Queenhithe,9,7
+1665,17,October,24,,St Andrew Undershaft,5,4
+1665,17,October,24,,St Lawrence Pountney,9,6
+1665,17,October,24,,St Michael Quern,4,2
+1665,17,October,24,,St Andrew Wardrobe,8,7
+1665,17,October,24,,St Leonard Eastcheap,4,3
+1665,17,October,24,,St Michael Royal,5,3
+1665,17,October,24,,St Ann Aldersgate,6,6
+1665,17,October,24,,St Leonard Fosterlane,7,5
+1665,17,October,24,,St Michael Woodstreet,6,4
+1665,17,October,24,,St Ann Blackfryers,17,13
+1665,17,October,24,,St Magnus Parish,5,4
+1665,17,October,24,,St Mildred Breadstreet,1,1
+1665,17,October,24,,St Antholins Parish,0,0
+1665,17,October,24,,St Margaret Lothbury,4,3
+1665,17,October,24,,St Mildred Poultrey,1,1
+1665,17,October,24,,St Austins Parish,0,0
+1665,17,October,24,,St Margaret Moses,0,0
+1665,17,October,24,,St Nicholas Acons,1,1
+1665,17,October,24,,St Bartholomew Exchange,5,4
+1665,17,October,24,,St Margaret Newfishstre.,3,2
+1665,17,October,24,,St Nicholas Coleabby,2,2
+1665,17,October,24,,St Bennet Fynck,2,1
+1665,17,October,24,,St Margaret Pattons,1,1
+1665,17,October,24,,St Nicholas Olaves,4,2
+1665,17,October,24,,St Bennet Gracechurch,2,2
+1665,17,October,24,,St Mary Abchurch,5,5
+1665,17,October,24,,St Olave Hartstreet,5,4
+1665,17,October,24,,St Bennet Paulswharf,6,5
+1665,17,October,24,,St Mary Aldermanbury,3,3
+1665,17,October,24,,St Olave Jewry,2,2
+1665,17,October,24,,St Bennet Sherehog,1,0
+1665,17,October,24,,St Mary Aldermary,1,0
+1665,17,October,24,,St Olave Silverstreet,6,4
+1665,17,October,24,,St Botolph Billingsgate,3,3
+1665,17,October,24,,St Mary le Bow,1,0
+1665,17,October,24,,St Pancras Soperlane,1,1
+1665,17,October,24,,Christ Church,17,12
+1665,17,October,24,,St Mary Bothaw,0,0
+1665,17,October,24,,St Peter Cheap,3,3
+1665,17,October,24,,St Christophers,4,4
+1665,17,October,24,,St Mary Colechurch,0,0
+1665,17,October,24,,St Peter Cornhil,1,0
+1665,17,October,24,,St Clement Eastcheap,2,1
+1665,17,October,24,,St Mary Hill,2,2
+1665,17,October,24,,St Peter Paulswharf,4,3
+1665,17,October,24,,St Dionis Backchurch,2,1
+1665,17,October,24,,St Mary Mounthaw,2,1
+1665,17,October,24,,St Peter Poor,0,0
+1665,17,October,24,,St Dunstan East,10,7
+1665,17,October,24,,St Mary Sommerset,11,10
+1665,17,October,24,,St Steven Colemanstreet,12,10
+1665,17,October,24,,St Edmund Lumbardstr.,1,1
+1665,17,October,24,,St Mary Stayning,0,0
+1665,17,October,24,,St Steven Walbrook,2,2
+1665,17,October,24,,St Ethelborough,5,2
+1665,17,October,24,,St Mary Woolchurch,6,4
+1665,17,October,24,,St Swithin,0,0
+1665,17,October,24,,St Faith,3,1
+1665,17,October,24,,St Mary Woolnoth,1,0
+1665,17,October,24,,St Thomas Apostles,3,2
+1665,17,October,24,,St Foster,2,2
+1665,17,October,24,,St Martin Iremongerlane,0,0
+1665,17,October,24,,Trinity Parish,3,1
+1665,17,October,24,,St Gabriel Fenchurch,2,1
+1665,17,October,24,,St Andrew Holborn,46,32
+1665,17,October,24,,St Botolph Aldgate,99,82
+1665,17,October,24,,Saviours Southwark,106,101
+1665,17,October,24,,St Bartholomew Great,0,0
+1665,17,October,24,,St Botolph Bishopsgate,41,30
+1665,17,October,24,,S Sepulchres Parish,40,19
+1665,17,October,24,,St Bartholomew Lesse,6,5
+1665,17,October,24,,St Dunstan West,28,21
+1665,17,October,24,,St Thomas Southwark,11,10
+1665,17,October,24,,St Bridget,24,17
+1665,17,October,24,,St George Southwark,22,18
+1665,17,October,24,,Trinity Minories,2,2
+1665,17,October,24,,Bridewel Precinct,3,2
+1665,17,October,24,,St Giles Cripplegate,56,28
+1665,17,October,24,,At the Pesthouse,1,1
+1665,17,October,24,,St Botolph Aldersgate,16,15
+1665,17,October,24,,St Olave Southwark,102,73
+1665,17,October,24,,St Giles in the fields,44,33
+1665,17,October,24,,Lambeth Parish,29,28
+1665,17,October,24,,St Mary Islington,8,8
+1665,17,October,24,,Hackney Parish,6,5
+1665,17,October,24,,St Leonard Shoreditch,28,20
+1665,17,October,24,,St Mary Whitechappel,60,46
+1665,17,October,24,,St James Clerkenwel,15,6
+1665,17,October,24,,St Magdalen Bermondsey,56,51
+1665,17,October,24,,Rothorith Parish,13,7
+1665,17,October,24,,St Kath. near the Tower,26,19
+1665,17,October,24,,St Mary Newington,24,24
+1665,17,October,24,,Stepney Parish,282,246
+1665,17,October,24,,St Clement Danes,36,30
+1665,17,October,24,,St Martin in the fields,60,38
+1665,17,October,24,,St Margaret Westminster,98,93
+1665,17,October,24,,St Paul Covent Garden,13,8
+1665,17,October,24,,St Mary Savoy,3,3
+1665,24,October,31,,St ALban Woodstreet,2,1
+1665,24,October,31,,St George Botolphlane,3,3
+1665,24,October,31,,St Martin Ludgate,5,1
+1665,24,October,31,,Alhallows Barking,19,18
+1665,24,October,31,,St Gregory by St Pauls,6,5
+1665,24,October,31,,St Martin Orgars,5,4
+1665,24,October,31,,Alhallows Breadstreet,0,0
+1665,24,October,31,,St Hellen,3,1
+1665,24,October,31,,St Martin Outwitch,1,0
+1665,24,October,31,,Alhallows Great,11,9
+1665,24,October,31,,St James Dukes place,9,6
+1665,24,October,31,,St Martin Vintrey,11,10
+1665,24,October,31,,Alhallows Honylane,0,0
+1665,24,October,31,,St James Garlickhithe,7,6
+1665,24,October,31,,St Matthew Fridaystreet,1,0
+1665,24,October,31,,Alhallows Lesse,7,3
+1665,24,October,31,,St John Baptist,3,2
+1665,24,October,31,,St Maudlin Milkstreet,0,0
+1665,24,October,31,,Alhallows Lumbardstree•,0,0
+1665,24,October,31,,St John Evangelist,2,0
+1665,24,October,31,,St Maudlin Oldfishstreet,9,7
+1665,24,October,31,,Alhallows Staining,9,7
+1665,24,October,31,,St John Zachary,2,2
+1665,24,October,31,,St Michael Bassishaw,1,0
+1665,24,October,31,,Alhallows the Wall,7,6
+1665,24,October,31,,St Katharine Coleman,6,5
+1665,24,October,31,,St Michael Cornhil,1,0
+1665,24,October,31,,St Alphage,4,1
+1665,24,October,31,,St Katharine Crechurch,7,5
+1665,24,October,31,,St Michael Crookedlane,7,6
+1665,24,October,31,,St Andrew Hubbard,2,2
+1665,24,October,31,,St Lawrence Jewry,1,1
+1665,24,October,31,,St Michael Queenhithe,5,5
+1665,24,October,31,,St Andrew Undershaft,4,3
+1665,24,October,31,,St Lawrence Pountney,5,2
+1665,24,October,31,,St Michael Quern,0,0
+1665,24,October,31,,St Andrew Wardrobe,6,2
+1665,24,October,31,,St Leonard Eastcheap,1,1
+1665,24,October,31,,St Michael Royal,6,3
+1665,24,October,31,,St Ann Aldersgate,2,2
+1665,24,October,31,,St Leonard Fosterlane,4,2
+1665,24,October,31,,St Michael Woodstreet,2,1
+1665,24,October,31,,St Ann Blackfryers,9,6
+1665,24,October,31,,St Magnus Parish,3,2
+1665,24,October,31,,St Mildred Breadstreet,2,0
+1665,24,October,31,,St Antholins Parish,0,0
+1665,24,October,31,,St Margaret Lothbury,3,2
+1665,24,October,31,,St Mildred Poultrey,1,0
+1665,24,October,31,,St Austins Parish,0,0
+1665,24,October,31,,St Margaret Moses,4,1
+1665,24,October,31,,St Nicholas Acons,1,1
+1665,24,October,31,,St Bartholomew Exchange,2,1
+1665,24,October,31,,St Margaret Newfishstreet,2,1
+1665,24,October,31,,St Nicholas Coleabby,5,4
+1665,24,October,31,,St Bennet Fynck,0,0
+1665,24,October,31,,St Margaret Pattons,1,1
+1665,24,October,31,,St Nicholas Olaves,3,3
+1665,24,October,31,,St Bennet Gracechurch,0,0
+1665,24,October,31,,St Mary Abchurch,0,0
+1665,24,October,31,,St Olave Hartstreet,7,7
+1665,24,October,31,,St Bennet Paulswharf,2,0
+1665,24,October,31,,St Mary Aldermanbury,4,4
+1665,24,October,31,,St Olave Jewry,2,2
+1665,24,October,31,,St Bennet Sherehog,0,0
+1665,24,October,31,,St Mary Aldermary,0,0
+1665,24,October,31,,St Olave Silverstreet,2,1
+1665,24,October,31,,St Botolph Billingsgate,6,3
+1665,24,October,31,,St Mary le Bow,0,0
+1665,24,October,31,,St Pancras Soperlane,1,0
+1665,24,October,31,,Christs Church,8,8
+1665,24,October,31,,St Mary Bothaw,0,0
+1665,24,October,31,,St Peter Cheap,1,0
+1665,24,October,31,,St Christophers,0,0
+1665,24,October,31,,St Mary Colechurch,1,1
+1665,24,October,31,,St Peter Cornhil,7,5
+1665,24,October,31,,St Clement Eastcheap,1,0
+1665,24,October,31,,St Mary Hill,3,3
+1665,24,October,31,,St Peter Paulswharf,1,1
+1665,24,October,31,,St Dionis Backchurch,5,4
+1665,24,October,31,,St Mary Mounthaw,0,0
+1665,24,October,31,,St Peter Poor,1,1
+1665,24,October,31,,St Dunstan East,4,4
+1665,24,October,31,,St Mary Sommerset,7,5
+1665,24,October,31,,St Steven Colemanstreet,13,12
+1665,24,October,31,,St Edmund Lumbardstr.,0,0
+1665,24,October,31,,St Mary Stayning,0,0
+1665,24,October,31,,St Steven Walbrook,1,1
+1665,24,October,31,,St Ethelborough,0,0
+1665,24,October,31,,St Mary Woolchurch,3,1
+1665,24,October,31,,St Swithin,1,0
+1665,24,October,31,,St Faith,3,3
+1665,24,October,31,,St Mary Woolnoth,5,4
+1665,24,October,31,,St Thomas Apostle,4,3
+1665,24,October,31,,St Foster,1,1
+1665,24,October,31,,St Martin Iremongerlane,0,0
+1665,24,October,31,,Trinity Parish,5,5
+1665,24,October,31,,St Gabriel Fenchurch,4,0
+1665,24,October,31,,St Andrew Holborn,40,31
+1665,24,October,31,,St Botolph Aldgate,65,53
+1665,24,October,31,,Saviours Southwark,89,82
+1665,24,October,31,,St Bartholomew Great,3,1
+1665,24,October,31,,St Botolph Bishopsgate,28,24
+1665,24,October,31,,S. Sepulchres Parish,22,11
+1665,24,October,31,,St Bartholomew Lesse,6,5
+1665,24,October,31,,St Dunstan West,21,15
+1665,24,October,31,,St Thomas Southwark,5,5
+1665,24,October,31,,St Bridget,29,15
+1665,24,October,31,,St George Southwark,16,14
+1665,24,October,31,,Trinity Minories,2,2
+1665,24,October,31,,Bridewel Precinct,5,3
+1665,24,October,31,,St Giles Cripplegate,39,22
+1665,24,October,31,,At the Pesthouse,4,4
+1665,24,October,31,,St Botolph Aldersgate,13,11
+1665,24,October,31,,St Olave Southwark,83,58
+1665,24,October,31,,"Ch•istned in the 16 Parishes without the Walls 36 Buried, and at the Pesthouse",470,356
+1665,24,October,31,,St Giles in the fields,30,20
+1665,24,October,31,,Lambeth Parish,33,23
+1665,24,October,31,,St Mary Islington,9,8
+1665,24,October,31,,Hackney Parish,3,3
+1665,24,October,31,,St Leonard Shoreditch,14,10
+1665,24,October,31,,St Mary Whitechappel,37,21
+1665,24,October,31,,St James Clerkenwel,13,5
+1665,24,October,31,,St Magdalen Bermondsey,57,40
+1665,24,October,31,,Rothorith Parish,12,8
+1665,24,October,31,,St Kath. near the Tower,21,13
+1665,24,October,31,,St Mary Newington,11,7
+1665,24,October,31,,Stepney Parish,195,165
+1665,24,October,31,,St Clement Danes,23,16
+1665,24,October,31,,St Martin in the fields,48,25
+1665,24,October,31,,St Margaret Westminster,78,72
+1665,24,October,31,,St Paul Covent Garden,6,4
+1665,24,October,31,,St Mary Savoy,3,2
+1665,31,October,7,November,St ALban Woodstreet,3,3
+1665,31,October,7,November,St George Botolphlane,4,1
+1665,31,October,7,November,St Martin Ludgate,6,5
+1665,31,October,7,November,Alhallows Barking,22,19
+1665,31,October,7,November,St Gregory by St Pauls,9,8
+1665,31,October,7,November,St Martin Orgars,1,1
+1665,31,October,7,November,••hallows Breadstreet,1,1
+1665,31,October,7,November,St Hellen,1,1
+1665,31,October,7,November,St Martin Outwitch,0,0
+1665,31,October,7,November,Alhallows Great,12,11
+1665,31,October,7,November,St James Dukes place,4,3
+1665,31,October,7,November,St Martin Vintrey,7,7
+1665,31,October,7,November,•lhallows Honylane,0,0
+1665,31,October,7,November,St James Garlickhithe,10,8
+1665,31,October,7,November,St Matthew Fridaystreet,3,2
+1665,31,October,7,November,Al•allows Lesse,8,7
+1665,31,October,7,November,St John Baptist,8,3
+1665,31,October,7,November,St Maudlin Milkstreet,1,0
+1665,31,October,7,November,•l•allows Lumbardstreet,1,0
+1665,31,October,7,November,St John Evangelist,0,0
+1665,31,October,7,November,St Maudlin Oldfishstreet,6,5
+1665,31,October,7,November,••hallows Staining,6,5
+1665,31,October,7,November,St John Zachary,1,1
+1665,31,October,7,November,St Michael Bassishaw,2,1
+1665,31,October,7,November,••hallows the Wall,17,14
+1665,31,October,7,November,St Katharine Coleman,6,6
+1665,31,October,7,November,St Michael Cornhil,3,1
+1665,31,October,7,November,St Alphage,1,0
+1665,31,October,7,November,St Katharine Crechurch,12,10
+1665,31,October,7,November,St Michael Crookedlane,5,5
+1665,31,October,7,November,St Andrew Hubbard,6,3
+1665,31,October,7,November,St Lawrence Jewry,2,1
+1665,31,October,7,November,St Michael Queenhithe,3,1
+1665,31,October,7,November,St Andrew Undershaft,9,7
+1665,31,October,7,November,St Lawrence Pountney,11,8
+1665,31,October,7,November,St Michael Quern,0,0
+1665,31,October,7,November,St Andrew Wardrobe,8,4
+1665,31,October,7,November,St Leonard Eastcheap,2,2
+1665,31,October,7,November,St Michael Royal,4,3
+1665,31,October,7,November,St Ann Aldersgate,5,4
+1665,31,October,7,November,St Leonard Fosterlane,5,3
+1665,31,October,7,November,St Michael Woodstreet,4,3
+1665,31,October,7,November,St Ann Blackfryers,18,13
+1665,31,October,7,November,St Magnus Parish,2,1
+1665,31,October,7,November,St Mildred Breadstreet,1,0
+1665,31,October,7,November,St Antholins Parish,0,0
+1665,31,October,7,November,St Margaret Lothbury,4,4
+1665,31,October,7,November,St Mildred Poultrey,4,3
+1665,31,October,7,November,St Austins Parish,0,0
+1665,31,October,7,November,St Margaret Moses,1,0
+1665,31,October,7,November,St Nicholas Acons,1,1
+1665,31,October,7,November,St Bartholomew Exchange,2,2
+1665,31,October,7,November,St Margaret Newfishstreet,9,6
+1665,31,October,7,November,St Nicholas Coleabby,5,4
+1665,31,October,7,November,St Bennet Fynck,2,1
+1665,31,October,7,November,St Margaret Pattons,2,1
+1665,31,October,7,November,St Nicholas Olaves,4,3
+1665,31,October,7,November,St Bennet Gracechurch,1,1
+1665,31,October,7,November,St Mary Abchurch,4,4
+1665,31,October,7,November,St Olave Hartstreet,11,7
+1665,31,October,7,November,St Bennet Paulswharf,7,5
+1665,31,October,7,November,St Mary Aldermanbury,7,3
+1665,31,October,7,November,St Olave Jewry,1,1
+1665,31,October,7,November,St Bennet Sherehog,0,0
+1665,31,October,7,November,St Mary Aldermary,9,7
+1665,31,October,7,November,St Olave Silverstreet,1,1
+1665,31,October,7,November,St Botolph Billingsgate,5,5
+1665,31,October,7,November,St Mary le Bow,0,0
+1665,31,October,7,November,St Pancras Soperlane,1,0
+1665,31,October,7,November,Christs Church,13,12
+1665,31,October,7,November,St Mary Bothaw,2,2
+1665,31,October,7,November,St Peter Cheap,1,1
+1665,31,October,7,November,St Christophers,2,2
+1665,31,October,7,November,St Mary Colechurch,0,0
+1665,31,October,7,November,St Peter Cornhil,5,3
+1665,31,October,7,November,St Clement Eastcheap,3,1
+1665,31,October,7,November,St Mary Hill,4,4
+1665,31,October,7,November,St Peter Paulswharf,4,2
+1665,31,October,7,November,•• Dionis Backchurch,3,1
+1665,31,October,7,November,St Mary Mounthaw,1,1
+1665,31,October,7,November,St Peter Poor,3,2
+1665,31,October,7,November,St Dunstan East,7,5
+1665,31,October,7,November,St Mary Sommerset,15,12
+1665,31,October,7,November,St Steven Colemanstreet,10,9
+1665,31,October,7,November,St Edmund Lumbardstr.,0,0
+1665,31,October,7,November,St Mary Stayning,1,0
+1665,31,October,7,November,St Steven Walbrook,1,1
+1665,31,October,7,November,St Ethelborough,1,0
+1665,31,October,7,November,St Mary Woolchurch,1,1
+1665,31,October,7,November,St Swithin,3,1
+1665,31,October,7,November,St Faith,2,1
+1665,31,October,7,November,St Mary Woolnoth,0,0
+1665,31,October,7,November,St Thomas Apostle,5,4
+1665,31,October,7,November,St Foster,0,0
+1665,31,October,7,November,St Martin Iremongerlane,2,2
+1665,31,October,7,November,Trinity Parish,4,3
+1665,31,October,7,November,St Gabriel Fenchurch,4,4
+1665,31,October,7,November,•t Andrew Holborn,43,36
+1665,31,October,7,November,St Botolph Aldgate,85,68
+1665,31,October,7,November,Saviours Southwark,113,108
+1665,31,October,7,November,St Bartholomew Great,4,4
+1665,31,October,7,November,St Botolph Bishopsgate,34,24
+1665,31,October,7,November,S. Sepulchres Parish,27,16
+1665,31,October,7,November,•• Bartholomew Lesse,3,3
+1665,31,October,7,November,St Dunstan West,20,13
+1665,31,October,7,November,St Thomas Southwark,10,8
+1665,31,October,7,November,St Bridget,24,16
+1665,31,October,7,November,St George Southwark,26,22
+1665,31,October,7,November,Trinity Minories,5,4
+1665,31,October,7,November,•••dewel Precinct,3,3
+1665,31,October,7,November,St Giles Cripplegate,48,39
+1665,31,October,7,November,At the Pesthouse,0,0
+1665,31,October,7,November,•t Botolph Aldersgate,15,14
+1665,31,October,7,November,St Olave Southwark,86,67
+1665,31,October,7,November,"Ch•istned in the 16 Parishes without the Walls 32 Buried, and at the Pesthouse",546,445
+1665,31,October,7,November,•t Giles in the fields,32,24
+1665,31,October,7,November,Lambeth Parish,51,39
+1665,31,October,7,November,St Mary Islington,6,4
+1665,31,October,7,November,••ckney Parish,11,9
+1665,31,October,7,November,St Leonard Shoreditch,28,21
+1665,31,October,7,November,St Mary Whitechappel,57,40
+1665,31,October,7,November,S• James Clerkenwel,12,5
+1665,31,October,7,November,St Magdalen Bermondsey,80,57
+1665,31,October,7,November,Rothorith Parish,15,12
+1665,31,October,7,November,•• Kath. near the Tower,13,8
+1665,31,October,7,November,St Mary Newington,22,16
+1665,31,October,7,November,Stepney Parish,282,253
+1665,31,October,7,November,St Clement Danes,38,28
+1665,31,October,7,November,St Martin in the fields,61,37
+1665,31,October,7,November,St Margaret Westminster,102,92
+1665,31,October,7,November,St Paul Covent Garden,5,3
+1665,31,October,7,November,St Mary Savoy,8,7
+1665,31,October,7,November,hristned in the 5 Parishes in the City and Liberties of Westminster 12 Buried,214,167
+1665,7,November,14,,St ALban Woodstreet,2,2
+1665,7,November,14,,St George Botolphlane,5,4
+1665,7,November,14,,St Martin Ludgate,3,3
+1665,7,November,14,,Alhallows Barking,12,10
+1665,7,November,14,,St Gregory by St Pauls,8,5
+1665,7,November,14,,St Martin Orgars,1,0
+1665,7,November,14,,Alhallows Breadstreet,1,1
+1665,7,November,14,,St Hellen,0,0
+1665,7,November,14,,St Martin Outwitch,1,0
+1665,7,November,14,,Alhallows Great,7,7
+1665,7,November,14,,St James Dukes place,3,3
+1665,7,November,14,,St Martin Vintrey,12,7
+1665,7,November,14,,Alhallows H••ylane,0,0
+1665,7,November,14,,St James Garlickhithe,12,8
+1665,7,November,14,,St Matthew Fridaystreet,2,0
+1665,7,November,14,,Alhallows Lesse,3,3
+1665,7,November,14,,St John Baptist,9,5
+1665,7,November,14,,St Maudlin Milkstreet,0,0
+1665,7,November,14,,Alhallows Lumbardstreet,1,0
+1665,7,November,14,,St John Evangelist,0,0
+1665,7,November,14,,St Maudlin Oldfishstreet,8,7
+1665,7,November,14,,Alhallows Staynin•,7,6
+1665,7,November,14,,St John Zachary,3,0
+1665,7,November,14,,St Michael Bassishaw,1,0
+1665,7,November,14,,Alhallows the Wall,10,10
+1665,7,November,14,,St Katharine Coleman,7,7
+1665,7,November,14,,St Michael Cornhil,2,2
+1665,7,November,14,,St Alphage,2,1
+1665,7,November,14,,St Katharine Crechurch,15,9
+1665,7,November,14,,St Michael Crookedlane,8,6
+1665,7,November,14,,St Andrew Hubbard,2,1
+1665,7,November,14,,St Lawrence Jewry,2,1
+1665,7,November,14,,St Michael Queenhithe,3,3
+1665,7,November,14,,St Andrew Undershaft,4,3
+1665,7,November,14,,St Lawrence Pountney,5,5
+1665,7,November,14,,St Michael Quern,1,0
+1665,7,November,14,,St Andrew Wardrobe,5,3
+1665,7,November,14,,St Leonard Eastcheap,2,2
+1665,7,November,14,,St Michael Royal,3,2
+1665,7,November,14,,St Ann Aldersgate,4,3
+1665,7,November,14,,St Leonard Fosterlane,6,6
+1665,7,November,14,,St Michael Woodstreet,3,2
+1665,7,November,14,,St Ann Blackfryers,13,12
+1665,7,November,14,,St Magnus Parish,3,3
+1665,7,November,14,,St Mildred Breadstreet,1,1
+1665,7,November,14,,St Antholins-Parish,0,0
+1665,7,November,14,,St Margaret Lothbury,3,3
+1665,7,November,14,,St Mildred Poultrey,0,0
+1665,7,November,14,,St Austins Parish,0,0
+1665,7,November,14,,St Margaret Moses,1,1
+1665,7,November,14,,St Nicholas Acons,3,3
+1665,7,November,14,,St Bartholomew Exchange,4,4
+1665,7,November,14,,St Margaret Newfishstre.,3,2
+1665,7,November,14,,St Nicholas Coleabby,2,2
+1665,7,November,14,,St Bennet Fynck,1,1
+1665,7,November,14,,St Margaret Pattons,1,0
+1665,7,November,14,,St Nicholas Olaves,2,2
+1665,7,November,14,,St Bennet Gracechurch,2,1
+1665,7,November,14,,St Mary Abchurch,5,3
+1665,7,November,14,,St Olave Hartstreet,9,7
+1665,7,November,14,,St Bennet Paulswharf,3,3
+1665,7,November,14,,St Mary Aldermanbury,3,0
+1665,7,November,14,,St Olave Jewry,0,0
+1665,7,November,14,,St Bennet Sherehog,0,0
+1665,7,November,14,,St Mary Aldermary,0,0
+1665,7,November,14,,St Olave Silverstreet,1,0
+1665,7,November,14,,St Botolph Billingsgate,6,4
+1665,7,November,14,,St Mary le Bow,1,1
+1665,7,November,14,,St Pancras Soperlane,0,0
+1665,7,November,14,,Christ Church,10,8
+1665,7,November,14,,St Mary Bothaw,1,0
+1665,7,November,14,,St Peter Cheap,1,1
+1665,7,November,14,,St Christophers,1,1
+1665,7,November,14,,St Mary Colechurch,0,0
+1665,7,November,14,,St Peter Cornhil,4,3
+1665,7,November,14,,St Clement Eastcheap,3,0
+1665,7,November,14,,St Mary Hill,6,6
+1665,7,November,14,,St Peter Paulswharf,4,4
+1665,7,November,14,,St Di•nis Backchurch,1,0
+1665,7,November,14,,St Mary Mounthaw,0,0
+1665,7,November,14,,St Peter Poor,0,0
+1665,7,November,14,,St Dunstan East,5,4
+1665,7,November,14,,St Mary Sommerset,9,9
+1665,7,November,14,,St Steven Colemanstreet,13,13
+1665,7,November,14,,St Edmund Lumbardstr.,5,3
+1665,7,November,14,,St Mary Stayning,0,0
+1665,7,November,14,,St Steven Walbrook,1,1
+1665,7,November,14,,St Ethelborough,3,1
+1665,7,November,14,,St Mary Woolchurch,3,2
+1665,7,November,14,,St Swithin,4,2
+1665,7,November,14,,St Faith,2,1
+1665,7,November,14,,St Mary Woolnoth,1,0
+1665,7,November,14,,St Thomas Apostles,5,3
+1665,7,November,14,,St Foster,3,3
+1665,7,November,14,,St Martin Iremongerlane,0,0
+1665,7,November,14,,Trinity Parish,3,1
+1665,7,November,14,,St Gabriel Fenchurch,6,6
+1665,7,November,14,,St Andrew Holborn,38,28
+1665,7,November,14,,St Botolph Aldgate,55,44
+1665,7,November,14,,Saviours Southwark,79,77
+1665,7,November,14,,St Bartholomew Great,1,0
+1665,7,November,14,,St Botolph Bishopsgate,23,17
+1665,7,November,14,,S Sepulchres Parish,26,13
+1665,7,November,14,,St Bartholomew Lesse,4,4
+1665,7,November,14,,St Dunstan West,20,17
+1665,7,November,14,,St Thomas Southwark,10,0
+1665,7,November,14,,St Bridget,18,10
+1665,7,November,14,,St George Southwark,13,13
+1665,7,November,14,,Trinity Minories,3,3
+1665,7,November,14,,Bridewel Precinct,1,1
+1665,7,November,14,,St Giles Cripplegate,34,23
+1665,7,November,14,,At the Pesthouse,1,1
+1665,7,November,14,,St Botolph Aldersgate,6,5
+1665,7,November,14,,St Olave Southwark,65,44
+1665,7,November,14,,"Ch•istned in the 16 Parishes without the Walls 30 Buried, and at the Pesthouse",397,309
+1665,7,November,14,,St Giles in the fields,26,21
+1665,7,November,14,,Lambeth Parish,54,46
+1665,7,November,14,,St Mary Islington,10,9
+1665,7,November,14,,Hackney Parish,2,2
+1665,7,November,14,,St Leonard Shoreditch,19,14
+1665,7,November,14,,St Mary Whitechappel,46,29
+1665,7,November,14,,St James Clerkenwel,12,4
+1665,7,November,14,,St Magdalen Bermondsey,42,36
+1665,7,November,14,,Rothorith Parish,13,10
+1665,7,November,14,,St Kath. near the Tower,14,9
+1665,7,November,14,,St Mary Newington,7,5
+1665,7,November,14,,Stepney Parish,215,191
+1665,7,November,14,,St Clement Danes,32,19
+1665,7,November,14,,St Martin in the fields,50,23
+1665,7,November,14,,St Margaret Westminster,66,57
+1665,7,November,14,,St Paul Covent Garden,5,2
+1665,7,November,14,,St Mary Savoy,3,2
+1665,14,November,21,,St ALban Woodstreet,2,1
+1665,14,November,21,,St George Botolphlane,3,2
+1665,14,November,21,,St Martin Ludgate,2,0
+1665,14,November,21,,Alhallows Barking,7,6
+1665,14,November,21,,St Gregory by St Pauls,4,4
+1665,14,November,21,,St Martin Orgars,1,1
+1665,14,November,21,,••hallows Breadstreet,0,0
+1665,14,November,21,,St Hellen,1,0
+1665,14,November,21,,St Martin Outwitch,0,0
+1665,14,November,21,,•lhallows Great,6,5
+1665,14,November,21,,St James Dukes place,1,1
+1665,14,November,21,,St Martin Vintrey,5,3
+1665,14,November,21,,••hallows Honylane,0,0
+1665,14,November,21,,St James Garlickhithe,5,3
+1665,14,November,21,,St Matthew Fridaystreet,1,0
+1665,14,November,21,,Alhallows Lesse,5,2
+1665,14,November,21,,St John Baptist,5,3
+1665,14,November,21,,St Maudlin Milkstreet,0,0
+1665,14,November,21,,Alhallows Lumbardstreet,0,0
+1665,14,November,21,,St John Evangelist,0,0
+1665,14,November,21,,St Maudlin Oldfishstreet,4,4
+1665,14,November,21,,Alhallows Stayning,3,1
+1665,14,November,21,,St John Zachary,0,0
+1665,14,November,21,,St Michael Bassishaw,2,1
+1665,14,November,21,,Alhallows the Wall,6,5
+1665,14,November,21,,St Katharine Coleman,8,7
+1665,14,November,21,,St Michael Cornhil,0,0
+1665,14,November,21,,St Alphage,4,2
+1665,14,November,21,,St Katharine Crechurch,8,6
+1665,14,November,21,,St Michael Crookedlane,1,1
+1665,14,November,21,,St Andrew Hubbard,2,0
+1665,14,November,21,,St Lawrence Jewry,0,0
+1665,14,November,21,,St Michael Queenhithe,4,2
+1665,14,November,21,,St Andrew Undershaft,2,1
+1665,14,November,21,,St Lawrence Pountney,3,2
+1665,14,November,21,,St Michael Quern,0,0
+1665,14,November,21,,St Andrew Wardrobe,4,3
+1665,14,November,21,,St Leonard Eastcheap,0,0
+1665,14,November,21,,St Michael Royal,2,1
+1665,14,November,21,,St Ann Aldersgate,4,3
+1665,14,November,21,,St Leonard Fosterlane,3,2
+1665,14,November,21,,St Michael Woodstreet,1,0
+1665,14,November,21,,St Ann Blackfryers,5,2
+1665,14,November,21,,St Magnus Parish,1,1
+1665,14,November,21,,St Mildred Breadstreet,0,0
+1665,14,November,21,,St Antholins Parish,1,0
+1665,14,November,21,,St Margaret Lothbury,1,1
+1665,14,November,21,,St Mildred Poultrey,1,1
+1665,14,November,21,,St Austins Parish,1,0
+1665,14,November,21,,St Margaret Moses,0,0
+1665,14,November,21,,St Nicholas Acons,3,1
+1665,14,November,21,,St Bartholomew Exchange,3,1
+1665,14,November,21,,St Margaret Newfishstre.,1,1
+1665,14,November,21,,St Nicholas Coleabby,4,3
+1665,14,November,21,,St Bennet Fynck,0,0
+1665,14,November,21,,St Margaret Pattons,0,0
+1665,14,November,21,,St Nicholas Olaves,1,1
+1665,14,November,21,,St Bennet Gracechurch,0,0
+1665,14,November,21,,St Mary Abchurch,0,0
+1665,14,November,21,,St Olave Hartstreet,1,0
+1665,14,November,21,,St Bennet Paulswharf,1,1
+1665,14,November,21,,St Mary Aldermanbury,0,0
+1665,14,November,21,,St Olave Jewry,1,1
+1665,14,November,21,,St Bennet Sherehog,0,0
+1665,14,November,21,,St Mary Aldermary,3,3
+1665,14,November,21,,St Olave Silverstreet,1,0
+1665,14,November,21,,St Botolph Billingsgate,4,3
+1665,14,November,21,,St Mary le Bow,0,0
+1665,14,November,21,,St Pancras Soperlane,0,0
+1665,14,November,21,,Christ Church,3,3
+1665,14,November,21,,St Mary Bothaw,1,0
+1665,14,November,21,,St Peter Cheap,0,0
+1665,14,November,21,,St Christophers,0,0
+1665,14,November,21,,St Mary Colechurch,1,0
+1665,14,November,21,,St Peter Cornhil,0,0
+1665,14,November,21,,St Clement Eastcheap,1,1
+1665,14,November,21,,St Mary Hill,4,2
+1665,14,November,21,,St Peter Paulswharf,0,0
+1665,14,November,21,,St Dionis Backchurch,2,0
+1665,14,November,21,,St Mary Mounthaw,1,0
+1665,14,November,21,,St Peter Poor,0,0
+1665,14,November,21,,St Dunstan East,4,3
+1665,14,November,21,,St Mary Sommerset,5,5
+1665,14,November,21,,St Steven Colemanstreet,9,8
+1665,14,November,21,,St Edmund Lumbardstr.,5,3
+1665,14,November,21,,St Mary Stayning,0,0
+1665,14,November,21,,St Steven Walbrook,0,0
+1665,14,November,21,,St Ethelborough,2,0
+1665,14,November,21,,St Mary Woolchurch,0,0
+1665,14,November,21,,St Swithin,3,2
+1665,14,November,21,,St Faith,0,0
+1665,14,November,21,,St Mary Woolnoth,3,2
+1665,14,November,21,,St Thomas Apostles,1,1
+1665,14,November,21,,St Foster,2,2
+1665,14,November,21,,St Martin Iremongerlane,0,0
+1665,14,November,21,,Trinity Parish,4,2
+1665,14,November,21,,St Gabriel Fenchurch,2,1
+1665,14,November,21,,St Andrew Holborn,25,18
+1665,14,November,21,,St Botolph Aldgate,33,24
+1665,14,November,21,,Saviours Southwark,68,65
+1665,14,November,21,,St Bartholomew Great,3,2
+1665,14,November,21,,St Botolph Bishopsgate,14,11
+1665,14,November,21,,S Sepulchres Parish,14,9
+1665,14,November,21,,St Bartholomew Lesse,2,1
+1665,14,November,21,,St Dunstan West,16,9
+1665,14,November,21,,St Thomas Southwark,9,8
+1665,14,November,21,,St Bridget,14,6
+1665,14,November,21,,St George Southwark,11,8
+1665,14,November,21,,Trinity Minories,3,0
+1665,14,November,21,,Bridewel Precinct,2,2
+1665,14,November,21,,St Giles Cripplegate,28,17
+1665,14,November,21,,At the Pesthouse,2,2
+1665,14,November,21,,St Botolph Aldersgate,7,6
+1665,14,November,21,,St Olave Southwark,47,29
+1665,14,November,21,,"Ch•istned in the 16 Parishes without the Walls 31 Buried, and at the Pesthouse",298,217
+1665,14,November,21,,St Giles in the fields,22,16
+1665,14,November,21,,Lambeth Parish,36,35
+1665,14,November,21,,St Mary Islington,6,3
+1665,14,November,21,,Hackney Parish,4,3
+1665,14,November,21,,St Leonard Shoreditch,10,6
+1665,14,November,21,,St Mary Whitechappel,35,30
+1665,14,November,21,,St James Clerkenwel,8,2
+1665,14,November,21,,St Magdalen Bermondsey,27,19
+1665,14,November,21,,Rothorith Parish,13,10
+1665,14,November,21,,St Kath. near the Tower,9,7
+1665,14,November,21,,St Mary Newington,3,1
+1665,14,November,21,,Stepney Parish,129,103
+1665,14,November,21,,St Clement Danes,15,7
+1665,14,November,21,,St Martin in the fields,38,15
+1665,14,November,21,,St Margaret Westminster,46,45
+1665,14,November,21,,St Paul Covent Garden,5,2
+1665,14,November,21,,St Mary Savoy,6,4
+1665,21,November,28,,St ALban Woodstreet,2,1
+1665,21,November,28,,St George Botolphlane,0,0
+1665,21,November,28,,St Martin Ludgate,2,0
+1665,21,November,28,,Alhallows Barking,8,4
+1665,21,November,28,,St Gregory by St Pauls,3,1
+1665,21,November,28,,St Martin Orgars,0,0
+1665,21,November,28,,Alhallows Breadstreet,0,0
+1665,21,November,28,,St Hellen,1,1
+1665,21,November,28,,St Martin Outwitch,0,0
+1665,21,November,28,,Alhallows Great,7,5
+1665,21,November,28,,St James Dukes place,2,2
+1665,21,November,28,,St Martin Vintrey,4,4
+1665,21,November,28,,Alhallows Honylane,0,0
+1665,21,November,28,,St James Garlickhithe,3,2
+1665,21,November,28,,St Matthew Fridaystreet,0,0
+1665,21,November,28,,Alhallows Lesse,2,2
+1665,21,November,28,,St John Baptist,4,3
+1665,21,November,28,,St Maudlin Milkstreet,0,0
+1665,21,November,28,,Alhallows Lumbardstreet,0,0
+1665,21,November,28,,St John Evangelist,0,0
+1665,21,November,28,,St Maudlin Oldfishstreet,1,1
+1665,21,November,28,,Alhallows Staining,1,0
+1665,21,November,28,,St John Zachary,0,0
+1665,21,November,28,,St Michael Bassishaw,1,0
+1665,21,November,28,,Alhallows the Wall,3,2
+1665,21,November,28,,St Katharine Coleman,1,1
+1665,21,November,28,,St Michael Cornhil,1,0
+1665,21,November,28,,St Alphage,0,0
+1665,21,November,28,,St Katharine Crechurch,5,4
+1665,21,November,28,,St Michael Crookedlane,4,2
+1665,21,November,28,,St Andrew Hubbard,0,0
+1665,21,November,28,,St Lawrence Jewry,0,0
+1665,21,November,28,,St Michael Queenhithe,0,0
+1665,21,November,28,,St Andrew Undershaft,1,1
+1665,21,November,28,,St Lawrence Pountney,1,1
+1665,21,November,28,,St Michael Quern,0,0
+1665,21,November,28,,St Andrew Wardrobe,2,1
+1665,21,November,28,,St Leonard Eastcheap,0,0
+1665,21,November,28,,St Michael Royal,1,1
+1665,21,November,28,,St Ann Aldersgate,1,0
+1665,21,November,28,,St Leonard Fosterlane,2,1
+1665,21,November,28,,St Michael Woodstreet,1,1
+1665,21,November,28,,St Ann Blackfryers,6,4
+1665,21,November,28,,St Magnus Parish,1,1
+1665,21,November,28,,St Mildred Breadstreet,1,0
+1665,21,November,28,,St Antholins Parish,1,1
+1665,21,November,28,,St Margaret Lothbury,0,0
+1665,21,November,28,,St Mildred Poultrey,0,0
+1665,21,November,28,,St Austins Parish,0,0
+1665,21,November,28,,St Margaret Moses,1,1
+1665,21,November,28,,St Nicholas Acons,0,0
+1665,21,November,28,,St Bartholomew Exchange,2,2
+1665,21,November,28,,St Margaret Newfishstreet,0,0
+1665,21,November,28,,St Nicholas Coleabby,0,0
+1665,21,November,28,,St Bennet Fynck,0,0
+1665,21,November,28,,St Margaret Pattons,0,0
+1665,21,November,28,,St Nicholas Olaves,0,0
+1665,21,November,28,,St Bennet Gracechurch,2,2
+1665,21,November,28,,St Mary Abchurch,0,0
+1665,21,November,28,,St Olave Hartstreet,3,0
+1665,21,November,28,,St Bennet Paulswharf,1,0
+1665,21,November,28,,St Mary Aldermanbury,0,0
+1665,21,November,28,,St Olave Jewry,0,0
+1665,21,November,28,,St Bennet Sherehog,0,0
+1665,21,November,28,,St Mary Aldermary,4,3
+1665,21,November,28,,St Olave Silverstreet,3,1
+1665,21,November,28,,St Botolph Billingsgate,1,0
+1665,21,November,28,,St Mary le Bow,0,0
+1665,21,November,28,,St Pancras Soperlane,1,1
+1665,21,November,28,,Christs Church,12,5
+1665,21,November,28,,St Mary Bothaw,1,0
+1665,21,November,28,,St Peter Cheap,0,0
+1665,21,November,28,,St Christophers,0,0
+1665,21,November,28,,St Mary Colechurch,0,0
+1665,21,November,28,,St Peter Cornhil,3,2
+1665,21,November,28,,St Clement Eastcheap,1,1
+1665,21,November,28,,St Mary Hill,1,0
+1665,21,November,28,,St Peter Paulswharf,0,0
+1665,21,November,28,,St Dionis Backchurch,3,0
+1665,21,November,28,,St Mary Mounthaw,0,0
+1665,21,November,28,,St Peter Poor,2,1
+1665,21,November,28,,St Dunstan East,8,6
+1665,21,November,28,,St Mary Sommerset,5,3
+1665,21,November,28,,St Steven Colemanstreet,4,4
+1665,21,November,28,,St Edmund Lumbardstr.,0,0
+1665,21,November,28,,St Mary Stayning,0,0
+1665,21,November,28,,St Steven Walbrook,0,0
+1665,21,November,28,,St Ethelborough,1,1
+1665,21,November,28,,St Mary Woolchurch,0,0
+1665,21,November,28,,St Swithin,1,0
+1665,21,November,28,,St Faith,1,1
+1665,21,November,28,,St Mary Woolnoth,1,0
+1665,21,November,28,,St Thomas Apostle,0,0
+1665,21,November,28,,St Foster,1,1
+1665,21,November,28,,St Martin Iremongerlane,0,0
+1665,21,November,28,,Trinity Parish,0,0
+1665,21,November,28,,St Gabriel Fenchurch,0,0
+1665,21,November,28,,St Andrew Holborn,15,10
+1665,21,November,28,,St Botolph Aldgate,22,8
+1665,21,November,28,,Saviours Southwark,28,22
+1665,21,November,28,,St Bartholomew Great,2,2
+1665,21,November,28,,St Botolph Bishopsgate,8,5
+1665,21,November,28,,S. Sepulchres Parish,16,3
+1665,21,November,28,,St Bartholomew Lesse,1,1
+1665,21,November,28,,St Dunstan West,8,5
+1665,21,November,28,,St Thomas Southwark,0,0
+1665,21,November,28,,St Bridget,11,2
+1665,21,November,28,,St George Southwark,3,2
+1665,21,November,28,,Trinity Minories,2,0
+1665,21,November,28,,Bridewel Precinct,2,1
+1665,21,November,28,,St Giles Cripplegate,10,2
+1665,21,November,28,,At the Pesthouse,2,1
+1665,21,November,28,,St Botolph Aldersgate,0,0
+1665,21,November,28,,St Olave Southwark,26,18
+1665,21,November,28,,St Giles in the fields,13,4
+1665,21,November,28,,Lambeth Parish,10,6
+1665,21,November,28,,St Mary Islington,7,4
+1665,21,November,28,,Hackney Parish,4,3
+1665,21,November,28,,St Leonard Shoreditch,6,2
+1665,21,November,28,,St Mary Whitechappel,11,4
+1665,21,November,28,,St James Clerkenwel,9,3
+1665,21,November,28,,St Magdalen Bermondsey,14,8
+1665,21,November,28,,Rothorith Parish,9,8
+1665,21,November,28,,St Kath. near the Tower,7,5
+1665,21,November,28,,St Mary Newington,5,3
+1665,21,November,28,,Stepney Parish,83,75
+1665,21,November,28,,St Clement Danes,11,4
+1665,21,November,28,,St Martin in the fields,25,13
+1665,21,November,28,,St Margaret Westminster,31,22
+1665,21,November,28,,St Paul Covent Garden,4,2
+1665,21,November,28,,St Mary Savoy,3,3
+1665,28,November,5,December,St ALban Woodstreet,0,0
+1665,28,November,5,December,St George Botolphlane,0,0
+1665,28,November,5,December,St Martin Ludgate,3,1
+1665,28,November,5,December,Alhallows Barking,0,0
+1665,28,November,5,December,St Gregory by St Pauls,1,0
+1665,28,November,5,December,St Martin Orgars,0,0
+1665,28,November,5,December,Alhallows Breadstreet,0,0
+1665,28,November,5,December,St Hellen,1,0
+1665,28,November,5,December,St Martin Outwitch,0,0
+1665,28,November,5,December,Alhallows Great,1,0
+1665,28,November,5,December,St James Dukes place,1,1
+1665,28,November,5,December,St Martin Vintrey,2,0
+1665,28,November,5,December,Alhallows Honylane,0,0
+1665,28,November,5,December,St James Garlickhithe,1,0
+1665,28,November,5,December,St Matthew Fridaystreet,0,0
+1665,28,November,5,December,Alhallows Lesse,4,0
+1665,28,November,5,December,St John Baptist,1,1
+1665,28,November,5,December,St Maudlin Milkstreet,0,0
+1665,28,November,5,December,Alhallows Lumbardstreet,0,0
+1665,28,November,5,December,St John Evangelist,0,0
+1665,28,November,5,December,St Maudlin Oldfishstreet,0,0
+1665,28,November,5,December,Alhallows Staining,3,0
+1665,28,November,5,December,St John Zachary,1,0
+1665,28,November,5,December,St Michael Bassishaw,1,0
+1665,28,November,5,December,Alhallows the Wall,1,0
+1665,28,November,5,December,St Katharine Coleman,0,0
+1665,28,November,5,December,St Michael Cornhil,2,1
+1665,28,November,5,December,St Alphage,1,0
+1665,28,November,5,December,St Katharine Crechurch,2,1
+1665,28,November,5,December,St Michael Crookedlane,1,1
+1665,28,November,5,December,St Andrew Hubbard,1,0
+1665,28,November,5,December,St Lawrence Jewry,4,3
+1665,28,November,5,December,St Michael Queenhithe,1,0
+1665,28,November,5,December,St Andrew Undershaft,1,0
+1665,28,November,5,December,St Lawrence Pountney,1,1
+1665,28,November,5,December,St Michael Quern,0,0
+1665,28,November,5,December,St Andrew Wardrobe,0,0
+1665,28,November,5,December,St Leonard Eastcheap,0,0
+1665,28,November,5,December,St Michael Royal,1,1
+1665,28,November,5,December,St Ann Aldersgate,0,0
+1665,28,November,5,December,St Leonard Fosterlane,3,1
+1665,28,November,5,December,St Michael Woodstreet,0,0
+1665,28,November,5,December,St Ann Blackfryers,3,1
+1665,28,November,5,December,St Magnus Parish,0,0
+1665,28,November,5,December,St Mildred Breadstreet,1,0
+1665,28,November,5,December,St Antholins Parish,0,0
+1665,28,November,5,December,St Margaret Lothbury,0,0
+1665,28,November,5,December,St Mildred Poultrey,0,0
+1665,28,November,5,December,St Austins Parish,1,0
+1665,28,November,5,December,St Margaret Moses,0,0
+1665,28,November,5,December,St Nicholas Acons,0,0
+1665,28,November,5,December,St Bartholomew Exchange,1,1
+1665,28,November,5,December,St Margaret Newfishstreet,0,0
+1665,28,November,5,December,St Nicholas Coleabby,0,0
+1665,28,November,5,December,St Bennet Fynck,0,0
+1665,28,November,5,December,St Margaret Pattons,0,0
+1665,28,November,5,December,St Nicholas Olaves,1,0
+1665,28,November,5,December,St Bennet Gracechurch,1,1
+1665,28,November,5,December,St Mary Abchurch,1,0
+1665,28,November,5,December,St Olave Hartstreet,3,1
+1665,28,November,5,December,St Bennet Paulswharf,2,0
+1665,28,November,5,December,St Mary Aldermanbury,1,0
+1665,28,November,5,December,St Olave Jewry,0,0
+1665,28,November,5,December,St Bennet Sherehog,0,0
+1665,28,November,5,December,St Mary Aldermary,1,1
+1665,28,November,5,December,St Olave Silverstreet,0,0
+1665,28,November,5,December,St Botolph Billingsgate,0,0
+1665,28,November,5,December,St Mary le Bow,0,0
+1665,28,November,5,December,St Pancras Soperlane,1,0
+1665,28,November,5,December,Christs Church,0,0
+1665,28,November,5,December,St Mary Bothaw,0,0
+1665,28,November,5,December,St Peter Cheap,0,0
+1665,28,November,5,December,St Christophers,1,0
+1665,28,November,5,December,St Mary Colechurch,0,0
+1665,28,November,5,December,St Peter Cornhil,1,0
+1665,28,November,5,December,St Clement Eastcheap,0,0
+1665,28,November,5,December,St Mary Hill,1,1
+1665,28,November,5,December,St Peter Paulswharf,0,0
+1665,28,November,5,December,St Dionis Backchurch,0,0
+1665,28,November,5,December,St Mary Mounthaw,0,0
+1665,28,November,5,December,St Peter Poor,0,0
+1665,28,November,5,December,St Dunstan East,2,2
+1665,28,November,5,December,St Mary Sommerset,3,2
+1665,28,November,5,December,St Steven Colemanstreet,1,1
+1665,28,November,5,December,St Edmund Lumbardstr.,0,0
+1665,28,November,5,December,St Mary Stayning,0,0
+1665,28,November,5,December,St Steven Walbrook,1,0
+1665,28,November,5,December,St Ethelborough,0,0
+1665,28,November,5,December,St Mary Woolchurch,0,0
+1665,28,November,5,December,St Swithin,0,0
+1665,28,November,5,December,St Faith,2,1
+1665,28,November,5,December,St Mary Woolnoth,0,0
+1665,28,November,5,December,St Thomas Apostles,1,0
+1665,28,November,5,December,St Foster,0,0
+1665,28,November,5,December,St Martin Iremongerlane,0,0
+1665,28,November,5,December,Trinity Parish,1,0
+1665,28,November,5,December,St Gabriel Fenchurch,1,0
+1665,28,November,5,December,St Andrew Holborn,14,2
+1665,28,November,5,December,St Botolph Aldgate,17,7
+1665,28,November,5,December,Saviours Southwark,22,20
+1665,28,November,5,December,St Bartholomew Great,1,1
+1665,28,November,5,December,St Botolph Bishopsgate,10,5
+1665,28,November,5,December,S. Sepulchres Parish,12,2
+1665,28,November,5,December,St Bartholomew Lesse,1,0
+1665,28,November,5,December,St Dunstan West,3,2
+1665,28,November,5,December,St Thomas Southwark,2,0
+1665,28,November,5,December,St Bridget,6,1
+1665,28,November,5,December,St George Southwark,7,3
+1665,28,November,5,December,Trinity Minories,3,2
+1665,28,November,5,December,Bridewel Precinct,3,2
+1665,28,November,5,December,St Giles Cripplegate,15,3
+1665,28,November,5,December,At the Pesthouse,1,1
+1665,28,November,5,December,St Botolph Aldersgate,2,0
+1665,28,November,5,December,St Olave Southwark,20,13
+1665,28,November,5,December,St Giles in the fields,8,4
+1665,28,November,5,December,Lambeth Parish,12,8
+1665,28,November,5,December,St Mary Islington,2,1
+1665,28,November,5,December,Hackney Parish,1,0
+1665,28,November,5,December,St Leonard Shoreditch,6,2
+1665,28,November,5,December,St Mary Whitechappel,17,11
+1665,28,November,5,December,St James Clerkenwel,5,2
+1665,28,November,5,December,St Magdalen Bermondsey,24,12
+1665,28,November,5,December,Rothorith Parish,4,2
+1665,28,November,5,December,St Kath. near the Tower,9,3
+1665,28,November,5,December,St Mary Newington,5,2
+1665,28,November,5,December,Stepney Parish,67,43
+1665,28,November,5,December,St Clement Danes,4,1
+1665,28,November,5,December,St Martin in the fields,24,13
+1665,28,November,5,December,St Margaret Westminster,26,14
+1665,28,November,5,December,St Paul Covent Garden,4,4
+1665,28,November,5,December,St Mary Savoy,0,0
+1665,5,December,12,,St ALban Woodstreet,1,0
+1665,5,December,12,,St George Botolphlane,0,0
+1665,5,December,12,,St Martin Ludgate,2,2
+1665,5,December,12,,Alhallows Barking,1,0
+1665,5,December,12,,St Gregory by St Pauls,1,1
+1665,5,December,12,,St Martin Orgars,0,0
+1665,5,December,12,,Alhallows Breadstreet,0,0
+1665,5,December,12,,St Hellen,0,0
+1665,5,December,12,,St Martin Outwitch,0,0
+1665,5,December,12,,Alhallows Great,0,0
+1665,5,December,12,,St James Dukes place,2,1
+1665,5,December,12,,St Martin Vintrey,1,0
+1665,5,December,12,,Alhallows Honylane,0,0
+1665,5,December,12,,St James Garlickhithe,6,2
+1665,5,December,12,,St Matthew Fridaystreet,0,0
+1665,5,December,12,,Alhallows Lesse,0,0
+1665,5,December,12,,St John Baptist,3,3
+1665,5,December,12,,St Maudlin Milkstreet,0,0
+1665,5,December,12,,Alhallows Lumbardstreet,2,2
+1665,5,December,12,,St John Evangelist,0,0
+1665,5,December,12,,St Maudlin Oldfishstreet,1,1
+1665,5,December,12,,Alhallows Stayning,0,0
+1665,5,December,12,,St John Zachary,0,0
+1665,5,December,12,,St Michael Bassishaw,0,0
+1665,5,December,12,,Alhallows the Wall,4,1
+1665,5,December,12,,St Katharine Coleman,1,0
+1665,5,December,12,,St Michael Cornhil,0,0
+1665,5,December,12,,St Alphage,1,1
+1665,5,December,12,,St Katharine Crechurch,4,3
+1665,5,December,12,,St Michael Crookedlane,3,2
+1665,5,December,12,,St Andrew Hubbard,3,2
+1665,5,December,12,,St Lawrence Jewry,0,0
+1665,5,December,12,,St Michael Queenhithe,1,0
+1665,5,December,12,,St Andrew Undershaft,0,0
+1665,5,December,12,,St Lawrence Pountney,1,0
+1665,5,December,12,,St Michael Quern,1,0
+1665,5,December,12,,St Andrew Wardrobe,1,0
+1665,5,December,12,,St Leonard Eastcheap,0,0
+1665,5,December,12,,St Michael Royal,0,0
+1665,5,December,12,,St Ann Aldersgate,2,1
+1665,5,December,12,,St Leonard Fosterlane,1,1
+1665,5,December,12,,St Michael Woodstreet,0,0
+1665,5,December,12,,St Ann Blackfryers,2,2
+1665,5,December,12,,St Magnus Parish,0,0
+1665,5,December,12,,St Mildred Breadstreet,0,0
+1665,5,December,12,,St Antholins Parish,0,0
+1665,5,December,12,,St Margaret Lothbury,2,2
+1665,5,December,12,,St Mildred Poultrey,0,0
+1665,5,December,12,,St Austins Parish,0,0
+1665,5,December,12,,St Margaret Moses,0,0
+1665,5,December,12,,St Nicholas Acons,0,0
+1665,5,December,12,,St Bartholomew Exchange,0,0
+1665,5,December,12,,St Margaret Newfishstre.,0,0
+1665,5,December,12,,St Nicholas Coleabby,0,0
+1665,5,December,12,,St Bennet Fynck,0,0
+1665,5,December,12,,St Margaret Pattons,0,0
+1665,5,December,12,,St Nicholas Olaves,0,0
+1665,5,December,12,,St Bennet Gracechurch,2,2
+1665,5,December,12,,St Mary Abchurch,5,5
+1665,5,December,12,,St Olave Hartstreet,8,6
+1665,5,December,12,,St Bennet Paulswharf,2,1
+1665,5,December,12,,St Mary Aldermanbury,0,0
+1665,5,December,12,,St Olave Jewry,0,0
+1665,5,December,12,,St Bennet Sherehog,0,0
+1665,5,December,12,,St Mary Aldermary,0,0
+1665,5,December,12,,St Olave Silverstreet,0,0
+1665,5,December,12,,St Botolph Billingsgate,1,1
+1665,5,December,12,,St Mary le Bow,1,1
+1665,5,December,12,,St Pancras Soperlane,0,0
+1665,5,December,12,,Christ Church,3,1
+1665,5,December,12,,St Mary Bothaw,1,0
+1665,5,December,12,,St Peter Cheap,0,0
+1665,5,December,12,,St Christophers,1,1
+1665,5,December,12,,St Mary Colechurch,0,0
+1665,5,December,12,,St Peter Cornhil,3,0
+1665,5,December,12,,St Clement Eastcheap,0,0
+1665,5,December,12,,St Mary Hill,3,3
+1665,5,December,12,,St Peter Paulswharf,2,0
+1665,5,December,12,,St Dionis Backchurch,0,0
+1665,5,December,12,,St Mary Mounthaw,1,1
+1665,5,December,12,,St Peter Poor,0,0
+1665,5,December,12,,St Dunstan East,3,1
+1665,5,December,12,,St Mary Sommerset,2,2
+1665,5,December,12,,St Steven Colemanstreet,2,2
+1665,5,December,12,,St Edmund Lumbardstr.,0,0
+1665,5,December,12,,St Mary Stayning,0,0
+1665,5,December,12,,St Steven Walbrook,0,0
+1665,5,December,12,,St Ethelborough,0,0
+1665,5,December,12,,St Mary Woolchurch,3,1
+1665,5,December,12,,St Swithin,1,1
+1665,5,December,12,,St Faith,1,1
+1665,5,December,12,,St Mary Woolnoth,0,0
+1665,5,December,12,,St Thomas Apostles,1,0
+1665,5,December,12,,St Foster,0,0
+1665,5,December,12,,St Martin Iremongerlane,0,0
+1665,5,December,12,,Trinity Parish,1,0
+1665,5,December,12,,St Gabriel Fenchurch,0,0
+1665,5,December,12,,St Andrew Holborn,13,7
+1665,5,December,12,,St Botolph Aldgate,18,16
+1665,5,December,12,,Saviours Southwark,23,13
+1665,5,December,12,,St Bartholomew Great,0,0
+1665,5,December,12,,St Botolph Bishopsgate,13,3
+1665,5,December,12,,S Sepulchres Parish,8,0
+1665,5,December,12,,St Bartholomew Lesse,0,0
+1665,5,December,12,,St Dunstan West,3,2
+1665,5,December,12,,St Thomas Southwark,3,2
+1665,5,December,12,,St Bridget,7,4
+1665,5,December,12,,St George Southwark,2,0
+1665,5,December,12,,Trinity Minories,0,0
+1665,5,December,12,,Bridewel Precinct,0,0
+1665,5,December,12,,St Giles Cripplegate,11,3
+1665,5,December,12,,At the Pesthouse,0,0
+1665,5,December,12,,St Botolph Aldersgate,7,4
+1665,5,December,12,,St Olave Southwark,24,16
+1665,5,December,12,,St Giles in the fields,11,5
+1665,5,December,12,,Lambeth Parish,11,6
+1665,5,December,12,,St Mary Islington,4,1
+1665,5,December,12,,Hackney Parish,3,0
+1665,5,December,12,,St Leonard Shoreditch,8,2
+1665,5,December,12,,St Mary Whitechappel,18,7
+1665,5,December,12,,St James Clerkenwel,3,0
+1665,5,December,12,,St Magdalen Bermondsey,15,7
+1665,5,December,12,,Rothorith Parish,5,4
+1665,5,December,12,,St Kath. near the Tower,5,2
+1665,5,December,12,,St Mary Newington,3,2
+1665,5,December,12,,Stepney Parish,61,38
+1665,5,December,12,,St Clement Danes,14,10
+1665,5,December,12,,St Martin in the fields,24,15
+1665,5,December,12,,St Margaret Westminster,27,15
+1665,5,December,12,,St Paul Covent Garden,3,1
+1665,5,December,12,,St Mary Savoy,1,1
+1665,12,December,19,,St ALban Woodstreet,1,1
+1665,12,December,19,,St George Botolphlane,2,2
+1665,12,December,19,,St Martin Ludgate,4,2
+1665,12,December,19,,Alhallows Barking,2,0
+1665,12,December,19,,St Gregory by St Pauls,2,0
+1665,12,December,19,,St Martin Orgars,1,1
+1665,12,December,19,,Alhallows Breadstreet,0,0
+1665,12,December,19,,St Hellen,1,0
+1665,12,December,19,,St Martin Outwitch,0,0
+1665,12,December,19,,Alhallows Great,2,2
+1665,12,December,19,,St James Dukes place,0,0
+1665,12,December,19,,St Martin Vintrey,2,0
+1665,12,December,19,,Alhallows Honylane,0,0
+1665,12,December,19,,St James Garlickhithe,1,1
+1665,12,December,19,,St Matthew Fridaystreet,0,0
+1665,12,December,19,,Alhallows Lesse,2,2
+1665,12,December,19,,St John Baptist,0,0
+1665,12,December,19,,St Maudlin Milkstreet,0,0
+1665,12,December,19,,Alhallows Lumbardstreet,0,0
+1665,12,December,19,,St John Evangelist,0,0
+1665,12,December,19,,St Maudlin Oldfishstreet,3,3
+1665,12,December,19,,Alhallows Stayning,0,0
+1665,12,December,19,,St John Zachary,0,0
+1665,12,December,19,,St Michael Bassishaw,1,0
+1665,12,December,19,,Alhallows the Wall,4,1
+1665,12,December,19,,St Katharine Coleman,4,0
+1665,12,December,19,,St Michael Cornhil,2,0
+1665,12,December,19,,St Alphage,1,0
+1665,12,December,19,,St Katharine Crechurch,9,5
+1665,12,December,19,,St Michael Crookedlane,2,2
+1665,12,December,19,,St Andrew Hubbard,0,0
+1665,12,December,19,,St Lawrence Jewry,1,1
+1665,12,December,19,,St Michael Queenhithe,6,5
+1665,12,December,19,,St Andrew Undershaft,4,2
+1665,12,December,19,,St Lawrence Pountney,2,1
+1665,12,December,19,,St Michael Quern,0,0
+1665,12,December,19,,St Andrew Wardrobe,4,2
+1665,12,December,19,,St Leonard Eastcheap,0,0
+1665,12,December,19,,St Michael Royal,1,1
+1665,12,December,19,,St Ann Aldersgate,3,2
+1665,12,December,19,,St Leonard Fosterlane,1,0
+1665,12,December,19,,St Michael Woodstreet,0,0
+1665,12,December,19,,St Ann Blackfryers,1,1
+1665,12,December,19,,St Magnus Parish,0,0
+1665,12,December,19,,St Mildred Breadstreet,0,0
+1665,12,December,19,,St Antholins Parish,0,0
+1665,12,December,19,,St Margaret Lothbury,0,0
+1665,12,December,19,,St Mildred Poultrey,0,0
+1665,12,December,19,,St Austins Parish,0,0
+1665,12,December,19,,St Margaret Moses,2,2
+1665,12,December,19,,St Nicholas Acons,0,0
+1665,12,December,19,,St Bartholomew Exchange,0,0
+1665,12,December,19,,St Margaret Newfishstre.,1,0
+1665,12,December,19,,St Nicholas Coleabby,0,0
+1665,12,December,19,,St Bennet Fynck,0,0
+1665,12,December,19,,St Margaret Pattons,1,0
+1665,12,December,19,,St Nicholas Olaves,1,1
+1665,12,December,19,,St Bennet Gracechurch,2,0
+1665,12,December,19,,St Mary Abchurch,2,1
+1665,12,December,19,,St Olave Hartstreet,1,0
+1665,12,December,19,,St Bennet Paulswharf,2,0
+1665,12,December,19,,St Mary Aldermanbury,2,0
+1665,12,December,19,,St Olave Jewry,1,1
+1665,12,December,19,,St Bennet Sherehog,1,1
+1665,12,December,19,,St Mary Aldermary,0,0
+1665,12,December,19,,St Olave Silverstreet,0,0
+1665,12,December,19,,St Botolph Billingsgate,2,1
+1665,12,December,19,,St Mary le Bow,3,2
+1665,12,December,19,,St Pancras Soperlane,1,0
+1665,12,December,19,,Christ Church,6,2
+1665,12,December,19,,St Mary Bothaw,1,1
+1665,12,December,19,,St Peter Cheap,0,0
+1665,12,December,19,,St Christophers,0,0
+1665,12,December,19,,St Mary Colechurch,0,0
+1665,12,December,19,,St Peter Cornhil,2,1
+1665,12,December,19,,St Clement Eastcheap,2,2
+1665,12,December,19,,St Mary Hill,1,0
+1665,12,December,19,,St Peter Paulswharf,1,1
+1665,12,December,19,,St Dionis Backchurch,1,0
+1665,12,December,19,,St Mary Mounthaw,0,0
+1665,12,December,19,,St Peter Poor,0,0
+1665,12,December,19,,St Dunstan East,6,4
+1665,12,December,19,,St Mary Sommerset,3,1
+1665,12,December,19,,St Steven Colemanstreet,0,0
+1665,12,December,19,,St Edmund Lumbardstr.,3,2
+1665,12,December,19,,St Mary Stayning,0,0
+1665,12,December,19,,St Steven Walbrook,0,0
+1665,12,December,19,,St Ethelborough,0,0
+1665,12,December,19,,St Mary Woolchurch,0,0
+1665,12,December,19,,St Swithin,1,1
+1665,12,December,19,,St Faith,2,2
+1665,12,December,19,,St Mary Woolnoth,0,0
+1665,12,December,19,,St Thomas Apostles,2,0
+1665,12,December,19,,St Foster,3,2
+1665,12,December,19,,St Martin Iremongerlane,0,0
+1665,12,December,19,,Trinity Parish,0,0
+1665,12,December,19,,St Gabriel Fenchurch,1,1
+1665,12,December,19,,St Andrew Holborn,13,4
+1665,12,December,19,,St Botolph Aldgate,23,11
+1665,12,December,19,,Saviours Southwark,24,19
+1665,12,December,19,,St Bartholomew Great,3,0
+1665,12,December,19,,St Botolph Bishopsgate,14,4
+1665,12,December,19,,S Sepulchres Parish,11,2
+1665,12,December,19,,St Bartholomew Lesse,1,1
+1665,12,December,19,,St Dunstan West,4,3
+1665,12,December,19,,St Thomas Southwark,1,0
+1665,12,December,19,,St Bridget,7,2
+1665,12,December,19,,St George Southwark,4,2
+1665,12,December,19,,Trinity Minories,0,0
+1665,12,December,19,,Bridewel Precinct,2,2
+1665,12,December,19,,St Giles Cripplegate,19,7
+1665,12,December,19,,At the Pesthouse,1,1
+1665,12,December,19,,St Botolph Aldersgate,9,5
+1665,12,December,19,,St Olave Southwark,20,12
+1665,12,December,19,,St Giles in the fields,7,2
+1665,12,December,19,,Lambeth Parish,23,21
+1665,12,December,19,,St Mary Islington,4,1
+1665,12,December,19,,Hackney Parish,4,1
+1665,12,December,19,,St Leonard Shoreditch,6,4
+1665,12,December,19,,St Mary Whitechappel,16,7
+1665,12,December,19,,St James Clerkenwel,6,1
+1665,12,December,19,,St Magdalen Bermondsey,25,13
+1665,12,December,19,,Ro•horith Parish,8,5
+1665,12,December,19,,St Kath. near the Tower,7,4
+1665,12,December,19,,St Mary Newington,10,3
+1665,12,December,19,,Stepney Parish,71,44
+1665,12,December,19,,St Clement Danes,10,4
+1665,12,December,19,,St Martin in the fields,12,6
+1665,12,December,19,,St Margaret Westminster,24,19
+1665,12,December,19,,St Paul Covent Garden,4,2
+1665,12,December,19,,St Mary Savoy,6,3
+1666,19,December,26,,ALban Woodstreet,2,0
+1666,19,December,26,,St Gregory by St Paul,0,0
+1666,19,December,26,,St Mary Mounthaw,1,0
+1666,19,December,26,,Alhallows Barking,1,0
+1666,19,December,26,,St Hellen,0,0
+1666,19,December,26,,St Mary Sommerset,1,0
+1666,19,December,26,,Alhallows Breadstreet,0,0
+1666,19,December,26,,St James Dukes Place,1,1
+1666,19,December,26,,St Mary Staining,0,0
+1666,19,December,26,,Alhallows the Great,3,2
+1666,19,December,26,,St James Garlickhithe,1,0
+1666,19,December,26,,St Mary Woolchurch,1,0
+1666,19,December,26,,Alhallows Honylane,0,0
+1666,19,December,26,,St John Baptist,1,0
+1666,19,December,26,,St Mary Woolnoth,0,0
+1666,19,December,26,,Alhallows the Less,0,0
+1666,19,December,26,,St John Evangelist,0,0
+1666,19,December,26,,St Matthew Fridaystreet,0,0
+1666,19,December,26,,Alhallows Lombardstreet,0,0
+1666,19,December,26,,St John Zachary,0,0
+1666,19,December,26,,St Michael Bassishaw,0,0
+1666,19,December,26,,Alhallows Staining,1,1
+1666,19,December,26,,St Katharine Coleman,2,1
+1666,19,December,26,,St Michael Cornhil,1,0
+1666,19,December,26,,Alhallows the Wall,0,0
+1666,19,December,26,,St Katharine Creechurch,1,0
+1666,19,December,26,,St Michael Crookedlane,2,2
+1666,19,December,26,,St Alphage,0,0
+1666,19,December,26,,St Lawrence Jewry,1,0
+1666,19,December,26,,St Michael Queenhithe,1,1
+1666,19,December,26,,St Andrew Hubbard,0,0
+1666,19,December,26,,St Lawrence Pountney,1,1
+1666,19,December,26,,St Michael Quern,0,0
+1666,19,December,26,,St Andrew Undershaft,0,0
+1666,19,December,26,,St Leonard Eastcheap,0,0
+1666,19,December,26,,St Michael Royal,0,0
+1666,19,December,26,,St Andrew Wardrobe,2,1
+1666,19,December,26,,St Leonard Fosterlane,1,0
+1666,19,December,26,,St Michael Woodstreet,0,0
+1666,19,December,26,,St Ann Aldersgate,1,1
+1666,19,December,26,,St Magnus Parish,0,0
+1666,19,December,26,,St Mildred Breadstreet,2,1
+1666,19,December,26,,St Ann Blackfriers,6,3
+1666,19,December,26,,St Margaret Lothbury,0,0
+1666,19,December,26,,St Mildred Poultry,1,1
+1666,19,December,26,,St Anthony alias Antholin,0,0
+1666,19,December,26,,St Margaret Moses,0,0
+1666,19,December,26,,St Nicholas Acons,1,0
+1666,19,December,26,,St Austins Parish,0,0
+1666,19,December,26,,St Margaret Newfishstreet,3,0
+1666,19,December,26,,St Nicholas Coleabby,0,0
+1666,19,December,26,,St Bartholomew Exchange,1,0
+1666,19,December,26,,St Margaret Pattons,0,0
+1666,19,December,26,,St Nicholas Olaves,0,0
+1666,19,December,26,,St Bennet Finck,0,0
+1666,19,December,26,,St Martin Iremongerlane,0,0
+1666,19,December,26,,St Olave Hartstreet,1,1
+1666,19,December,26,,St Bennet Gracechurch,0,0
+1666,19,December,26,,St Martin Ludgate,0,0
+1666,19,December,26,,St Olave Jewry,0,0
+1666,19,December,26,,St Bennet Paulswharf,1,0
+1666,19,December,26,,St Martin Orgars,1,1
+1666,19,December,26,,St Olave Silverstreet,0,0
+1666,19,December,26,,St Bennet Sherehog,0,0
+1666,19,December,26,,St Martin Outwitch,0,0
+1666,19,December,26,,St Pancras Soperlane,0,0
+1666,19,December,26,,St Botolph Billingsgate,1,1
+1666,19,December,26,,St Martin Vintrey,0,0
+1666,19,December,26,,St Peter Cheap,0,0
+1666,19,December,26,,Christ's Church,1,0
+1666,19,December,26,,St Mary Abchurch,1,0
+1666,19,December,26,,St Peter Cornhil,1,1
+1666,19,December,26,,St Christophers,2,2
+1666,19,December,26,,St Mary Aldermanbury,0,0
+1666,19,December,26,,St Peter Paulswharf,0,0
+1666,19,December,26,,St Clement Eastcheap,2,1
+1666,19,December,26,,St Mary Aldermary,0,0
+1666,19,December,26,,St Peter Poor,1,0
+1666,19,December,26,,St Dionis Backchurch,0,0
+1666,19,December,26,,St Mary-le-bow,1,0
+1666,19,December,26,,St Steven Colemanstreet,2,2
+1666,19,December,26,,St Dunstan East,3,0
+1666,19,December,26,,St Mary Bothaw,1,1
+1666,19,December,26,,St Steven Walbrook,0,0
+1666,19,December,26,,St Edmund Lumbardstr.,1,0
+1666,19,December,26,,St Mary Colechurch,0,0
+1666,19,December,26,,St Swithin,2,1
+1666,19,December,26,,St Ethelburga,0,0
+1666,19,December,26,,St Mary Hill,0,0
+1666,19,December,26,,St Thomas Apostle,0,0
+1666,19,December,26,,St Faith,2,0
+1666,19,December,26,,St Mary Milkstreet,0,0
+1666,19,December,26,,Trinity Parish,0,0
+1666,19,December,26,,St Gabriel Fenchurch,0,0
+1666,19,December,26,,St Mary Mag. Oldfishstreet,0,0
+1666,19,December,26,,St Vedast alias Foster,0,0
+1666,19,December,26,,St George Botolphlane,0,0
+1666,19,December,26,,St Andrew Holborn,13,6
+1666,19,December,26,,St Botolph Aldgate,13,6
+1666,19,December,26,,Saviour Southwark,30,22
+1666,19,December,26,,St Bartholomew the Great,1,0
+1666,19,December,26,,St Botolph Bishopsgate,5,1
+1666,19,December,26,,St Sepulchres Parish,6,2
+1666,19,December,26,,St Bartholomew the Lesse,0,0
+1666,19,December,26,,St Dunstan West,3,0
+1666,19,December,26,,St Thomas Southwark,4,2
+1666,19,December,26,,St Bridget,5,1
+1666,19,December,26,,St George Southwark,4,4
+1666,19,December,26,,Trinity Minories,1,0
+1666,19,December,26,,Bridewel Precinct,0,0
+1666,19,December,26,,St Giles Cripplegate,16,3
+1666,19,December,26,,At the Pesthouse,0,0
+1666,19,December,26,,St Botolph Aldersgate,4,3
+1666,19,December,26,,St Olave Southwark,17,9
+1666,19,December,26,,...hritt Church,0,0
+1666,19,December,26,,St Katharine Tower,4,1
+1666,19,December,26,,St Mary Newington,5,3
+1666,19,December,26,,Dunstan Stepney,43,28
+1666,19,December,26,,Lambeth Parish,6,4
+1666,19,December,26,,St Mary Whitechappel,8,4
+1666,19,December,26,,St Giles in the Fields,11,4
+1666,19,December,26,,St Leonard Shoreditch,6,1
+1666,19,December,26,,St. Paul Shadwel,0,0
+1666,19,December,26,,St James Clerkenwel,1,0
+1666,19,December,26,,St Mary Islington,0,0
+1666,19,December,26,,Rotherhith Parish,2,2
+1666,19,December,26,,John at Hackney,1,1
+1666,19,December,26,,St Mary Magd. Bermondsey,10,3
+1666,19,December,26,,St Ann Westminster,0,0
+1666,19,December,26,,St Margaret Westminster,9,9
+1666,19,December,26,,St Mary Savoy,3,1
+1666,19,December,26,,St Clement Danes,9,1
+1666,19,December,26,,St Martin in the Fields,13,4
+1666,19,December,26,,St Paul Covent Garden,3,0
+1666,19,December,26,,St James Westminster,0,0
+1666,26,December,2,January,ALban Woodstreet,0,0
+1666,26,December,2,January,St Gregory by St Paul,1,0
+1666,26,December,2,January,St Mary Mounthaw,0,0
+1666,26,December,2,January,Alhallows Barking,0,0
+1666,26,December,2,January,St Hellen,1,0
+1666,26,December,2,January,St Mary Sommerset,0,0
+1666,26,December,2,January,Alhallows Breadstreet,0,0
+1666,26,December,2,January,St James Dukes Place,0,0
+1666,26,December,2,January,St Mary Staining,0,0
+1666,26,December,2,January,Alhallows the Great,3,1
+1666,26,December,2,January,St James Garlickhithe,2,0
+1666,26,December,2,January,St Mary Woolchurch,1,0
+1666,26,December,2,January,Alhallows Honylane,0,0
+1666,26,December,2,January,St John Baptist,0,0
+1666,26,December,2,January,St Mary Woolnoth,1,0
+1666,26,December,2,January,Alhallows the Less,0,0
+1666,26,December,2,January,St John Evangelist,0,0
+1666,26,December,2,January,St Matthew Fridaystreet,0,0
+1666,26,December,2,January,Alhallows Lombardstreet,0,0
+1666,26,December,2,January,St John Zachary,0,0
+1666,26,December,2,January,St Michael Bassishaw,0,0
+1666,26,December,2,January,Alhallows Staining,1,0
+1666,26,December,2,January,St Katharine Coleman,1,0
+1666,26,December,2,January,St Michael Cornhil,1,0
+1666,26,December,2,January,Alhallows the Wall,1,1
+1666,26,December,2,January,St Katharine Creechurch,0,0
+1666,26,December,2,January,St Michael Crookedlane,1,1
+1666,26,December,2,January,St Alphage,1,1
+1666,26,December,2,January,St Lawrence Jewry,1,0
+1666,26,December,2,January,St Michael Queenhithe,1,0
+1666,26,December,2,January,St Andrew Hubbard,0,0
+1666,26,December,2,January,St Lawrence Pountney,0,0
+1666,26,December,2,January,St Michael Quern,0,0
+1666,26,December,2,January,St Andrew Undershaft,0,0
+1666,26,December,2,January,St Leonard Eastcheap,0,0
+1666,26,December,2,January,St Michael Royal,0,0
+1666,26,December,2,January,St Andrew Wardrobe,1,1
+1666,26,December,2,January,St Leonard Fosterlane,0,0
+1666,26,December,2,January,St Michael Woodstreet,0,0
+1666,26,December,2,January,St Ann Aldersgate,1,0
+1666,26,December,2,January,St Magnus Parish,0,0
+1666,26,December,2,January,St Mildred Breadstreet,0,0
+1666,26,December,2,January,St Ann Blackfriers,1,0
+1666,26,December,2,January,St Margaret Lothbury,0,0
+1666,26,December,2,January,St Mildred Poultry,0,0
+1666,26,December,2,January,St Anthony alias Antholin,0,0
+1666,26,December,2,January,St Margaret Moses,1,0
+1666,26,December,2,January,St Nicholas Acons,0,0
+1666,26,December,2,January,St Austins Parish,0,0
+1666,26,December,2,January,St Margaret Newfishstreet,0,0
+1666,26,December,2,January,St Nicholas Coleabby,0,0
+1666,26,December,2,January,St Bartholomew Exchange,1,0
+1666,26,December,2,January,St Margaret Pattons,1,1
+1666,26,December,2,January,St Nicholas Olaves,0,0
+1666,26,December,2,January,St Bennet Finck,0,0
+1666,26,December,2,January,St Martin Iremongerlane,0,0
+1666,26,December,2,January,St Olave Hartstreet,0,0
+1666,26,December,2,January,St Bennet Gracechurch,0,0
+1666,26,December,2,January,St Martin Ludgate,1,0
+1666,26,December,2,January,St Olave Jewry,0,0
+1666,26,December,2,January,St Bennet Paulswharf,1,0
+1666,26,December,2,January,St Martin Orgars,0,0
+1666,26,December,2,January,St Olave Silverstreet,1,0
+1666,26,December,2,January,St Bennet Sherehog,0,0
+1666,26,December,2,January,St Martin Outwitch,0,0
+1666,26,December,2,January,St Pancras Soperlane,0,0
+1666,26,December,2,January,St Botolph Billingsgate,1,0
+1666,26,December,2,January,St Martin Vintrey,0,0
+1666,26,December,2,January,St Peter Cheap,0,0
+1666,26,December,2,January,Christ's Church,1,1
+1666,26,December,2,January,St Mary Abchurch,0,0
+1666,26,December,2,January,St Peter Cornhil,1,1
+1666,26,December,2,January,St Christophers,0,0
+1666,26,December,2,January,St Mary Aldermanbury,2,0
+1666,26,December,2,January,St Peter Paulswharf,1,1
+1666,26,December,2,January,St Clement Eastcheap,0,0
+1666,26,December,2,January,St Mary Aldermary,0,0
+1666,26,December,2,January,St Peter Poor,0,0
+1666,26,December,2,January,St Dionis Backchurch,0,0
+1666,26,December,2,January,St Mary-le-bow,0,0
+1666,26,December,2,January,St Steven Colemanstreet,3,2
+1666,26,December,2,January,St Dunstan East,2,2
+1666,26,December,2,January,St Mary Bothaw,0,0
+1666,26,December,2,January,St Steven Walbrook,0,0
+1666,26,December,2,January,St Edmund Lumbardstr.,1,0
+1666,26,December,2,January,St Mary Colechurch,0,0
+1666,26,December,2,January,St Swithin,0,0
+1666,26,December,2,January,St Ethelburga,0,0
+1666,26,December,2,January,St Mary Hill,0,0
+1666,26,December,2,January,St Thomas Apostle,0,0
+1666,26,December,2,January,St Faith,1,1
+1666,26,December,2,January,St Mary Milkstreet,0,0
+1666,26,December,2,January,Trinity Parish,0,0
+1666,26,December,2,January,St Gabriel Fenchurch,1,0
+1666,26,December,2,January,St Mary Mag. Oldfishstreet,2,0
+1666,26,December,2,January,St Vedast alias Foster,1,0
+1666,26,December,2,January,St George Botolphlane,0,0
+1666,26,December,2,January,St Andrew Holborn,12,4
+1666,26,December,2,January,St Botolph Aldgate,15,9
+1666,26,December,2,January,Saviour Southwark,12,2
+1666,26,December,2,January,St Bartholomew the Great,1,0
+1666,26,December,2,January,St Botolph Bishopsgate,6,1
+1666,26,December,2,January,St Sepulchres Parish,3,0
+1666,26,December,2,January,St Bartholomew the Lesse,0,0
+1666,26,December,2,January,St Dunstan West,7,2
+1666,26,December,2,January,St Thomas Southwark,2,0
+1666,26,December,2,January,St Bridget,12,0
+1666,26,December,2,January,St George Southwark,4,3
+1666,26,December,2,January,Trinity Minories,1,0
+1666,26,December,2,January,Bridewel Precinct,1,1
+1666,26,December,2,January,St Giles Cripplegate,7,1
+1666,26,December,2,January,At the Pesthouse,0,0
+1666,26,December,2,January,St Botolph Aldersgate,2,0
+1666,26,December,2,January,St Olave Southwark,7,1
+1666,26,December,2,January,...hritt Church,0,0
+1666,26,December,2,January,St Katharine Tower,1,0
+1666,26,December,2,January,St Mary Newington,1,0
+1666,26,December,2,January,Dunstan Stepney,35,12
+1666,26,December,2,January,Lambeth Parish,4,3
+1666,26,December,2,January,St Mary Whitechappel,13,3
+1666,26,December,2,January,St Giles in the Fields,6,2
+1666,26,December,2,January,St Leonard Shoreditch,2,0
+1666,26,December,2,January,St. Paul Shadwel,0,0
+1666,26,December,2,January,St James Clerkenwel,3,1
+1666,26,December,2,January,St Mary Islington,0,0
+1666,26,December,2,January,Rotherhith Parish,1,1
+1666,26,December,2,January,John at Hackney,0,0
+1666,26,December,2,January,St Mary Magd. Bermondsey,9,1
+1666,26,December,2,January,St Ann Westminster,0,0
+1666,26,December,2,January,St Margaret Westminster,15,3
+1666,26,December,2,January,St Mary Savoy,1,0
+1666,26,December,2,January,St Clement Danes,9,1
+1666,26,December,2,January,St Martin in the Fields,18,5
+1666,26,December,2,January,St Paul Covent Garden,1,0
+1666,26,December,2,January,St James Westminster,0,0
+1666,2,January,9,,ALban Woodstreet,0,0
+1666,2,January,9,,St Gregory by St Paul,1,0
+1666,2,January,9,,St Mary Mounthaw,0,0
+1666,2,January,9,,Alhallows Barking,1,0
+1666,2,January,9,,St Hellen,1,0
+1666,2,January,9,,St Mary Sommerset,3,1
+1666,2,January,9,,Alhallows Breadstreet,0,0
+1666,2,January,9,,St James Dukes Place,0,0
+1666,2,January,9,,St Mary Staining,0,0
+1666,2,January,9,,Alhallows the Great,2,0
+1666,2,January,9,,St James Garlickhithe,2,0
+1666,2,January,9,,St Mary Woolchurch,1,0
+1666,2,January,9,,Alhallows Honylane,0,0
+1666,2,January,9,,St John Baptist,1,0
+1666,2,January,9,,St Mary Woolnoth,0,0
+1666,2,January,9,,Alhallows the Less,2,2
+1666,2,January,9,,St John Evangelist,0,0
+1666,2,January,9,,St Matthew Fridaystreet,0,0
+1666,2,January,9,,Alhallows Lombardstreet,0,0
+1666,2,January,9,,St John Zachary,0,0
+1666,2,January,9,,St Michael Bassishaw,2,1
+1666,2,January,9,,Alhallows Staining,0,0
+1666,2,January,9,,St Katharine Coleman,0,0
+1666,2,January,9,,St Michael Cornhil,1,0
+1666,2,January,9,,Alhallows the Wall,1,1
+1666,2,January,9,,St Katharine Creechurch,0,0
+1666,2,January,9,,St Michael Crookedlane,0,0
+1666,2,January,9,,St Alphage,0,0
+1666,2,January,9,,St Lawrence Jewry,0,0
+1666,2,January,9,,St Michael Queenhithe,1,0
+1666,2,January,9,,St Andrew Hubbard,2,2
+1666,2,January,9,,St Lawrence Pountney,2,1
+1666,2,January,9,,St Michael Quern,0,0
+1666,2,January,9,,St Andrew Undershaft,0,0
+1666,2,January,9,,St Leonard Eastcheap,0,0
+1666,2,January,9,,St Michael Royal,0,0
+1666,2,January,9,,St Andrew Wardrobe,1,0
+1666,2,January,9,,St Leonard Fosterlane,0,0
+1666,2,January,9,,St Michael Woodstreet,0,0
+1666,2,January,9,,St Ann Aldersgate,1,1
+1666,2,January,9,,St Magnus Parish,1,0
+1666,2,January,9,,St Mildred Breadstreet,1,0
+1666,2,January,9,,St Ann Blackfriers,3,2
+1666,2,January,9,,St Margaret Lothbury,2,1
+1666,2,January,9,,St Mildred Poultry,0,0
+1666,2,January,9,,St Anthony alias Antholin,0,0
+1666,2,January,9,,St Margaret Moses,0,0
+1666,2,January,9,,St Nicholas Acons,0,0
+1666,2,January,9,,St Austins Parish,0,0
+1666,2,January,9,,St Margaret Newfishstreet,0,0
+1666,2,January,9,,St Nicholas Coleabby,0,0
+1666,2,January,9,,St Bartholomew Exchange,2,1
+1666,2,January,9,,St Margaret Pattons,0,0
+1666,2,January,9,,St Nicholas Olaves,1,1
+1666,2,January,9,,St Bennet Finck,0,0
+1666,2,January,9,,St Martin Iremongerlane,0,0
+1666,2,January,9,,St Olave Hartstreet,0,0
+1666,2,January,9,,St Bennet Gracechurch,0,0
+1666,2,January,9,,St Martin Ludgate,0,0
+1666,2,January,9,,St Olave Jewry,0,0
+1666,2,January,9,,St Bennet Paulswharf,0,0
+1666,2,January,9,,St Martin Orgars,0,0
+1666,2,January,9,,St Olave Silverstreet,0,0
+1666,2,January,9,,St Bennet Sherehog,0,0
+1666,2,January,9,,St Martin Outwitch,0,0
+1666,2,January,9,,St Pancras Soperlane,0,0
+1666,2,January,9,,St Botolph Billingsgate,3,2
+1666,2,January,9,,St Martin Vintrey,0,0
+1666,2,January,9,,St Peter Cheap,0,0
+1666,2,January,9,,Christ's Church,1,0
+1666,2,January,9,,St Mary Abchurch,2,0
+1666,2,January,9,,St Peter Cornhil,1,1
+1666,2,January,9,,St Christophers,0,0
+1666,2,January,9,,St Mary Aldermanbury,1,0
+1666,2,January,9,,St Peter Paulswharf,0,0
+1666,2,January,9,,St Clement Eastcheap,0,0
+1666,2,January,9,,St Mary Aldermary,2,2
+1666,2,January,9,,St Peter Poor,0,0
+1666,2,January,9,,St Dionis Backchurch,3,0
+1666,2,January,9,,St Mary-le-bow,0,0
+1666,2,January,9,,St Steven Colemanstreet,1,1
+1666,2,January,9,,St Dunstan East,1,1
+1666,2,January,9,,St Mary Bothaw,0,0
+1666,2,January,9,,St Steven Walbrook,1,0
+1666,2,January,9,,St Edmund Lumbardstr.,0,0
+1666,2,January,9,,St Mary Colechurch,0,0
+1666,2,January,9,,St Swithin,1,0
+1666,2,January,9,,St Ethelburga,0,0
+1666,2,January,9,,St Mary Hill,1,0
+1666,2,January,9,,St Thomas Apostle,0,0
+1666,2,January,9,,St Faith,0,0
+1666,2,January,9,,St Mary Milkstreet,0,0
+1666,2,January,9,,Trinity Parish,1,1
+1666,2,January,9,,St Gabriel Fenchurch,0,0
+1666,2,January,9,,St Mary Mag. Oldfishstreet,2,0
+1666,2,January,9,,St Vedast alias Foster,0,0
+1666,2,January,9,,St George Botolphlane,0,0
+1666,2,January,9,,St Andrew Holborn,6,4
+1666,2,January,9,,St Botolph Aldgate,10,3
+1666,2,January,9,,Saviour Southwark,16,8
+1666,2,January,9,,St Bartholomew the Great,1,1
+1666,2,January,9,,St Botolph Bishopsgate,7,1
+1666,2,January,9,,St Sepulchres Parish,9,0
+1666,2,January,9,,St Bartholomew the Lesse,1,0
+1666,2,January,9,,St Dunstan West,6,2
+1666,2,January,9,,St Thomas Southwark,1,0
+1666,2,January,9,,St Bridget,7,2
+1666,2,January,9,,St George Southwark,1,0
+1666,2,January,9,,Trinity Minories,1,0
+1666,2,January,9,,Bridewel Precinct,0,0
+1666,2,January,9,,St Giles Cripplegate,11,4
+1666,2,January,9,,At the Pesthouse,0,0
+1666,2,January,9,,St Botolph Aldersgate,0,0
+1666,2,January,9,,St Olave Southwark,7,2
+1666,2,January,9,,...hritt Church,0,0
+1666,2,January,9,,St Katharine Tower,4,0
+1666,2,January,9,,St Mary Newington,3,0
+1666,2,January,9,,Dunstan Stepney,31,16
+1666,2,January,9,,Lambeth Parish,9,5
+1666,2,January,9,,St Mary Whitechappel,13,3
+1666,2,January,9,,St Giles in the Fields,10,1
+1666,2,January,9,,St Leonard Shoreditch,6,0
+1666,2,January,9,,St. Paul Shadwel,0,0
+1666,2,January,9,,St James Clerkenwel,4,0
+1666,2,January,9,,St Mary Islington,2,0
+1666,2,January,9,,Rotherhith Parish,5,3
+1666,2,January,9,,John at Hackney,1,0
+1666,2,January,9,,St Mary Magd. Bermondsey,10,5
+1666,2,January,9,,St Ann Westminster,0,0
+1666,2,January,9,,St Margaret Westminster,10,4
+1666,2,January,9,,St Mary Savoy,1,0
+1666,2,January,9,,St Clement Danes,6,1
+1666,2,January,9,,St Martin in the Fields,9,2
+1666,2,January,9,,St Paul Covent Garden,1,0
+1666,2,January,9,,St James Westminster,0,0
+1666,9,January,16,,ALban Woodstreet,0,0
+1666,9,January,16,,St Gregory by St Paul,1,0
+1666,9,January,16,,St Mary Mounthaw,0,0
+1666,9,January,16,,Alhallows Barking,1,0
+1666,9,January,16,,St Hellen,0,0
+1666,9,January,16,,St Mary Sommerset,3,0
+1666,9,January,16,,Alhallows Breadstreet,0,0
+1666,9,January,16,,St James Dukes Place,3,2
+1666,9,January,16,,St Mary Staining,0,0
+1666,9,January,16,,Alhallows the Great,0,0
+1666,9,January,16,,St James Garlickhithe,0,0
+1666,9,January,16,,St Mary Woolchurch,0,0
+1666,9,January,16,,Alhallows Honylane,0,0
+1666,9,January,16,,St John Baptist,1,1
+1666,9,January,16,,St Mary Woolnoth,1,0
+1666,9,January,16,,Alhallows the Less,2,2
+1666,9,January,16,,St John Evangelist,0,0
+1666,9,January,16,,St Matthew Fridaystreet,0,0
+1666,9,January,16,,Alhallows Lombardstreet,0,0
+1666,9,January,16,,St John Zachary,1,0
+1666,9,January,16,,St Michael Bassishaw,1,0
+1666,9,January,16,,Alhallows Staining,1,0
+1666,9,January,16,,St Katharine Coleman,3,3
+1666,9,January,16,,St Michael Cornhil,1,1
+1666,9,January,16,,Alhallows the Wall,2,1
+1666,9,January,16,,St Katharine Creechurch,1,1
+1666,9,January,16,,St Michael Crookedlane,1,1
+1666,9,January,16,,St Alphage,1,0
+1666,9,January,16,,St Lawrence Jewry,0,0
+1666,9,January,16,,St Michael Queenhithe,3,1
+1666,9,January,16,,St Andrew Hubbard,0,0
+1666,9,January,16,,St Lawrence Pountney,1,1
+1666,9,January,16,,St Michael Quern,0,0
+1666,9,January,16,,St Andrew Undershaft,1,1
+1666,9,January,16,,St Leonard Eastcheap,1,0
+1666,9,January,16,,St Michael Royal,0,0
+1666,9,January,16,,St Andrew Wardrobe,3,2
+1666,9,January,16,,St Leonard Fosterlane,0,0
+1666,9,January,16,,St Michael Woodstreet,1,0
+1666,9,January,16,,St Ann Aldersgate,1,0
+1666,9,January,16,,St Magnus Parish,0,0
+1666,9,January,16,,St Mildred Breadstreet,0,0
+1666,9,January,16,,St Ann Blackfriers,2,1
+1666,9,January,16,,St Margaret Lothbury,0,0
+1666,9,January,16,,St Mildred Poultry,0,0
+1666,9,January,16,,St Anthony alias Antholin,0,0
+1666,9,January,16,,St Margaret Moses,0,0
+1666,9,January,16,,St Nicholas Acons,0,0
+1666,9,January,16,,St Austins Parish,1,1
+1666,9,January,16,,St Margaret Newfishstreet,1,0
+1666,9,January,16,,St Nicholas Coleabby,0,0
+1666,9,January,16,,St Bartholomew Exchange,0,0
+1666,9,January,16,,St Margaret Pattons,3,1
+1666,9,January,16,,St Nicholas Olaves,0,0
+1666,9,January,16,,St Bennet Finck,1,1
+1666,9,January,16,,St Martin Iremongerlane,0,0
+1666,9,January,16,,St Olave Hartstreet,2,2
+1666,9,January,16,,St Bennet Gracechurch,1,0
+1666,9,January,16,,St Martin Ludgate,0,0
+1666,9,January,16,,St Olave Jewry,0,0
+1666,9,January,16,,St Bennet Paulswharf,0,0
+1666,9,January,16,,St Martin Orgars,2,1
+1666,9,January,16,,St Olave Silverstreet,0,0
+1666,9,January,16,,St Bennet Sherehog,0,0
+1666,9,January,16,,St Martin Outwitch,0,0
+1666,9,January,16,,St Pancras Soperlane,0,0
+1666,9,January,16,,St Botolph Billingsgate,1,0
+1666,9,January,16,,St Martin Vintrey,3,0
+1666,9,January,16,,St Peter Cheap,0,0
+1666,9,January,16,,Christ's Church,2,1
+1666,9,January,16,,St Mary Abchurch,1,0
+1666,9,January,16,,St Peter Cornhil,0,0
+1666,9,January,16,,St Christophers,0,0
+1666,9,January,16,,St Mary Aldermanbury,0,0
+1666,9,January,16,,St Peter Paulswharf,0,0
+1666,9,January,16,,St Clement Eastcheap,1,1
+1666,9,January,16,,St Mary Aldermary,0,0
+1666,9,January,16,,St Peter Poor,0,0
+1666,9,January,16,,St Dionis Backchurch,1,1
+1666,9,January,16,,St Mary-le-bow,1,0
+1666,9,January,16,,St Steven Colemanstreet,4,2
+1666,9,January,16,,St Dunstan East,2,2
+1666,9,January,16,,St Mary Bothaw,0,0
+1666,9,January,16,,St Steven Walbrook,1,0
+1666,9,January,16,,St Edmund Lumbardstr.,1,1
+1666,9,January,16,,St Mary Colechurch,0,0
+1666,9,January,16,,St Swithin,0,0
+1666,9,January,16,,St Ethelburga,1,1
+1666,9,January,16,,St Mary Hill,1,1
+1666,9,January,16,,St Thomas Apostle,1,0
+1666,9,January,16,,St Faith,0,0
+1666,9,January,16,,St Mary Milkstreet,1,1
+1666,9,January,16,,Trinity Parish,0,0
+1666,9,January,16,,St Gabriel Fenchurch,0,0
+1666,9,January,16,,St Mary Mag. Oldfishstreet,0,0
+1666,9,January,16,,St Vedast alias Foster,0,0
+1666,9,January,16,,St George Botolphlane,0,0
+1666,9,January,16,,St Andrew Holborn,9,7
+1666,9,January,16,,St Botolph Aldgate,13,6
+1666,9,January,16,,Saviour Southwark,29,21
+1666,9,January,16,,St Bartholomew the Great,0,0
+1666,9,January,16,,St Botolph Bishopsgate,6,0
+1666,9,January,16,,St Sepulchres Parish,13,5
+1666,9,January,16,,St Bartholomew the Lesse,2,0
+1666,9,January,16,,St Dunstan West,4,3
+1666,9,January,16,,St Thomas Southwark,2,1
+1666,9,January,16,,St Bridget,10,2
+1666,9,January,16,,St George Southwark,4,0
+1666,9,January,16,,Trinity Minories,0,0
+1666,9,January,16,,Bridewel Precinct,1,0
+1666,9,January,16,,St Giles Cripplegate,17,3
+1666,9,January,16,,At the Pesthouse,1,1
+1666,9,January,16,,St Botolph Aldersgate,3,0
+1666,9,January,16,,St Olave Southwark,17,4
+1666,9,January,16,,St Katharine Tower,4,0
+1666,9,January,16,,St Mary Newington,3,0
+1666,9,January,16,,Dunstan Stepney,50,29
+1666,9,January,16,,Lambeth Parish,10,6
+1666,9,January,16,,St Mary Whitechappel,8,4
+1666,9,January,16,,St Giles in the Fields,14,6
+1666,9,January,16,,St Leonard Shoreditch,5,1
+1666,9,January,16,,St. Paul Shadwel,0,0
+1666,9,January,16,,St James Clerkenwel,3,0
+1666,9,January,16,,St Mary Islington,5,0
+1666,9,January,16,,Rotherhith Parish,8,8
+1666,9,January,16,,John at Hackney,1,0
+1666,9,January,16,,St Mary Magd. Bermondsey,12,7
+1666,9,January,16,,St Ann Westminster,0,0
+1666,9,January,16,,St Margaret Westminster,18,5
+1666,9,January,16,,St Mary Savoy,1,0
+1666,9,January,16,,St Clement Danes,7,0
+1666,9,January,16,,St Martin in the Fields,23,3
+1666,9,January,16,,St Paul Covent Garden,2,0
+1666,9,January,16,,St James Westminster,0,0
+1666,16,January,23,,ALban Woodstreet,1,0
+1666,16,January,23,,St Gregory by St Paul,0,0
+1666,16,January,23,,St Mary Mounthaw,0,0
+1666,16,January,23,,Alhallows Barking,5,0
+1666,16,January,23,,St Hellen,2,0
+1666,16,January,23,,St Mary Sommerset,1,1
+1666,16,January,23,,Alhallows Breadstreet,0,0
+1666,16,January,23,,St James Dukes Place,3,1
+1666,16,January,23,,St Mary Staining,0,0
+1666,16,January,23,,Alhallows the Great,2,1
+1666,16,January,23,,St James Garlickhithe,0,0
+1666,16,January,23,,St Mary Woolchurch,1,0
+1666,16,January,23,,Alhallows Honylane,1,0
+1666,16,January,23,,St John Baptist,1,0
+1666,16,January,23,,St Mary Woolnoth,0,0
+1666,16,January,23,,Alhallows the Less,0,0
+1666,16,January,23,,St John Evangelist,0,0
+1666,16,January,23,,St Matthew Fridaystreet,1,0
+1666,16,January,23,,Alhallows Lombardstreet,0,0
+1666,16,January,23,,St John Zachary,0,0
+1666,16,January,23,,St Michael Bassishaw,0,0
+1666,16,January,23,,Alhallows Staining,2,0
+1666,16,January,23,,St Katharine Coleman,1,0
+1666,16,January,23,,St Michael Cornhil,0,0
+1666,16,January,23,,Alhallows the Wall,2,1
+1666,16,January,23,,St Katharine Creechurch,3,2
+1666,16,January,23,,St Michael Crookedlane,1,0
+1666,16,January,23,,St Alphage,1,0
+1666,16,January,23,,St Lawrence Jewry,0,0
+1666,16,January,23,,St Michael Queenhithe,3,0
+1666,16,January,23,,St Andrew Hubbard,0,0
+1666,16,January,23,,St Lawrence Pountney,3,3
+1666,16,January,23,,St Michael Quern,0,0
+1666,16,January,23,,St Andrew Undershaft,1,1
+1666,16,January,23,,St Leonard Eastcheap,0,0
+1666,16,January,23,,St Michael Royal,0,0
+1666,16,January,23,,St Andrew Wardrobe,2,0
+1666,16,January,23,,St Leonard Fosterlane,0,0
+1666,16,January,23,,St Michael Woodstreet,1,0
+1666,16,January,23,,St Ann Aldersgate,5,1
+1666,16,January,23,,St Magnus Parish,1,0
+1666,16,January,23,,St Mildred Breadstreet,0,0
+1666,16,January,23,,St Ann Blackfriers,2,0
+1666,16,January,23,,St Margaret Lothbury,0,0
+1666,16,January,23,,St Mildred Poultry,1,0
+1666,16,January,23,,St Anthony alias Antholin,0,0
+1666,16,January,23,,St Margaret Moses,0,0
+1666,16,January,23,,St Nicholas Acons,1,0
+1666,16,January,23,,St Austins Parish,0,0
+1666,16,January,23,,St Margaret Newfishstreet,1,0
+1666,16,January,23,,St Nicholas Coleabby,0,0
+1666,16,January,23,,St Bartholomew Exchange,0,0
+1666,16,January,23,,St Margaret Pattons,2,0
+1666,16,January,23,,St Nicholas Olaves,0,0
+1666,16,January,23,,St Bennet Finck,2,0
+1666,16,January,23,,St Martin Iremongerlane,0,0
+1666,16,January,23,,St Olave Hartstreet,0,0
+1666,16,January,23,,St Bennet Gracechurch,0,0
+1666,16,January,23,,St Martin Ludgate,1,0
+1666,16,January,23,,St Olave Jewry,0,0
+1666,16,January,23,,St Bennet Paulswharf,0,0
+1666,16,January,23,,St Martin Orgars,0,0
+1666,16,January,23,,St Olave Silverstreet,0,0
+1666,16,January,23,,St Bennet Sherehog,1,0
+1666,16,January,23,,St Martin Outwitch,0,0
+1666,16,January,23,,St Pancras Soperlane,0,0
+1666,16,January,23,,St Botolph Billingsgate,1,1
+1666,16,January,23,,St Martin Vintrey,1,0
+1666,16,January,23,,St Peter Cheap,0,0
+1666,16,January,23,,Christ's Church,2,0
+1666,16,January,23,,St Mary Abchurch,0,0
+1666,16,January,23,,St Peter Cornhil,0,0
+1666,16,January,23,,St Christophers,0,0
+1666,16,January,23,,St Mary Aldermanbury,0,0
+1666,16,January,23,,St Peter Paulswharf,0,0
+1666,16,January,23,,St Clement Eastcheap,0,0
+1666,16,January,23,,St Mary Aldermary,0,0
+1666,16,January,23,,St Peter Poor,0,0
+1666,16,January,23,,St Dionis Backchurch,0,0
+1666,16,January,23,,St Mary-le-bow,0,0
+1666,16,January,23,,St Steven Colemanstreet,2,0
+1666,16,January,23,,St Dunstan East,1,0
+1666,16,January,23,,St Mary Bothaw,0,0
+1666,16,January,23,,St Steven Walbrook,0,0
+1666,16,January,23,,St Edmund Lumbardstr.,3,3
+1666,16,January,23,,St Mary Colechurch,0,0
+1666,16,January,23,,St Swithin,2,0
+1666,16,January,23,,St Ethelburga,2,1
+1666,16,January,23,,St Mary Hill,0,0
+1666,16,January,23,,St Thomas Apostle,0,0
+1666,16,January,23,,St Faith,0,0
+1666,16,January,23,,St Mary Milkstreet,0,0
+1666,16,January,23,,Trinity Parish,0,0
+1666,16,January,23,,St Gabriel Fenchurch,0,0
+1666,16,January,23,,St Mary Mag. Oldfishstreet,0,0
+1666,16,January,23,,St Vedast alias Foster,0,0
+1666,16,January,23,,St George Botolphlane,0,0
+1666,16,January,23,,St Andrew Holborn,7,2
+1666,16,January,23,,St Botolph Aldgate,0,0
+1666,16,January,23,,Saviour Southwark,9,6
+1666,16,January,23,,St Bartholomew the Great,2,0
+1666,16,January,23,,St Botolph Bishopsgate,4,1
+1666,16,January,23,,St Sepulchres Parish,4,2
+1666,16,January,23,,St Bartholomew the Lesse,0,0
+1666,16,January,23,,St Dunstan West,2,0
+1666,16,January,23,,St Thomas Southwark,2,1
+1666,16,January,23,,St Bridget,5,1
+1666,16,January,23,,St George Southwark,2,0
+1666,16,January,23,,Trinity Minories,1,0
+1666,16,January,23,,Bridewel Precinct,0,0
+1666,16,January,23,,St Giles Cripplegate,18,5
+1666,16,January,23,,At the Pesthouse,1,1
+1666,16,January,23,,St Botolph Aldersgate,14,4
+1666,16,January,23,,St Olave Southwark,11,1
+1666,16,January,23,,...hritt Church,0,0
+1666,16,January,23,,St Katharine Tower,2,1
+1666,16,January,23,,St Mary Newington,3,0
+1666,16,January,23,,Dunstan Stepney,35,18
+1666,16,January,23,,Lambeth Parish,8,8
+1666,16,January,23,,St Mary Whitechappel,7,0
+1666,16,January,23,,St Giles in the Fields,12,0
+1666,16,January,23,,St Leonard Shoreditch,6,1
+1666,16,January,23,,St. Paul Shadwel,0,0
+1666,16,January,23,,St James Clerkenwel,3,1
+1666,16,January,23,,St Mary Islington,2,0
+1666,16,January,23,,Rotherhith Parish,5,2
+1666,16,January,23,,John at Hackney,1,1
+1666,16,January,23,,St Mary Magd. Bermondsey,5,2
+1666,16,January,23,,St Ann Westminster,0,0
+1666,16,January,23,,St Margaret Westminster,17,3
+1666,16,January,23,,St Mary Savoy,0,0
+1666,16,January,23,,St Clement Danes,4,0
+1666,16,January,23,,St Martin in the Fields,11,2
+1666,16,January,23,,St Paul Covent Garden,0,0
+1666,16,January,23,,St James Westminster,0,0
+1666,23,January,30,,ALban Woodstreet,0,0
+1666,23,January,30,,St Gregory by St Paul,1,0
+1666,23,January,30,,St Mary Mounthaw,1,1
+1666,23,January,30,,Alhallows Barking,4,2
+1666,23,January,30,,St Hellen,0,0
+1666,23,January,30,,St Mary Sommerset,1,0
+1666,23,January,30,,Alhallows Breadstreet,0,0
+1666,23,January,30,,St James Dukes Place,1,1
+1666,23,January,30,,St Mary Staining,0,0
+1666,23,January,30,,Alhallows the Great,0,0
+1666,23,January,30,,St James Garlickhithe,0,0
+1666,23,January,30,,St Mary Woolchurch,0,0
+1666,23,January,30,,Alhallows Honylane,0,0
+1666,23,January,30,,St John Baptist,0,0
+1666,23,January,30,,St Mary Woolnoth,1,1
+1666,23,January,30,,Alhallows the Less,2,2
+1666,23,January,30,,St John Evangelist,0,0
+1666,23,January,30,,St Matthew Fridaystreet,1,0
+1666,23,January,30,,Alhallows Lombardstreet,0,0
+1666,23,January,30,,St John Zachary,0,0
+1666,23,January,30,,St Michael Bassishaw,2,0
+1666,23,January,30,,Alhallows Staining,0,0
+1666,23,January,30,,St Katharine Coleman,1,0
+1666,23,January,30,,St Michael Cornhil,0,0
+1666,23,January,30,,Alhallows the Wall,1,1
+1666,23,January,30,,St Katharine Creechurch,3,1
+1666,23,January,30,,St Michael Crookedlane,0,0
+1666,23,January,30,,St Alphage,1,0
+1666,23,January,30,,St Lawrence Jewry,0,0
+1666,23,January,30,,St Michael Queenhithe,1,0
+1666,23,January,30,,St Andrew Hubbard,0,0
+1666,23,January,30,,St Lawrence Pountney,1,1
+1666,23,January,30,,St Michael Quern,0,0
+1666,23,January,30,,St Andrew Undershaft,0,0
+1666,23,January,30,,St Leonard Eastcheap,0,0
+1666,23,January,30,,St Michael Royal,1,0
+1666,23,January,30,,St Andrew Wardrobe,0,0
+1666,23,January,30,,St Leonard Fosterlane,2,1
+1666,23,January,30,,St Michael Woodstreet,0,0
+1666,23,January,30,,St Ann Aldersgate,0,0
+1666,23,January,30,,St Magnus Parish,1,0
+1666,23,January,30,,St Mildred Breadstreet,0,0
+1666,23,January,30,,St Ann Blackfriers,2,1
+1666,23,January,30,,St Margaret Lothbury,1,1
+1666,23,January,30,,St Mildred Poultry,0,0
+1666,23,January,30,,St Anthony alias Antholin,0,0
+1666,23,January,30,,St Margaret Moses,0,0
+1666,23,January,30,,St Nicholas Acons,0,0
+1666,23,January,30,,St Austins Parish,0,0
+1666,23,January,30,,St Margaret Newfishstreet,0,0
+1666,23,January,30,,St Nicholas Coleabby,2,0
+1666,23,January,30,,St Bartholomew Exchange,0,0
+1666,23,January,30,,St Margaret Pattons,0,0
+1666,23,January,30,,St Nicholas Olaves,1,0
+1666,23,January,30,,St Bennet Finck,0,0
+1666,23,January,30,,St Martin Iremongerlane,0,0
+1666,23,January,30,,St Olave Hartstreet,1,0
+1666,23,January,30,,St Bennet Gracechurch,1,0
+1666,23,January,30,,St Martin Ludgate,1,0
+1666,23,January,30,,St Olave Jewry,0,0
+1666,23,January,30,,St Bennet Paulswharf,1,0
+1666,23,January,30,,St Martin Orgars,0,0
+1666,23,January,30,,St Olave Silverstreet,0,0
+1666,23,January,30,,St Bennet Sherehog,0,0
+1666,23,January,30,,St Martin Outwitch,0,0
+1666,23,January,30,,St Pancras Soperlane,0,0
+1666,23,January,30,,St Botolph Billingsgate,0,0
+1666,23,January,30,,St Martin Vintrey,0,0
+1666,23,January,30,,St Peter Cheap,0,0
+1666,23,January,30,,Christ's Church,0,0
+1666,23,January,30,,St Mary Abchurch,1,1
+1666,23,January,30,,St Peter Cornhil,0,0
+1666,23,January,30,,St Christophers,0,0
+1666,23,January,30,,St Mary Aldermanbury,1,1
+1666,23,January,30,,St Peter Paulswharf,1,0
+1666,23,January,30,,St Clement Eastcheap,1,1
+1666,23,January,30,,St Mary Aldermary,1,0
+1666,23,January,30,,St Peter Poor,1,0
+1666,23,January,30,,St Dionis Backchurch,0,0
+1666,23,January,30,,St Mary-le-bow,0,0
+1666,23,January,30,,St Steven Colemanstreet,2,1
+1666,23,January,30,,St Dunstan East,2,0
+1666,23,January,30,,St Mary Bothaw,0,0
+1666,23,January,30,,St Steven Walbrook,1,0
+1666,23,January,30,,St Edmund Lumbardstr.,1,1
+1666,23,January,30,,St Mary Colechurch,0,0
+1666,23,January,30,,St Swithin,0,0
+1666,23,January,30,,St Ethelburga,0,0
+1666,23,January,30,,St Mary Hill,1,0
+1666,23,January,30,,St Thomas Apostle,0,0
+1666,23,January,30,,St Faith,1,0
+1666,23,January,30,,St Mary Milkstreet,0,0
+1666,23,January,30,,Trinity Parish,1,0
+1666,23,January,30,,St Gabriel Fenchurch,0,0
+1666,23,January,30,,St Mary Mag. Oldfishstreet,0,0
+1666,23,January,30,,St Vedast alias Foster,1,0
+1666,23,January,30,,St George Botolphlane,1,0
+1666,23,January,30,,St Andrew Holborn,6,0
+1666,23,January,30,,St Botolph Aldgate,9,2
+1666,23,January,30,,Saviour Southwark,10,6
+1666,23,January,30,,St Bartholomew the Great,1,0
+1666,23,January,30,,St Botolph Bishopsgate,7,0
+1666,23,January,30,,St Sepulchres Parish,9,0
+1666,23,January,30,,St Bartholomew the Lesse,0,0
+1666,23,January,30,,St Dunstan West,1,1
+1666,23,January,30,,St Thomas Southwark,1,0
+1666,23,January,30,,St Bridget,3,1
+1666,23,January,30,,St George Southwark,0,0
+1666,23,January,30,,Trinity Minories,0,0
+1666,23,January,30,,Bridewel Precinct,1,0
+1666,23,January,30,,St Giles Cripplegate,12,2
+1666,23,January,30,,At the Pesthouse,0,0
+1666,23,January,30,,St Botolph Aldersgate,2,0
+1666,23,January,30,,St Olave Southwark,9,1
+1666,23,January,30,,...hritt Church,0,0
+1666,23,January,30,,St Katharine Tower,1,0
+1666,23,January,30,,St Mary Newington,5,1
+1666,23,January,30,,Dunstan Stepney,41,11
+1666,23,January,30,,Lambeth Parish,10,5
+1666,23,January,30,,St Mary Whitechappel,5,0
+1666,23,January,30,,St Giles in the Fields,4,0
+1666,23,January,30,,St Leonard Shoreditch,5,0
+1666,23,January,30,,St. Paul Shadwel,0,0
+1666,23,January,30,,St James Clerkenwel,3,1
+1666,23,January,30,,St Mary Islington,0,0
+1666,23,January,30,,Rotherhith Parish,3,3
+1666,23,January,30,,John at Hackney,1,0
+1666,23,January,30,,St Mary Magd. Bermondsey,3,1
+1666,23,January,30,,St Ann Westminster,0,0
+1666,23,January,30,,St Margaret Westminster,9,2
+1666,23,January,30,,St Mary Savoy,4,0
+1666,23,January,30,,St Clement Danes,3,0
+1666,23,January,30,,St Martin in the Fields,5,0
+1666,23,January,30,,St Paul Covent Garden,0,0
+1666,23,January,30,,St James Westminster,0,0
+1666,30,January,6,February,ALban Woodstreet,0,0
+1666,30,January,6,February,St Gregory by St Paul,0,0
+1666,30,January,6,February,St Mary Mounthaw,0,0
+1666,30,January,6,February,Alhallows Barking,5,1
+1666,30,January,6,February,St Hellen,1,0
+1666,30,January,6,February,St Mary Sommerset,0,0
+1666,30,January,6,February,Alhallows Breadstreet,0,0
+1666,30,January,6,February,St James Dukes Place,0,0
+1666,30,January,6,February,St Mary Staining,0,0
+1666,30,January,6,February,Alhallows the Great,1,0
+1666,30,January,6,February,St James Garlickhithe,1,0
+1666,30,January,6,February,St Mary Woolchurch,0,0
+1666,30,January,6,February,Alhallows Honylane,0,0
+1666,30,January,6,February,St John Baptist,0,0
+1666,30,January,6,February,St Mary Woolnoth,1,0
+1666,30,January,6,February,Alhallows the Less,0,0
+1666,30,January,6,February,St John Evangelist,0,0
+1666,30,January,6,February,St Matthew Fridaystreet,0,0
+1666,30,January,6,February,Alhallows Lombardstreet,0,0
+1666,30,January,6,February,St John Zachary,1,0
+1666,30,January,6,February,St Michael Bassishaw,1,0
+1666,30,January,6,February,Alhallows Staining,2,0
+1666,30,January,6,February,St Katharine Coleman,0,0
+1666,30,January,6,February,St Michael Cornhil,1,0
+1666,30,January,6,February,Alhallows the Wall,1,1
+1666,30,January,6,February,St Katharine Creechurch,2,1
+1666,30,January,6,February,St Michael Crookedlane,2,1
+1666,30,January,6,February,St Alphage,0,0
+1666,30,January,6,February,St Lawrence Jewry,0,0
+1666,30,January,6,February,St Michael Queenhithe,1,0
+1666,30,January,6,February,St Andrew Hubbard,0,0
+1666,30,January,6,February,St Lawrence Pountney,1,0
+1666,30,January,6,February,St Michael Quern,0,0
+1666,30,January,6,February,St Andrew Undershaft,2,0
+1666,30,January,6,February,St Leonard Eastcheap,0,0
+1666,30,January,6,February,St Michael Royal,1,0
+1666,30,January,6,February,St Andrew Wardrobe,1,0
+1666,30,January,6,February,St Leonard Fosterlane,0,0
+1666,30,January,6,February,St Michael Woodstreet,2,0
+1666,30,January,6,February,St Ann Aldersgate,0,0
+1666,30,January,6,February,St Magnus Parish,0,0
+1666,30,January,6,February,St Mildred Breadstreet,0,0
+1666,30,January,6,February,St Ann Blackfriers,2,0
+1666,30,January,6,February,St Margaret Lothbury,1,1
+1666,30,January,6,February,St Mildred Poultry,0,0
+1666,30,January,6,February,St Anthony alias Antholin,0,0
+1666,30,January,6,February,St Margaret Moses,0,0
+1666,30,January,6,February,St Nicholas Acons,0,0
+1666,30,January,6,February,St Austins Parish,0,0
+1666,30,January,6,February,St Margaret Newfishstreet,0,0
+1666,30,January,6,February,St Nicholas Coleabby,0,0
+1666,30,January,6,February,St Bartholomew Exchange,0,0
+1666,30,January,6,February,St Margaret Pattons,1,1
+1666,30,January,6,February,St Nicholas Olaves,0,0
+1666,30,January,6,February,St Bennet Finck,0,0
+1666,30,January,6,February,St Martin Iremongerlane,0,0
+1666,30,January,6,February,St Olave Hartstreet,2,0
+1666,30,January,6,February,St Bennet Gracechurch,0,0
+1666,30,January,6,February,St Martin Ludgate,1,0
+1666,30,January,6,February,St Olave Jewry,1,0
+1666,30,January,6,February,St Bennet Paulswharf,1,0
+1666,30,January,6,February,St Martin Orgars,1,1
+1666,30,January,6,February,St Olave Silverstreet,1,0
+1666,30,January,6,February,St Bennet Sherehog,0,0
+1666,30,January,6,February,St Martin Outwitch,0,0
+1666,30,January,6,February,St Pancras Soperlane,0,0
+1666,30,January,6,February,St Botolph Billingsgate,1,1
+1666,30,January,6,February,St Martin Vintrey,0,0
+1666,30,January,6,February,St Peter Cheap,1,0
+1666,30,January,6,February,Christ's Church,1,0
+1666,30,January,6,February,St Mary Abchurch,0,0
+1666,30,January,6,February,St Peter Cornhil,0,0
+1666,30,January,6,February,St Christophers,0,0
+1666,30,January,6,February,St Mary Aldermanbury,1,0
+1666,30,January,6,February,St Peter Paulswharf,1,0
+1666,30,January,6,February,St Clement Eastcheap,1,1
+1666,30,January,6,February,St Mary Aldermary,0,0
+1666,30,January,6,February,St Peter Poor,1,0
+1666,30,January,6,February,St Dionis Backchurch,1,0
+1666,30,January,6,February,St Mary-le-bow,1,0
+1666,30,January,6,February,St Steven Colemanstreet,0,0
+1666,30,January,6,February,St Dunstan East,1,0
+1666,30,January,6,February,St Mary Bothaw,0,0
+1666,30,January,6,February,St Steven Walbrook,0,0
+1666,30,January,6,February,St Edmund Lumbardstr.,0,0
+1666,30,January,6,February,St Mary Colechurch,0,0
+1666,30,January,6,February,St Swithin,0,0
+1666,30,January,6,February,St Ethelburga,0,0
+1666,30,January,6,February,St Mary Hill,1,1
+1666,30,January,6,February,St Thomas Apostle,0,0
+1666,30,January,6,February,St Faith,1,0
+1666,30,January,6,February,St Mary Milkstreet,0,0
+1666,30,January,6,February,Trinity Parish,0,0
+1666,30,January,6,February,St Gabriel Fenchurch,0,0
+1666,30,January,6,February,St Mary Mag. Oldfishstreet,0,0
+1666,30,January,6,February,St Vedast alias Foster,1,1
+1666,30,January,6,February,St George Botolphlane,0,0
+1666,30,January,6,February,St Andrew Holborn,8,1
+1666,30,January,6,February,St Botolph Aldgate,6,4
+1666,30,January,6,February,Saviour Southwark,12,5
+1666,30,January,6,February,St Bartholomew the Great,0,0
+1666,30,January,6,February,St Botolph Bishopsgate,5,1
+1666,30,January,6,February,St Sepulchres Parish,12,1
+1666,30,January,6,February,St Bartholomew the Lesse,0,0
+1666,30,January,6,February,St Dunstan West,4,0
+1666,30,January,6,February,St Thomas Southwark,1,0
+1666,30,January,6,February,St Bridget,2,0
+1666,30,January,6,February,St George Southwark,1,0
+1666,30,January,6,February,Trinity Minories,1,0
+1666,30,January,6,February,Bridewel Precinct,0,0
+1666,30,January,6,February,St Giles Cripplegate,16,1
+1666,30,January,6,February,At the Pesthouse,0,0
+1666,30,January,6,February,St Botolph Aldersgate,1,0
+1666,30,January,6,February,St Olave Southwark,6,1
+1666,30,January,6,February,...hritt Church,0,0
+1666,30,January,6,February,St Katharine Tower,5,0
+1666,30,January,6,February,St Mary Newington,3,2
+1666,30,January,6,February,Dunstan Stepney,25,15
+1666,30,January,6,February,Lambeth Parish,5,5
+1666,30,January,6,February,St Mary Whitechappel,5,0
+1666,30,January,6,February,St Giles in the Fields,7,0
+1666,30,January,6,February,St Leonard Shoreditch,6,1
+1666,30,January,6,February,St. Paul Shadwel,0,0
+1666,30,January,6,February,St James Clerkenwel,5,0
+1666,30,January,6,February,St Mary Islington,4,0
+1666,30,January,6,February,Rotherhith Parish,3,0
+1666,30,January,6,February,John at Hackney,3,1
+1666,30,January,6,February,St Mary Magd. Bermondsey,5,2
+1666,30,January,6,February,St Ann Westminster,0,0
+1666,30,January,6,February,St Margaret Westminster,10,0
+1666,30,January,6,February,St Mary Savoy,1,0
+1666,30,January,6,February,St Clement Danes,8,1
+1666,30,January,6,February,St Martin in the Fields,8,0
+1666,30,January,6,February,St Paul Covent Garden,2,0
+1666,30,January,6,February,St James Westminster,0,0
+1666,6,February,13,,ALban Woodstreet,1,1
+1666,6,February,13,,St Gregory by St Paul,0,0
+1666,6,February,13,,St Mary Mounthaw,0,0
+1666,6,February,13,,Alhallows Barking,3,3
+1666,6,February,13,,St Hellen,1,0
+1666,6,February,13,,St Mary Sommerset,1,0
+1666,6,February,13,,Alhallows Breadstreet,0,0
+1666,6,February,13,,St James Dukes Place,1,1
+1666,6,February,13,,St Mary Staining,0,0
+1666,6,February,13,,Alhallows the Great,1,1
+1666,6,February,13,,St James Garlickhithe,2,1
+1666,6,February,13,,St Mary Woolchurch,1,0
+1666,6,February,13,,Alhallows Honylane,0,0
+1666,6,February,13,,St John Baptist,1,1
+1666,6,February,13,,St Mary Woolnoth,0,0
+1666,6,February,13,,Alhallows the Less,0,0
+1666,6,February,13,,St John Evangelist,0,0
+1666,6,February,13,,St Matthew Fridaystreet,0,0
+1666,6,February,13,,Alhallows Lombardstreet,0,0
+1666,6,February,13,,St John Zachary,0,0
+1666,6,February,13,,St Michael Bassishaw,0,0
+1666,6,February,13,,Alhallows Staining,0,0
+1666,6,February,13,,St Katharine Coleman,1,0
+1666,6,February,13,,St Michael Cornhil,1,0
+1666,6,February,13,,Alhallows the Wall,0,0
+1666,6,February,13,,St Katharine Creechurch,0,0
+1666,6,February,13,,St Michael Crookedlane,1,0
+1666,6,February,13,,St Alphage,1,0
+1666,6,February,13,,St Lawrence Jewry,2,0
+1666,6,February,13,,St Michael Queenhithe,0,0
+1666,6,February,13,,St Andrew Hubbard,0,0
+1666,6,February,13,,St Lawrence Pountney,0,0
+1666,6,February,13,,St Michael Quern,2,0
+1666,6,February,13,,St Andrew Undershaft,0,0
+1666,6,February,13,,St Leonard Eastcheap,0,0
+1666,6,February,13,,St Michael Royal,0,0
+1666,6,February,13,,St Andrew Wardrobe,1,0
+1666,6,February,13,,St Leonard Fosterlane,0,0
+1666,6,February,13,,St Michael Woodstreet,0,0
+1666,6,February,13,,St Ann Aldersgate,0,0
+1666,6,February,13,,St Magnus Parish,1,0
+1666,6,February,13,,St Mildred Breadstreet,0,0
+1666,6,February,13,,St Ann Blackfriers,0,0
+1666,6,February,13,,St Margaret Lothbury,0,0
+1666,6,February,13,,St Mildred Poultry,0,0
+1666,6,February,13,,St Anthony alias Antholin,0,0
+1666,6,February,13,,St Margaret Moses,0,0
+1666,6,February,13,,St Nicholas Acons,0,0
+1666,6,February,13,,St Austins Parish,0,0
+1666,6,February,13,,St Margaret Newfishstreet,0,0
+1666,6,February,13,,St Nicholas Coleabby,1,0
+1666,6,February,13,,St Bartholomew Exchange,0,0
+1666,6,February,13,,St Margaret Pattons,0,0
+1666,6,February,13,,St Nicholas Olaves,0,0
+1666,6,February,13,,St Bennet Finck,0,0
+1666,6,February,13,,St Martin Iremongerlane,1,0
+1666,6,February,13,,St Olave Hartstreet,0,0
+1666,6,February,13,,St Bennet Gracechurch,0,0
+1666,6,February,13,,St Martin Ludgate,1,0
+1666,6,February,13,,St Olave Jewry,0,0
+1666,6,February,13,,St Bennet Paulswharf,3,0
+1666,6,February,13,,St Martin Orgars,0,0
+1666,6,February,13,,St Olave Silverstreet,0,0
+1666,6,February,13,,St Bennet Sherehog,0,0
+1666,6,February,13,,St Martin Outwitch,0,0
+1666,6,February,13,,St Pancras Soperlane,1,0
+1666,6,February,13,,St Botolph Billingsgate,0,0
+1666,6,February,13,,St Martin Vintrey,0,0
+1666,6,February,13,,St Peter Cheap,1,0
+1666,6,February,13,,Christ's Church,2,0
+1666,6,February,13,,St Mary Abchurch,1,0
+1666,6,February,13,,St Peter Cornhil,0,0
+1666,6,February,13,,St Christophers,0,0
+1666,6,February,13,,St Mary Aldermanbury,0,0
+1666,6,February,13,,St Peter Paulswharf,2,0
+1666,6,February,13,,St Clement Eastcheap,0,0
+1666,6,February,13,,St Mary Aldermary,1,0
+1666,6,February,13,,St Peter Poor,0,0
+1666,6,February,13,,St Dionis Backchurch,0,0
+1666,6,February,13,,St Mary-le-bow,1,0
+1666,6,February,13,,St Steven Colemanstreet,0,0
+1666,6,February,13,,St Dunstan East,3,2
+1666,6,February,13,,St Mary Bothaw,0,0
+1666,6,February,13,,St Steven Walbrook,0,0
+1666,6,February,13,,St Edmund Lumbardstr.,2,1
+1666,6,February,13,,St Mary Colechurch,0,0
+1666,6,February,13,,St Swithin,0,0
+1666,6,February,13,,St Ethelburga,1,0
+1666,6,February,13,,St Mary Hill,0,0
+1666,6,February,13,,St Thomas Apostle,0,0
+1666,6,February,13,,St Faith,0,0
+1666,6,February,13,,St Mary Milkstreet,0,0
+1666,6,February,13,,Trinity Parish,1,0
+1666,6,February,13,,St Gabriel Fenchurch,0,0
+1666,6,February,13,,St Mary Mag. Oldfishstreet,0,0
+1666,6,February,13,,St Vedast alias Foster,0,0
+1666,6,February,13,,St George Botolphlane,0,0
+1666,6,February,13,,St Andrew Holborn,10,4
+1666,6,February,13,,St Botolph Aldgate,8,1
+1666,6,February,13,,Saviour Southwark,13,5
+1666,6,February,13,,St Bartholomew the Great,1,0
+1666,6,February,13,,St Botolph Bishopsgate,7,1
+1666,6,February,13,,St Sepulchres Parish,8,3
+1666,6,February,13,,St Bartholomew the Lesse,0,0
+1666,6,February,13,,St Dunstan West,5,2
+1666,6,February,13,,St Thomas Southwark,1,0
+1666,6,February,13,,St Bridget,10,1
+1666,6,February,13,,St George Southwark,1,0
+1666,6,February,13,,Trinity Minories,0,0
+1666,6,February,13,,Bridewel Precinct,0,0
+1666,6,February,13,,St Giles Cripplegate,9,3
+1666,6,February,13,,At the Pesthouse,0,0
+1666,6,February,13,,St Botolph Aldersgate,7,0
+1666,6,February,13,,St Olave Southwark,11,1
+1666,6,February,13,,...hritt Church,0,0
+1666,6,February,13,,St Katharine Tower,2,0
+1666,6,February,13,,St Mary Newington,2,0
+1666,6,February,13,,Dunstan Stepney,32,11
+1666,6,February,13,,Lambeth Parish,8,5
+1666,6,February,13,,St Mary Whitechappel,13,4
+1666,6,February,13,,St Giles in the Fields,4,0
+1666,6,February,13,,St Leonard Shoreditch,6,1
+1666,6,February,13,,St. Paul Shadwel,0,0
+1666,6,February,13,,St James Clerkenwel,2,0
+1666,6,February,13,,St Mary Islington,0,0
+1666,6,February,13,,Rotherhith Parish,4,1
+1666,6,February,13,,John at Hackney,3,0
+1666,6,February,13,,St Mary Magd. Bermondsey,8,1
+1666,6,February,13,,St Ann Westminster,0,0
+1666,6,February,13,,St Margaret Westminster,12,1
+1666,6,February,13,,St Mary Savoy,0,0
+1666,6,February,13,,St Clement Danes,5,1
+1666,6,February,13,,St Martin in the Fields,13,2
+1666,6,February,13,,St Paul Covent Garden,0,0
+1666,6,February,13,,St James Westminster,0,0
+1666,13,February,20,,ALban Woodstreet,0,0
+1666,13,February,20,,St Gregory by St Paul,4,0
+1666,13,February,20,,St Mary Mounthaw,2,1
+1666,13,February,20,,Alhallows Barking,3,1
+1666,13,February,20,,St Hellen,1,0
+1666,13,February,20,,St Mary Sommerset,0,0
+1666,13,February,20,,Alhallows Breadstreet,1,0
+1666,13,February,20,,St James Dukes Place,0,0
+1666,13,February,20,,St Mary Staining,0,0
+1666,13,February,20,,Alhallows the Great,5,1
+1666,13,February,20,,St James Garlickhithe,1,0
+1666,13,February,20,,St Mary Woolchurch,0,0
+1666,13,February,20,,Alhallows Honylane,0,0
+1666,13,February,20,,St John Baptist,0,0
+1666,13,February,20,,St Mary Woolnoth,0,0
+1666,13,February,20,,Alhallows the Less,4,3
+1666,13,February,20,,St John Evangelist,1,0
+1666,13,February,20,,St Matthew Fridaystreet,0,0
+1666,13,February,20,,Alhallows Lombardstreet,0,0
+1666,13,February,20,,St John Zachary,0,0
+1666,13,February,20,,St Michael Bassishaw,1,0
+1666,13,February,20,,Alhallows Staining,0,0
+1666,13,February,20,,St Katharine Coleman,0,0
+1666,13,February,20,,St Michael Cornhil,0,0
+1666,13,February,20,,Alhallows the Wall,1,0
+1666,13,February,20,,St Katharine Creechurch,1,0
+1666,13,February,20,,St Michael Crookedlane,1,0
+1666,13,February,20,,St Alphage,2,1
+1666,13,February,20,,St Lawrence Jewry,0,0
+1666,13,February,20,,St Michael Queenhithe,2,1
+1666,13,February,20,,St Andrew Hubbard,0,0
+1666,13,February,20,,St Lawrence Pountney,2,0
+1666,13,February,20,,St Michael Quern,0,0
+1666,13,February,20,,St Andrew Undershaft,0,0
+1666,13,February,20,,St Leonard Eastcheap,0,0
+1666,13,February,20,,St Michael Royal,2,0
+1666,13,February,20,,St Andrew Wardrobe,0,0
+1666,13,February,20,,St Leonard Fosterlane,1,0
+1666,13,February,20,,St Michael Woodstreet,0,0
+1666,13,February,20,,St Ann Aldersgate,0,0
+1666,13,February,20,,St Magnus Parish,0,0
+1666,13,February,20,,St Mildred Breadstreet,0,0
+1666,13,February,20,,St Ann Blackfriers,1,0
+1666,13,February,20,,St Margaret Lothbury,1,0
+1666,13,February,20,,St Mildred Poultry,0,0
+1666,13,February,20,,St Anthony alias Antholin,0,0
+1666,13,February,20,,St Margaret Moses,0,0
+1666,13,February,20,,St Nicholas Acons,0,0
+1666,13,February,20,,St Austins Parish,1,1
+1666,13,February,20,,St Margaret Newfishstreet,0,0
+1666,13,February,20,,St Nicholas Coleabby,0,0
+1666,13,February,20,,St Bartholomew Exchange,0,0
+1666,13,February,20,,St Margaret Pattons,0,0
+1666,13,February,20,,St Nicholas Olaves,0,0
+1666,13,February,20,,St Bennet Finck,1,0
+1666,13,February,20,,St Martin Iremongerlane,0,0
+1666,13,February,20,,St Olave Hartstreet,0,0
+1666,13,February,20,,St Bennet Gracechurch,0,0
+1666,13,February,20,,St Martin Ludgate,0,0
+1666,13,February,20,,St Olave Jewry,0,0
+1666,13,February,20,,St Bennet Paulswharf,0,0
+1666,13,February,20,,St Martin Orgars,1,0
+1666,13,February,20,,St Olave Silverstreet,0,0
+1666,13,February,20,,St Bennet Sherehog,1,0
+1666,13,February,20,,St Martin Outwitch,0,0
+1666,13,February,20,,St Pancras Soperlane,0,0
+1666,13,February,20,,St Botolph Billingsgate,0,0
+1666,13,February,20,,St Martin Vintrey,0,0
+1666,13,February,20,,St Peter Cheap,0,0
+1666,13,February,20,,Christ's Church,2,1
+1666,13,February,20,,St Mary Abchurch,0,0
+1666,13,February,20,,St Peter Cornhil,1,0
+1666,13,February,20,,St Christophers,0,0
+1666,13,February,20,,St Mary Aldermanbury,0,0
+1666,13,February,20,,St Peter Paulswharf,1,0
+1666,13,February,20,,St Clement Eastcheap,1,0
+1666,13,February,20,,St Mary Aldermary,0,0
+1666,13,February,20,,St Peter Poor,0,0
+1666,13,February,20,,St Dionis Backchurch,0,0
+1666,13,February,20,,St Mary-le-bow,1,0
+1666,13,February,20,,St Steven Colemanstreet,1,1
+1666,13,February,20,,St Dunstan East,1,0
+1666,13,February,20,,St Mary Bothaw,0,0
+1666,13,February,20,,St Steven Walbrook,0,0
+1666,13,February,20,,St Edmund Lumbardstr.,0,0
+1666,13,February,20,,St Mary Colechurch,0,0
+1666,13,February,20,,St Swithin,0,0
+1666,13,February,20,,St Ethelburga,0,0
+1666,13,February,20,,St Mary Hill,1,1
+1666,13,February,20,,St Thomas Apostle,0,0
+1666,13,February,20,,St Faith,0,0
+1666,13,February,20,,St Mary Milkstreet,0,0
+1666,13,February,20,,Trinity Parish,1,0
+1666,13,February,20,,St Gabriel Fenchurch,0,0
+1666,13,February,20,,St Mary Mag. Oldfishstreet,1,1
+1666,13,February,20,,St Vedast alias Foster,0,0
+1666,13,February,20,,St George Botolphlane,0,0
+1666,13,February,20,,St Andrew Holborn,15,5
+1666,13,February,20,,St Botolph Aldgate,9,4
+1666,13,February,20,,Saviour Southwark,16,8
+1666,13,February,20,,St Bartholomew the Great,1,0
+1666,13,February,20,,St Botolph Bishopsgate,3,1
+1666,13,February,20,,St Sepulchres Parish,9,1
+1666,13,February,20,,St Bartholomew the Lesse,1,0
+1666,13,February,20,,St Dunstan West,2,0
+1666,13,February,20,,St Thomas Southwark,0,0
+1666,13,February,20,,St Bridget,7,0
+1666,13,February,20,,St George Southwark,6,0
+1666,13,February,20,,Trinity Minories,1,0
+1666,13,February,20,,Bridewel Precinct,0,0
+1666,13,February,20,,St Giles Cripplegate,10,2
+1666,13,February,20,,At the Pesthouse,1,1
+1666,13,February,20,,St Botolph Aldersgate,2,1
+1666,13,February,20,,St Olave Southwark,9,2
+1666,13,February,20,,...hritt Church,0,0
+1666,13,February,20,,St Katharine Tower,2,0
+1666,13,February,20,,St Mary Newington,0,0
+1666,13,February,20,,Dunstan Stepney,32,14
+1666,13,February,20,,Lambeth Parish,6,4
+1666,13,February,20,,St Mary Whitechappel,10,2
+1666,13,February,20,,St Giles in the Fields,8,1
+1666,13,February,20,,St Leonard Shoreditch,4,1
+1666,13,February,20,,St. Paul Shadwel,0,0
+1666,13,February,20,,St James Clerkenwel,5,1
+1666,13,February,20,,St Mary Islington,0,0
+1666,13,February,20,,Rotherhith Parish,1,1
+1666,13,February,20,,John at Hackney,3,1
+1666,13,February,20,,St Mary Magd. Bermondsey,6,4
+1666,13,February,20,,St Ann Westminster,0,0
+1666,13,February,20,,St Margaret Westminster,4,1
+1666,13,February,20,,St Mary Savoy,1,0
+1666,13,February,20,,St Clement Danes,10,1
+1666,13,February,20,,St Martin in the Fields,15,0
+1666,13,February,20,,St Paul Covent Garden,1,0
+1666,13,February,20,,St James Westminster,0,0
+1666,20,February,27,,ALban Woodstreet,0,0
+1666,20,February,27,,St Gregory by St Paul,1,0
+1666,20,February,27,,St Mary Mounthaw,0,0
+1666,20,February,27,,Alhallows Barking,1,0
+1666,20,February,27,,St Hellen,2,0
+1666,20,February,27,,St Mary Sommerset,0,0
+1666,20,February,27,,Alhallows Breadstreet,0,0
+1666,20,February,27,,St James Dukes Place,0,0
+1666,20,February,27,,St Mary Staining,1,0
+1666,20,February,27,,Alhallows the Great,1,0
+1666,20,February,27,,St James Garlickhithe,2,1
+1666,20,February,27,,St Mary Woolchurch,0,0
+1666,20,February,27,,Alhallows Honylane,0,0
+1666,20,February,27,,St John Baptist,0,0
+1666,20,February,27,,St Mary Woolnoth,0,0
+1666,20,February,27,,Alhallows the Less,1,0
+1666,20,February,27,,St John Evangelist,0,0
+1666,20,February,27,,St Matthew Fridaystreet,0,0
+1666,20,February,27,,Alhallows Lombardstreet,0,0
+1666,20,February,27,,St John Zachary,0,0
+1666,20,February,27,,St Michael Bassishaw,1,0
+1666,20,February,27,,Alhallows Staining,0,0
+1666,20,February,27,,St Katharine Coleman,0,0
+1666,20,February,27,,St Michael Cornhil,1,0
+1666,20,February,27,,Alhallows the Wall,2,0
+1666,20,February,27,,St Katharine Creechurch,1,0
+1666,20,February,27,,St Michael Crookedlane,0,0
+1666,20,February,27,,St Alphage,1,0
+1666,20,February,27,,St Lawrence Jewry,0,0
+1666,20,February,27,,St Michael Queenhithe,1,0
+1666,20,February,27,,St Andrew Hubbard,0,0
+1666,20,February,27,,St Lawrence Pountney,0,0
+1666,20,February,27,,St Michael Quern,0,0
+1666,20,February,27,,St Andrew Undershaft,1,0
+1666,20,February,27,,St Leonard Eastcheap,0,0
+1666,20,February,27,,St Michael Royal,0,0
+1666,20,February,27,,St Andrew Wardrobe,1,0
+1666,20,February,27,,St Leonard Fosterlane,0,0
+1666,20,February,27,,St Michael Woodstreet,1,0
+1666,20,February,27,,St Ann Aldersgate,0,0
+1666,20,February,27,,St Magnus Parish,0,0
+1666,20,February,27,,St Mildred Breadstreet,0,0
+1666,20,February,27,,St Ann Blackfriers,0,0
+1666,20,February,27,,St Margaret Lothbury,0,0
+1666,20,February,27,,St Mildred Poultry,2,1
+1666,20,February,27,,St Anthony alias Antholin,0,0
+1666,20,February,27,,St Margaret Moses,0,0
+1666,20,February,27,,St Nicholas Acons,0,0
+1666,20,February,27,,St Austins Parish,0,0
+1666,20,February,27,,St Margaret Newfishstreet,0,0
+1666,20,February,27,,St Nicholas Coleabby,0,0
+1666,20,February,27,,St Bartholomew Exchange,0,0
+1666,20,February,27,,St Margaret Pattons,2,0
+1666,20,February,27,,St Nicholas Olaves,1,0
+1666,20,February,27,,St Bennet Finck,2,1
+1666,20,February,27,,St Martin Iremongerlane,0,0
+1666,20,February,27,,St Olave Hartstreet,2,0
+1666,20,February,27,,St Bennet Gracechurch,0,0
+1666,20,February,27,,St Martin Ludgate,0,0
+1666,20,February,27,,St Olave Jewry,0,0
+1666,20,February,27,,St Bennet Paulswharf,1,0
+1666,20,February,27,,St Martin Orgars,2,0
+1666,20,February,27,,St Olave Silverstreet,2,0
+1666,20,February,27,,St Bennet Sherehog,0,0
+1666,20,February,27,,St Martin Outwitch,0,0
+1666,20,February,27,,St Pancras Soperlane,1,0
+1666,20,February,27,,St Botolph Billingsgate,0,0
+1666,20,February,27,,St Martin Vintrey,0,0
+1666,20,February,27,,St Peter Cheap,0,0
+1666,20,February,27,,Christ's Church,2,0
+1666,20,February,27,,St Mary Abchurch,0,0
+1666,20,February,27,,St Peter Cornhil,0,0
+1666,20,February,27,,St Christophers,0,0
+1666,20,February,27,,St Mary Aldermanbury,1,0
+1666,20,February,27,,St Peter Paulswharf,0,0
+1666,20,February,27,,St Clement Eastcheap,1,0
+1666,20,February,27,,St Mary Aldermary,0,0
+1666,20,February,27,,St Peter Poor,0,0
+1666,20,February,27,,St Dionis Backchurch,0,0
+1666,20,February,27,,St Mary-le-bow,0,0
+1666,20,February,27,,St Steven Colemanstreet,2,1
+1666,20,February,27,,St Dunstan East,3,2
+1666,20,February,27,,St Mary Bothaw,0,0
+1666,20,February,27,,St Steven Walbrook,0,0
+1666,20,February,27,,St Edmund Lumbardstr.,0,0
+1666,20,February,27,,St Mary Colechurch,0,0
+1666,20,February,27,,St Swithin,1,0
+1666,20,February,27,,St Ethelburga,0,0
+1666,20,February,27,,St Mary Hill,0,0
+1666,20,February,27,,St Thomas Apostle,0,0
+1666,20,February,27,,St Faith,0,0
+1666,20,February,27,,St Mary Milkstreet,0,0
+1666,20,February,27,,Trinity Parish,1,0
+1666,20,February,27,,St Gabriel Fenchurch,0,0
+1666,20,February,27,,St Mary Mag. Oldfishstreet,1,0
+1666,20,February,27,,St Vedast alias Foster,0,0
+1666,20,February,27,,St George Botolphlane,0,0
+1666,20,February,27,,St Andrew Holborn,13,1
+1666,20,February,27,,St Botolph Aldgate,7,2
+1666,20,February,27,,Saviour Southwark,8,0
+1666,20,February,27,,St Bartholomew the Great,0,0
+1666,20,February,27,,St Botolph Bishopsgate,10,3
+1666,20,February,27,,St Sepulchres Parish,14,0
+1666,20,February,27,,St Bartholomew the Lesse,0,0
+1666,20,February,27,,St Dunstan West,7,2
+1666,20,February,27,,St Thomas Southwark,1,0
+1666,20,February,27,,St Bridget,3,0
+1666,20,February,27,,St George Southwark,3,0
+1666,20,February,27,,Trinity Minories,1,1
+1666,20,February,27,,Bridewel Precinct,1,0
+1666,20,February,27,,St Giles Cripplegate,7,1
+1666,20,February,27,,At the Pesthouse,1,0
+1666,20,February,27,,St Botolph Aldersgate,2,1
+1666,20,February,27,,St Olave Southwark,10,2
+1666,20,February,27,,...hritt Church,0,0
+1666,20,February,27,,St Katharine Tower,4,0
+1666,20,February,27,,St Mary Newington,4,0
+1666,20,February,27,,Dunstan Stepney,29,8
+1666,20,February,27,,Lambeth Parish,13,7
+1666,20,February,27,,St Mary Whitechappel,2,0
+1666,20,February,27,,St Giles in the Fields,9,2
+1666,20,February,27,,St Leonard Shoreditch,2,0
+1666,20,February,27,,St. Paul Shadwel,0,0
+1666,20,February,27,,St James Clerkenwel,2,0
+1666,20,February,27,,St Mary Islington,4,0
+1666,20,February,27,,Rotherhith Parish,3,1
+1666,20,February,27,,John at Hackney,1,0
+1666,20,February,27,,St Mary Magd. Bermondsey,8,4
+1666,20,February,27,,St Ann Westminster,0,0
+1666,20,February,27,,St Margaret Westminster,7,0
+1666,20,February,27,,St Mary Savoy,1,0
+1666,20,February,27,,St Clement Danes,7,1
+1666,20,February,27,,St Martin in the Fields,6,0
+1666,20,February,27,,St Paul Covent Garden,1,0
+1666,20,February,27,,St James Westminster,0,0
+1666,27,February,16,March,ALban Woodstreet,1,0
+1666,27,February,16,March,St Gregory by St Paul,0,0
+1666,27,February,16,March,St Mary Mounthaw,0,0
+1666,27,February,16,March,Alhallows Barking,1,0
+1666,27,February,16,March,St Hellen,1,0
+1666,27,February,16,March,St Mary Sommerset,0,0
+1666,27,February,16,March,Alhallows Breadstreet,0,0
+1666,27,February,16,March,St James Dukes Place,0,0
+1666,27,February,16,March,St Mary Staining,0,0
+1666,27,February,16,March,Alhallows the Great,0,0
+1666,27,February,16,March,St James Garlickhithe,0,0
+1666,27,February,16,March,St Mary Woolchurch,1,0
+1666,27,February,16,March,Alhallows Honylane,0,0
+1666,27,February,16,March,St John Baptist,0,0
+1666,27,February,16,March,St Mary Woolnoth,0,0
+1666,27,February,16,March,Alhallows the Less,0,0
+1666,27,February,16,March,St John Evangelist,0,0
+1666,27,February,16,March,St Matthew Fridaystreet,0,0
+1666,27,February,16,March,Alhallows Lombardstreet,0,0
+1666,27,February,16,March,St John Zachary,0,0
+1666,27,February,16,March,St Michael Bassishaw,1,0
+1666,27,February,16,March,Alhallows Staining,0,0
+1666,27,February,16,March,St Katharine Coleman,2,0
+1666,27,February,16,March,St Michael Cornhil,0,0
+1666,27,February,16,March,Alhallows the Wall,1,1
+1666,27,February,16,March,St Katharine Creechurch,1,0
+1666,27,February,16,March,St Michael Crookedlane,3,1
+1666,27,February,16,March,St Alphage,2,0
+1666,27,February,16,March,St Lawrence Jewry,0,0
+1666,27,February,16,March,St Michael Queenhithe,0,0
+1666,27,February,16,March,St Andrew Hubbard,0,0
+1666,27,February,16,March,St Lawrence Pountney,1,0
+1666,27,February,16,March,St Michael Quern,0,0
+1666,27,February,16,March,St Andrew Undershaft,0,0
+1666,27,February,16,March,St Leonard Eastcheap,1,0
+1666,27,February,16,March,St Michael Royal,0,0
+1666,27,February,16,March,St Andrew Wardrobe,1,0
+1666,27,February,16,March,St Leonard Fosterlane,1,0
+1666,27,February,16,March,St Michael Woodstreet,0,0
+1666,27,February,16,March,St Ann Aldersgate,1,0
+1666,27,February,16,March,St Magnus Parish,0,0
+1666,27,February,16,March,St Mildred Breadstreet,0,0
+1666,27,February,16,March,St Ann Blackfriers,1,0
+1666,27,February,16,March,St Margaret Lothbury,0,0
+1666,27,February,16,March,St Mildred Poultry,0,0
+1666,27,February,16,March,St Anthony alias Antholin,0,0
+1666,27,February,16,March,St Margaret Moses,0,0
+1666,27,February,16,March,St Nicholas Acons,1,1
+1666,27,February,16,March,St Austins Parish,2,0
+1666,27,February,16,March,St Margaret Newfishstreet,1,0
+1666,27,February,16,March,St Nicholas Coleabby,2,0
+1666,27,February,16,March,St Bartholomew Exchange,1,0
+1666,27,February,16,March,St Margaret Pattons,0,0
+1666,27,February,16,March,St Nicholas Olaves,0,0
+1666,27,February,16,March,St Bennet Finck,1,0
+1666,27,February,16,March,St Martin Iremongerlane,0,0
+1666,27,February,16,March,St Olave Hartstreet,1,0
+1666,27,February,16,March,St Bennet Gracechurch,0,0
+1666,27,February,16,March,St Martin Ludgate,0,0
+1666,27,February,16,March,St Olave Jewry,1,0
+1666,27,February,16,March,St Bennet Paulswharf,2,0
+1666,27,February,16,March,St Martin Orgars,2,1
+1666,27,February,16,March,St Olave Silverstreet,0,0
+1666,27,February,16,March,St Bennet Sherehog,0,0
+1666,27,February,16,March,St Martin Outwitch,0,0
+1666,27,February,16,March,St Pancras Soperlane,0,0
+1666,27,February,16,March,St Botolph Billingsgate,0,0
+1666,27,February,16,March,St Martin Vintrey,1,0
+1666,27,February,16,March,St Peter Cheap,0,0
+1666,27,February,16,March,Christ's Church,2,0
+1666,27,February,16,March,St Mary Abchurch,2,1
+1666,27,February,16,March,St Peter Cornhil,0,0
+1666,27,February,16,March,St Christophers,0,0
+1666,27,February,16,March,St Mary Aldermanbury,0,0
+1666,27,February,16,March,St Peter Paulswharf,0,0
+1666,27,February,16,March,St Clement Eastcheap,1,1
+1666,27,February,16,March,St Mary Aldermary,0,0
+1666,27,February,16,March,St Peter Poor,1,0
+1666,27,February,16,March,St Dionis Backchurch,0,0
+1666,27,February,16,March,St Mary-le-bow,1,0
+1666,27,February,16,March,St Steven Colemanstreet,2,0
+1666,27,February,16,March,St Dunstan East,2,0
+1666,27,February,16,March,St Mary Bothaw,1,1
+1666,27,February,16,March,St Steven Walbrook,0,0
+1666,27,February,16,March,St Edmund Lumbardstr.,0,0
+1666,27,February,16,March,St Mary Colechurch,0,0
+1666,27,February,16,March,St Swithin,1,0
+1666,27,February,16,March,St Ethelburga,1,0
+1666,27,February,16,March,St Mary Hill,0,0
+1666,27,February,16,March,St Thomas Apostle,1,0
+1666,27,February,16,March,St Faith,2,0
+1666,27,February,16,March,St Mary Milkstreet,0,0
+1666,27,February,16,March,Trinity Parish,1,0
+1666,27,February,16,March,St Gabriel Fenchurch,0,0
+1666,27,February,16,March,St Mary Mag. Oldfishstreet,1,0
+1666,27,February,16,March,St Vedast alias Foster,0,0
+1666,27,February,16,March,St George Botolphlane,0,0
+1666,27,February,16,March,St Andrew Holborn,7,0
+1666,27,February,16,March,St Botolph Aldgate,12,2
+1666,27,February,16,March,Saviour Southwark,7,0
+1666,27,February,16,March,St Bartholomew the Great,1,0
+1666,27,February,16,March,St Botolph Bishopsgate,1,0
+1666,27,February,16,March,St Sepulchres Parish,10,0
+1666,27,February,16,March,St Bartholomew the Lesse,1,0
+1666,27,February,16,March,St Dunstan West,2,0
+1666,27,February,16,March,St Thomas Southwark,1,0
+1666,27,February,16,March,St Bridget,1,0
+1666,27,February,16,March,St George Southwark,2,0
+1666,27,February,16,March,Trinity Minories,1,0
+1666,27,February,16,March,Bridewel Precinct,1,0
+1666,27,February,16,March,St Giles Cripplegate,13,1
+1666,27,February,16,March,At the Pesthouse,0,0
+1666,27,February,16,March,St Botolph Aldersgate,2,1
+1666,27,February,16,March,St Olave Southwark,14,2
+1666,27,February,16,March,...hritt Church,0,0
+1666,27,February,16,March,St Katharine Tower,0,0
+1666,27,February,16,March,St Mary Newington,7,0
+1666,27,February,16,March,Dunstan Stepney,18,6
+1666,27,February,16,March,Lambeth Parish,3,1
+1666,27,February,16,March,St Mary Whitechappel,10,0
+1666,27,February,16,March,St Giles in the Fields,14,0
+1666,27,February,16,March,St Leonard Shoreditch,5,0
+1666,27,February,16,March,St. Paul Shadwel,1,0
+1666,27,February,16,March,St James Clerkenwel,10,1
+1666,27,February,16,March,St Mary Islington,3,0
+1666,27,February,16,March,Rotherhith Parish,1,0
+1666,27,February,16,March,John at Hackney,2,0
+1666,27,February,16,March,St Mary Magd. Bermondsey,5,1
+1666,27,February,16,March,St Ann Westminster,0,0
+1666,27,February,16,March,St Margaret Westminster,10,0
+1666,27,February,16,March,St Mary Savoy,2,2
+1666,27,February,16,March,St Clement Danes,5,1
+1666,27,February,16,March,St Martin in the Fields,18,1
+1666,27,February,16,March,St Paul Covent Garden,0,0
+1666,27,February,16,March,St James Westminster,0,0
+1666,6,March,13,,ALban Woodstreet,0,0
+1666,6,March,13,,St Gregory by St Paul,1,0
+1666,6,March,13,,St Mary Mounthaw,0,0
+1666,6,March,13,,Alhallows Barking,3,0
+1666,6,March,13,,St Hellen,1,0
+1666,6,March,13,,St Mary Sommerset,0,0
+1666,6,March,13,,Alhallows Breadstreet,0,0
+1666,6,March,13,,St James Dukes Place,1,0
+1666,6,March,13,,St Mary Staining,0,0
+1666,6,March,13,,Alhallows the Great,1,0
+1666,6,March,13,,St James Garlickhithe,0,0
+1666,6,March,13,,St Mary Woolchurch,0,0
+1666,6,March,13,,Alhallows Honylane,0,0
+1666,6,March,13,,St John Baptist,0,0
+1666,6,March,13,,St Mary Woolnoth,3,0
+1666,6,March,13,,Alhallows the Less,1,0
+1666,6,March,13,,St John Evangelist,0,0
+1666,6,March,13,,St Matthew Fridaystreet,0,0
+1666,6,March,13,,Alhallows Lombardstreet,2,1
+1666,6,March,13,,St John Zachary,2,0
+1666,6,March,13,,St Michael Bassishaw,0,0
+1666,6,March,13,,Alhallows Staining,0,0
+1666,6,March,13,,St Katharine Coleman,1,0
+1666,6,March,13,,St Michael Cornhil,1,0
+1666,6,March,13,,Alhallows the Wall,2,0
+1666,6,March,13,,St Katharine Creechurch,0,0
+1666,6,March,13,,St Michael Crookedlane,0,0
+1666,6,March,13,,St Alphage,0,0
+1666,6,March,13,,St Lawrence Jewry,0,0
+1666,6,March,13,,St Michael Queenhithe,1,0
+1666,6,March,13,,St Andrew Hubbard,0,0
+1666,6,March,13,,St Lawrence Pountney,0,0
+1666,6,March,13,,St Michael Quern,0,0
+1666,6,March,13,,St Andrew Undershaft,1,0
+1666,6,March,13,,St Leonard Eastcheap,0,0
+1666,6,March,13,,St Michael Royal,0,0
+1666,6,March,13,,St Andrew Wardrobe,0,0
+1666,6,March,13,,St Leonard Fosterlane,1,0
+1666,6,March,13,,St Michael Woodstreet,0,0
+1666,6,March,13,,St Ann Aldersgate,0,0
+1666,6,March,13,,St Magnus Parish,0,0
+1666,6,March,13,,St Mildred Breadstreet,0,0
+1666,6,March,13,,St Ann Blackfriers,0,0
+1666,6,March,13,,St Margaret Lothbury,2,0
+1666,6,March,13,,St Mildred Poultry,1,0
+1666,6,March,13,,St Anthony alias Antholin,0,0
+1666,6,March,13,,St Margaret Moses,0,0
+1666,6,March,13,,St Nicholas Acons,0,0
+1666,6,March,13,,St Austins Parish,1,0
+1666,6,March,13,,St Margaret Newfishstreet,1,0
+1666,6,March,13,,St Nicholas Coleabby,0,0
+1666,6,March,13,,St Bartholomew Exchange,0,0
+1666,6,March,13,,St Margaret Pattons,0,0
+1666,6,March,13,,St Nicholas Olaves,0,0
+1666,6,March,13,,St Bennet Finck,0,0
+1666,6,March,13,,St Martin Iremongerlane,0,0
+1666,6,March,13,,St Olave Hartstreet,2,0
+1666,6,March,13,,St Bennet Gracechurch,1,0
+1666,6,March,13,,St Martin Ludgate,0,0
+1666,6,March,13,,St Olave Jewry,1,0
+1666,6,March,13,,St Bennet Paulswharf,0,0
+1666,6,March,13,,St Martin Orgars,0,0
+1666,6,March,13,,St Olave Silverstreet,0,0
+1666,6,March,13,,St Bennet Sherehog,0,0
+1666,6,March,13,,St Martin Outwitch,0,0
+1666,6,March,13,,St Pancras Soperlane,0,0
+1666,6,March,13,,St Botolph Billingsgate,0,0
+1666,6,March,13,,St Martin Vintrey,1,0
+1666,6,March,13,,St Peter Cheap,0,0
+1666,6,March,13,,Christ's Church,1,0
+1666,6,March,13,,St Mary Abchurch,0,0
+1666,6,March,13,,St Peter Cornhil,0,0
+1666,6,March,13,,St Christophers,0,0
+1666,6,March,13,,St Mary Aldermanbury,0,0
+1666,6,March,13,,St Peter Paulswharf,1,0
+1666,6,March,13,,St Clement Eastcheap,0,0
+1666,6,March,13,,St Mary Aldermary,0,0
+1666,6,March,13,,St Peter Poor,0,0
+1666,6,March,13,,St Dionis Backchurch,0,0
+1666,6,March,13,,St Mary-le-bow,0,0
+1666,6,March,13,,St Steven Colemanstreet,2,0
+1666,6,March,13,,St Dunstan East,2,0
+1666,6,March,13,,St Mary Bothaw,2,1
+1666,6,March,13,,St Steven Walbrook,2,0
+1666,6,March,13,,St Edmund Lumbardstr.,1,1
+1666,6,March,13,,St Mary Colechurch,0,0
+1666,6,March,13,,St Swithin,1,0
+1666,6,March,13,,St Ethelburga,1,0
+1666,6,March,13,,St Mary Hill,0,0
+1666,6,March,13,,St Thomas Apostle,0,0
+1666,6,March,13,,St Faith,1,0
+1666,6,March,13,,St Mary Milkstreet,0,0
+1666,6,March,13,,Trinity Parish,1,0
+1666,6,March,13,,St Gabriel Fenchurch,0,0
+1666,6,March,13,,St Mary Mag. Oldfishstreet,0,0
+1666,6,March,13,,St Vedast alias Foster,0,0
+1666,6,March,13,,St George Botolphlane,1,0
+1666,6,March,13,,St Andrew Holborn,9,1
+1666,6,March,13,,St Botolph Aldgate,13,4
+1666,6,March,13,,Saviour Southwark,4,2
+1666,6,March,13,,St Bartholomew the Great,0,0
+1666,6,March,13,,St Botolph Bishopsgate,4,0
+1666,6,March,13,,St Sepulchres Parish,4,0
+1666,6,March,13,,St Bartholomew the Lesse,1,0
+1666,6,March,13,,St Dunstan West,4,0
+1666,6,March,13,,St Thomas Southwark,1,0
+1666,6,March,13,,St Bridget,5,0
+1666,6,March,13,,St George Southwark,4,1
+1666,6,March,13,,Trinity Minories,0,0
+1666,6,March,13,,Bridewel Precinct,0,0
+1666,6,March,13,,St Giles Cripplegate,9,1
+1666,6,March,13,,At the Pesthouse,0,0
+1666,6,March,13,,St Botolph Aldersgate,3,0
+1666,6,March,13,,St Olave Southwark,4,0
+1666,6,March,13,,...hritt Church,0,0
+1666,6,March,13,,St Katharine Tower,1,0
+1666,6,March,13,,St Mary Newington,3,1
+1666,6,March,13,,Dunstan Stepney,47,4
+1666,6,March,13,,Lambeth Parish,8,1
+1666,6,March,13,,St Mary Whitechappel,10,5
+1666,6,March,13,,St Giles in the Fields,4,1
+1666,6,March,13,,St Leonard Shoreditch,8,0
+1666,6,March,13,,St. Paul Shadwel,0,0
+1666,6,March,13,,St James Clerkenwel,3,1
+1666,6,March,13,,St Mary Islington,1,0
+1666,6,March,13,,Rotherhith Parish,2,0
+1666,6,March,13,,John at Hackney,0,0
+1666,6,March,13,,St Mary Magd. Bermondsey,8,1
+1666,6,March,13,,St Ann Westminster,0,0
+1666,6,March,13,,St Margaret Westminster,9,1
+1666,6,March,13,,St Mary Savoy,2,0
+1666,6,March,13,,St Clement Danes,2,0
+1666,6,March,13,,St Martin in the Fields,12,2
+1666,6,March,13,,St Paul Covent Garden,4,0
+1666,6,March,13,,St James Westminster,0,0
+1666,13,March,20,,ALban Woodstreet,1,0
+1666,13,March,20,,St Gregory by St Paul,1,0
+1666,13,March,20,,St Mary Mounthaw,1,1
+1666,13,March,20,,Alhallows Barking,2,0
+1666,13,March,20,,St Hellen,0,0
+1666,13,March,20,,St Mary Sommerset,1,0
+1666,13,March,20,,Alhallows Breadstreet,1,0
+1666,13,March,20,,St James Dukes Place,2,0
+1666,13,March,20,,St Mary Staining,0,0
+1666,13,March,20,,Alhallows the Great,1,0
+1666,13,March,20,,St James Garlickhithe,1,0
+1666,13,March,20,,St Mary Woolchurch,0,0
+1666,13,March,20,,Alhallows Honylane,0,0
+1666,13,March,20,,St John Baptist,0,0
+1666,13,March,20,,St Mary Woolnoth,0,0
+1666,13,March,20,,Alhallows the Less,0,0
+1666,13,March,20,,St John Evangelist,0,0
+1666,13,March,20,,St Matthew Fridaystreet,0,0
+1666,13,March,20,,Alhallows Lombardstreet,0,0
+1666,13,March,20,,St John Zachary,0,0
+1666,13,March,20,,St Michael Bassishaw,3,0
+1666,13,March,20,,Alhallows Staining,0,0
+1666,13,March,20,,St Katharine Coleman,1,0
+1666,13,March,20,,St Michael Cornhil,2,0
+1666,13,March,20,,Alhallows the Wall,1,0
+1666,13,March,20,,St Katharine Creechurch,0,0
+1666,13,March,20,,St Michael Crookedlane,0,0
+1666,13,March,20,,St Alphage,3,0
+1666,13,March,20,,St Lawrence Jewry,0,0
+1666,13,March,20,,St Michael Queenhithe,0,0
+1666,13,March,20,,St Andrew Hubbard,0,0
+1666,13,March,20,,St Lawrence Pountney,0,0
+1666,13,March,20,,St Michael Quern,0,0
+1666,13,March,20,,St Andrew Undershaft,0,0
+1666,13,March,20,,St Leonard Eastcheap,0,0
+1666,13,March,20,,St Michael Royal,0,0
+1666,13,March,20,,St Andrew Wardrobe,1,0
+1666,13,March,20,,St Leonard Fosterlane,0,0
+1666,13,March,20,,St Michael Woodstreet,0,0
+1666,13,March,20,,St Ann Aldersgate,1,0
+1666,13,March,20,,St Magnus Parish,0,0
+1666,13,March,20,,St Mildred Breadstreet,1,0
+1666,13,March,20,,St Ann Blackfriers,2,0
+1666,13,March,20,,St Margaret Lothbury,0,0
+1666,13,March,20,,St Mildred Poultry,0,0
+1666,13,March,20,,St Anthony alias Antholin,1,0
+1666,13,March,20,,St Margaret Moses,1,0
+1666,13,March,20,,St Nicholas Acons,0,0
+1666,13,March,20,,St Austins Parish,1,0
+1666,13,March,20,,St Margaret Newfishstreet,0,0
+1666,13,March,20,,St Nicholas Coleabby,0,0
+1666,13,March,20,,St Bartholomew Exchange,0,0
+1666,13,March,20,,St Margaret Pattons,0,0
+1666,13,March,20,,St Nicholas Olaves,0,0
+1666,13,March,20,,St Bennet Finck,0,0
+1666,13,March,20,,St Martin Iremongerlane,0,0
+1666,13,March,20,,St Olave Hartstreet,2,0
+1666,13,March,20,,St Bennet Gracechurch,1,0
+1666,13,March,20,,St Martin Ludgate,1,0
+1666,13,March,20,,St Olave Jewry,0,0
+1666,13,March,20,,St Bennet Paulswharf,0,0
+1666,13,March,20,,St Martin Orgars,1,0
+1666,13,March,20,,St Olave Silverstreet,0,0
+1666,13,March,20,,St Bennet Sherehog,0,0
+1666,13,March,20,,St Martin Outwitch,0,0
+1666,13,March,20,,St Pancras Soperlane,0,0
+1666,13,March,20,,St Botolph Billingsgate,0,0
+1666,13,March,20,,St Martin Vintrey,0,0
+1666,13,March,20,,St Peter Cheap,1,0
+1666,13,March,20,,Christ's Church,1,0
+1666,13,March,20,,St Mary Abchurch,0,0
+1666,13,March,20,,St Peter Cornhil,0,0
+1666,13,March,20,,St Christophers,0,0
+1666,13,March,20,,St Mary Aldermanbury,1,0
+1666,13,March,20,,St Peter Paulswharf,1,0
+1666,13,March,20,,St Clement Eastcheap,0,0
+1666,13,March,20,,St Mary Aldermary,0,0
+1666,13,March,20,,St Peter Poor,0,0
+1666,13,March,20,,St Dionis Backchurch,0,0
+1666,13,March,20,,St Mary-le-bow,0,0
+1666,13,March,20,,St Steven Colemanstreet,2,0
+1666,13,March,20,,St Dunstan East,1,0
+1666,13,March,20,,St Mary Bothaw,0,0
+1666,13,March,20,,St Steven Walbrook,0,0
+1666,13,March,20,,St Edmund Lumbardstr.,0,0
+1666,13,March,20,,St Mary Colechurch,0,0
+1666,13,March,20,,St Swithin,0,0
+1666,13,March,20,,St Ethelburga,1,0
+1666,13,March,20,,St Mary Hill,0,0
+1666,13,March,20,,St Thomas Apostle,0,0
+1666,13,March,20,,St Faith,0,0
+1666,13,March,20,,St Mary Milkstreet,0,0
+1666,13,March,20,,Trinity Parish,0,0
+1666,13,March,20,,St Gabriel Fenchurch,0,0
+1666,13,March,20,,St Mary Mag. Oldfishstreet,0,0
+1666,13,March,20,,St Vedast alias Foster,1,0
+1666,13,March,20,,St George Botolphlane,0,0
+1666,13,March,20,,St Andrew Holborn,9,1
+1666,13,March,20,,St Botolph Aldgate,11,6
+1666,13,March,20,,Saviour Southwark,10,1
+1666,13,March,20,,St Bartholomew the Great,0,0
+1666,13,March,20,,St Botolph Bishopsgate,7,0
+1666,13,March,20,,St Sepulchres Parish,13,1
+1666,13,March,20,,St Bartholomew the Lesse,0,0
+1666,13,March,20,,St Dunstan West,3,0
+1666,13,March,20,,St Thomas Southwark,0,0
+1666,13,March,20,,St Bridget,13,1
+1666,13,March,20,,St George Southwark,2,0
+1666,13,March,20,,Trinity Minories,0,0
+1666,13,March,20,,Bridewel Precinct,1,0
+1666,13,March,20,,St Giles Cripplegate,11,0
+1666,13,March,20,,At the Pesthouse,0,0
+1666,13,March,20,,St Botolph Aldersgate,4,0
+1666,13,March,20,,St Olave Southwark,11,3
+1666,13,March,20,,...hritt Church,0,0
+1666,13,March,20,,St Katharine Tower,3,1
+1666,13,March,20,,St Mary Newington,0,0
+1666,13,March,20,,Dunstan Stepney,29,5
+1666,13,March,20,,Lambeth Parish,4,4
+1666,13,March,20,,St Mary Whitechappel,4,0
+1666,13,March,20,,St Giles in the Fields,6,0
+1666,13,March,20,,St Leonard Shoreditch,9,0
+1666,13,March,20,,St. Paul Shadwel,0,0
+1666,13,March,20,,St James Clerkenwel,1,0
+1666,13,March,20,,St Mary Islington,1,0
+1666,13,March,20,,Rotherhith Parish,2,1
+1666,13,March,20,,John at Hackney,4,2
+1666,13,March,20,,St Mary Magd. Bermondsey,4,1
+1666,13,March,20,,St Ann Westminster,0,0
+1666,13,March,20,,St Margaret Westminster,5,1
+1666,13,March,20,,St Mary Savoy,4,1
+1666,13,March,20,,St Clement Danes,6,1
+1666,13,March,20,,St Martin in the Fields,11,2
+1666,13,March,20,,St Paul Covent Garden,2,0
+1666,13,March,20,,St James Westminster,0,0
+1666,20,March,27,,ALban Woodstreet,0,0
+1666,20,March,27,,St Gregory by St Paul,2,0
+1666,20,March,27,,St Mary Mounthaw,0,0
+1666,20,March,27,,Alhallows Barking,0,0
+1666,20,March,27,,St Hellen,0,0
+1666,20,March,27,,St Mary Sommerset,1,0
+1666,20,March,27,,Alhallows Breadstreet,0,0
+1666,20,March,27,,St James Dukes Place,1,0
+1666,20,March,27,,St Mary Staining,0,0
+1666,20,March,27,,Alhallows the Great,1,0
+1666,20,March,27,,St James Garlickhithe,0,0
+1666,20,March,27,,St Mary Woolchurch,0,0
+1666,20,March,27,,Alhallows Honylane,0,0
+1666,20,March,27,,St John Baptist,0,0
+1666,20,March,27,,St Mary Woolnoth,1,0
+1666,20,March,27,,Alhallows the Less,2,0
+1666,20,March,27,,St John Evangelist,0,0
+1666,20,March,27,,St Matthew Fridaystreet,0,0
+1666,20,March,27,,Alhallows Lombardstreet,0,0
+1666,20,March,27,,St John Zachary,0,0
+1666,20,March,27,,St Michael Bassishaw,0,0
+1666,20,March,27,,Alhallows Staining,0,0
+1666,20,March,27,,St Katharine Coleman,0,0
+1666,20,March,27,,St Michael Cornhil,0,0
+1666,20,March,27,,Alhallows the Wall,1,0
+1666,20,March,27,,St Katharine Creechurch,1,0
+1666,20,March,27,,St Michael Crookedlane,0,0
+1666,20,March,27,,St Alphage,1,0
+1666,20,March,27,,St Lawrence Jewry,1,0
+1666,20,March,27,,St Michael Queenhithe,0,0
+1666,20,March,27,,St Andrew Hubbard,0,0
+1666,20,March,27,,St Lawrence Pountney,1,0
+1666,20,March,27,,St Michael Quern,0,0
+1666,20,March,27,,St Andrew Undershaft,0,0
+1666,20,March,27,,St Leonard Eastcheap,0,0
+1666,20,March,27,,St Michael Royal,0,0
+1666,20,March,27,,St Andrew Wardrobe,0,0
+1666,20,March,27,,St Leonard Fosterlane,1,0
+1666,20,March,27,,St Michael Woodstreet,0,0
+1666,20,March,27,,St Ann Aldersgate,0,0
+1666,20,March,27,,St Magnus Parish,1,0
+1666,20,March,27,,St Mildred Breadstreet,0,0
+1666,20,March,27,,St Ann Blackfriers,1,0
+1666,20,March,27,,St Margaret Lothbury,1,0
+1666,20,March,27,,St Mildred Poultry,0,0
+1666,20,March,27,,St Anthony alias Antholin,0,0
+1666,20,March,27,,St Margaret Moses,0,0
+1666,20,March,27,,St Nicholas Acons,0,0
+1666,20,March,27,,St Austins Parish,0,0
+1666,20,March,27,,St Margaret Newfishstreet,1,0
+1666,20,March,27,,St Nicholas Coleabby,0,0
+1666,20,March,27,,St Bartholomew Exchange,1,0
+1666,20,March,27,,St Margaret Pattons,0,0
+1666,20,March,27,,St Nicholas Olaves,1,0
+1666,20,March,27,,St Bennet Finck,0,0
+1666,20,March,27,,St Martin Iremongerlane,0,0
+1666,20,March,27,,St Olave Hartstreet,0,0
+1666,20,March,27,,St Bennet Gracechurch,0,0
+1666,20,March,27,,St Martin Ludgate,1,0
+1666,20,March,27,,St Olave Jewry,0,0
+1666,20,March,27,,St Bennet Paulswharf,1,0
+1666,20,March,27,,St Martin Orgars,1,0
+1666,20,March,27,,St Olave Silverstreet,2,0
+1666,20,March,27,,St Bennet Sherehog,0,0
+1666,20,March,27,,St Martin Outwitch,0,0
+1666,20,March,27,,St Pancras Soperlane,0,0
+1666,20,March,27,,St Botolph Billingsgate,0,0
+1666,20,March,27,,St Martin Vintrey,2,0
+1666,20,March,27,,St Peter Cheap,0,0
+1666,20,March,27,,Christ's Church,2,0
+1666,20,March,27,,St Mary Abchurch,0,0
+1666,20,March,27,,St Peter Cornhil,0,0
+1666,20,March,27,,St Christophers,0,0
+1666,20,March,27,,St Mary Aldermanbury,0,0
+1666,20,March,27,,St Peter Paulswharf,0,0
+1666,20,March,27,,St Clement Eastcheap,0,0
+1666,20,March,27,,St Mary Aldermary,0,0
+1666,20,March,27,,St Peter Poor,2,0
+1666,20,March,27,,St Dionis Backchurch,1,0
+1666,20,March,27,,St Mary-le-bow,1,0
+1666,20,March,27,,St Steven Colemanstreet,0,0
+1666,20,March,27,,St Dunstan East,3,1
+1666,20,March,27,,St Mary Bothaw,0,0
+1666,20,March,27,,St Steven Walbrook,0,0
+1666,20,March,27,,St Edmund Lumbardstr.,0,0
+1666,20,March,27,,St Mary Colechurch,0,0
+1666,20,March,27,,St Swithin,0,0
+1666,20,March,27,,St Ethelburga,0,0
+1666,20,March,27,,St Mary Hill,1,0
+1666,20,March,27,,St Thomas Apostle,0,0
+1666,20,March,27,,St Faith,1,0
+1666,20,March,27,,St Mary Milkstreet,0,0
+1666,20,March,27,,Trinity Parish,0,0
+1666,20,March,27,,St Gabriel Fenchurch,0,0
+1666,20,March,27,,St Mary Mag. Oldfishstreet,1,0
+1666,20,March,27,,St Vedast alias Foster,0,0
+1666,20,March,27,,St George Botolphlane,0,0
+1666,20,March,27,,St Andrew Holborn,6,3
+1666,20,March,27,,St Botolph Aldgate,12,0
+1666,20,March,27,,Saviour Southwark,12,3
+1666,20,March,27,,St Bartholomew the Great,1,0
+1666,20,March,27,,St Botolph Bishopsgate,3,0
+1666,20,March,27,,St Sepulchres Parish,9,0
+1666,20,March,27,,St Bartholomew the Lesse,0,0
+1666,20,March,27,,St Dunstan West,2,0
+1666,20,March,27,,St Thomas Southwark,0,0
+1666,20,March,27,,St Bridget,4,0
+1666,20,March,27,,St George Southwark,4,0
+1666,20,March,27,,Trinity Minories,0,0
+1666,20,March,27,,Bridewel Precinct,1,0
+1666,20,March,27,,St Giles Cripplegate,16,0
+1666,20,March,27,,At the Pesthouse,4,2
+1666,20,March,27,,St Botolph Aldersgate,3,0
+1666,20,March,27,,St Olave Southwark,10,2
+1666,20,March,27,,...hritt Church,0,0
+1666,20,March,27,,St Katharine Tower,2,0
+1666,20,March,27,,St Mary Newington,1,0
+1666,20,March,27,,Dunstan Stepney,16,0
+1666,20,March,27,,Lambeth Parish,3,2
+1666,20,March,27,,St Mary Whitechappel,10,1
+1666,20,March,27,,St Giles in the Fields,13,0
+1666,20,March,27,,St Leonard Shoreditch,7,0
+1666,20,March,27,,St. Paul Shadwel,0,0
+1666,20,March,27,,St James Clerkenwel,2,0
+1666,20,March,27,,St Mary Islington,0,0
+1666,20,March,27,,Rotherhith Parish,0,0
+1666,20,March,27,,John at Hackney,2,0
+1666,20,March,27,,St Mary Magd. Bermondsey,7,0
+1666,20,March,27,,St Ann Westminster,0,0
+1666,20,March,27,,St Margaret Westminster,14,0
+1666,20,March,27,,St Mary Savoy,1,0
+1666,20,March,27,,St Clement Danes,9,2
+1666,20,March,27,,St Martin in the Fields,10,0
+1666,20,March,27,,St Paul Covent Garden,1,0
+1666,20,March,27,,St James Westminster,0,0
+1666,27,March,3,April,ALban Woodstreet,0,0
+1666,27,March,3,April,St Gregory by St Paul,1,0
+1666,27,March,3,April,St Mary Mounthaw,0,0
+1666,27,March,3,April,Alhallows Barking,1,0
+1666,27,March,3,April,St Hellen,1,0
+1666,27,March,3,April,St Mary Sommerset,2,0
+1666,27,March,3,April,Alhallows Breadstreet,0,0
+1666,27,March,3,April,St James Dukes Place,1,0
+1666,27,March,3,April,St Mary Staining,0,0
+1666,27,March,3,April,Alhallows the Great,0,0
+1666,27,March,3,April,St James Garlickhithe,0,0
+1666,27,March,3,April,St Mary Woolchurch,0,0
+1666,27,March,3,April,Alhallows Honylane,0,0
+1666,27,March,3,April,St John Baptist,0,0
+1666,27,March,3,April,St Mary Woolnoth,0,0
+1666,27,March,3,April,Alhallows the Less,0,0
+1666,27,March,3,April,St John Evangelist,0,0
+1666,27,March,3,April,St Matthew Fridaystreet,1,0
+1666,27,March,3,April,Alhallows Lombardstreet,1,0
+1666,27,March,3,April,St John Zachary,0,0
+1666,27,March,3,April,St Michael Bassishaw,2,0
+1666,27,March,3,April,Alhallows Staining,0,0
+1666,27,March,3,April,St Katharine Coleman,2,0
+1666,27,March,3,April,St Michael Cornhil,0,0
+1666,27,March,3,April,Alhallows the Wall,1,0
+1666,27,March,3,April,St Katharine Creechurch,3,0
+1666,27,March,3,April,St Michael Crookedlane,0,0
+1666,27,March,3,April,St Alphage,2,0
+1666,27,March,3,April,St Lawrence Jewry,0,0
+1666,27,March,3,April,St Michael Queenhithe,2,0
+1666,27,March,3,April,St Andrew Hubbard,2,0
+1666,27,March,3,April,St Lawrence Pountney,0,0
+1666,27,March,3,April,St Michael Quern,2,0
+1666,27,March,3,April,St Andrew Undershaft,0,0
+1666,27,March,3,April,St Leonard Eastcheap,0,0
+1666,27,March,3,April,St Michael Royal,0,0
+1666,27,March,3,April,St Andrew Wardrobe,1,0
+1666,27,March,3,April,St Leonard Fosterlane,2,0
+1666,27,March,3,April,St Michael Woodstreet,3,0
+1666,27,March,3,April,St Ann Aldersgate,1,0
+1666,27,March,3,April,St Magnus Parish,0,0
+1666,27,March,3,April,St Mildred Breadstreet,0,0
+1666,27,March,3,April,St Ann Blackfriers,0,0
+1666,27,March,3,April,St Margaret Lothbury,2,0
+1666,27,March,3,April,St Mildred Poultry,1,0
+1666,27,March,3,April,St Anthony alias Antholin,0,0
+1666,27,March,3,April,St Margaret Moses,0,0
+1666,27,March,3,April,St Nicholas Acons,0,0
+1666,27,March,3,April,St Austins Parish,0,0
+1666,27,March,3,April,St Margaret Newfishstreet,1,0
+1666,27,March,3,April,St Nicholas Coleabby,1,0
+1666,27,March,3,April,St Bartholomew Exchange,0,0
+1666,27,March,3,April,St Margaret Pattons,0,0
+1666,27,March,3,April,St Nicholas Olaves,1,0
+1666,27,March,3,April,St Bennet Finck,2,1
+1666,27,March,3,April,St Martin Iremongerlane,1,1
+1666,27,March,3,April,St Olave Hartstreet,0,0
+1666,27,March,3,April,St Bennet Gracechurch,0,0
+1666,27,March,3,April,St Martin Ludgate,0,0
+1666,27,March,3,April,St Olave Jewry,0,0
+1666,27,March,3,April,St Bennet Paulswharf,1,0
+1666,27,March,3,April,St Martin Orgars,1,0
+1666,27,March,3,April,St Olave Silverstreet,4,0
+1666,27,March,3,April,St Bennet Sherehog,0,0
+1666,27,March,3,April,St Martin Outwitch,0,0
+1666,27,March,3,April,St Pancras Soperlane,0,0
+1666,27,March,3,April,St Botolph Billingsgate,1,0
+1666,27,March,3,April,St Martin Vintrey,0,0
+1666,27,March,3,April,St Peter Cheap,0,0
+1666,27,March,3,April,Christ's Church,4,2
+1666,27,March,3,April,St Mary Abchurch,1,0
+1666,27,March,3,April,St Peter Cornhil,0,0
+1666,27,March,3,April,St Christophers,1,0
+1666,27,March,3,April,St Mary Aldermanbury,2,0
+1666,27,March,3,April,St Peter Paulswharf,1,0
+1666,27,March,3,April,St Clement Eastcheap,0,0
+1666,27,March,3,April,St Mary Aldermary,0,0
+1666,27,March,3,April,St Peter Poor,0,0
+1666,27,March,3,April,St Dionis Backchurch,0,0
+1666,27,March,3,April,St Mary-le-bow,1,0
+1666,27,March,3,April,St Steven Colemanstreet,0,0
+1666,27,March,3,April,St Dunstan East,3,1
+1666,27,March,3,April,St Mary Bothaw,1,0
+1666,27,March,3,April,St Steven Walbrook,0,0
+1666,27,March,3,April,St Edmund Lumbardstr.,0,0
+1666,27,March,3,April,St Mary Colechurch,0,0
+1666,27,March,3,April,St Swithin,0,0
+1666,27,March,3,April,St Ethelburga,0,0
+1666,27,March,3,April,St Mary Hill,0,0
+1666,27,March,3,April,St Thomas Apostle,0,0
+1666,27,March,3,April,St Faith,0,0
+1666,27,March,3,April,St Mary Milkstreet,0,0
+1666,27,March,3,April,Trinity Parish,0,0
+1666,27,March,3,April,St Gabriel Fenchurch,0,0
+1666,27,March,3,April,St Mary Mag. Oldfishstreet,1,0
+1666,27,March,3,April,St Vedast alias Foster,1,0
+1666,27,March,3,April,St George Botolphlane,0,0
+1666,27,March,3,April,St Andrew Holborn,5,0
+1666,27,March,3,April,St Botolph Aldgate,10,2
+1666,27,March,3,April,Saviour Southwark,4,1
+1666,27,March,3,April,St Bartholomew the Great,2,0
+1666,27,March,3,April,St Botolph Bishopsgate,5,0
+1666,27,March,3,April,St Sepulchres Parish,9,2
+1666,27,March,3,April,St Bartholomew the Lesse,0,0
+1666,27,March,3,April,St Dunstan West,4,0
+1666,27,March,3,April,St Thomas Southwark,0,0
+1666,27,March,3,April,St Bridget,5,0
+1666,27,March,3,April,St George Southwark,4,0
+1666,27,March,3,April,Trinity Minories,1,0
+1666,27,March,3,April,Bridewel Precinct,0,0
+1666,27,March,3,April,St Giles Cripplegate,5,0
+1666,27,March,3,April,At the Pesthouse,1,1
+1666,27,March,3,April,St Botolph Aldersgate,0,0
+1666,27,March,3,April,St Olave Southwark,9,2
+1666,27,March,3,April,...hritt Church,0,0
+1666,27,March,3,April,St Katharine Tower,4,0
+1666,27,March,3,April,St Mary Newington,2,0
+1666,27,March,3,April,Dunstan Stepney,19,9
+1666,27,March,3,April,Lambeth Parish,0,0
+1666,27,March,3,April,St Mary Whitechappel,9,1
+1666,27,March,3,April,St Giles in the Fields,7,0
+1666,27,March,3,April,St Leonard Shoreditch,3,0
+1666,27,March,3,April,St. Paul Shadwel,0,0
+1666,27,March,3,April,St James Clerkenwel,1,0
+1666,27,March,3,April,St Mary Islington,0,0
+1666,27,March,3,April,Rotherhith Parish,3,1
+1666,27,March,3,April,John at Hackney,4,1
+1666,27,March,3,April,St Mary Magd. Bermondsey,4,0
+1666,27,March,3,April,St Ann Westminster,0,0
+1666,27,March,3,April,St Margaret Westminster,6,0
+1666,27,March,3,April,St Mary Savoy,1,0
+1666,27,March,3,April,St Clement Danes,7,1
+1666,27,March,3,April,St Martin in the Fields,11,0
+1666,27,March,3,April,St Paul Covent Garden,1,0
+1666,27,March,3,April,St James Westminster,0,0
+1666,3,April,10,,ALban Woodstreet,1,0
+1666,3,April,10,,St Gregory by St Paul,2,1
+1666,3,April,10,,St Mary Mounthaw,0,0
+1666,3,April,10,,Alhallows Barking,4,2
+1666,3,April,10,,St Hellen,0,0
+1666,3,April,10,,St Mary Sommerset,0,0
+1666,3,April,10,,Alhallows Breadstreet,1,0
+1666,3,April,10,,St James Dukes Place,0,0
+1666,3,April,10,,St Mary Staining,0,0
+1666,3,April,10,,Alhallows the Great,0,0
+1666,3,April,10,,St James Garlickhithe,3,0
+1666,3,April,10,,St Mary Woolchurch,1,0
+1666,3,April,10,,Alhallows Honylane,0,0
+1666,3,April,10,,St John Baptist,0,0
+1666,3,April,10,,St Mary Woolnoth,0,0
+1666,3,April,10,,Alhallows the Less,0,0
+1666,3,April,10,,St John Evangelist,0,0
+1666,3,April,10,,St Matthew Fridaystreet,0,0
+1666,3,April,10,,Alhallows Lombardstreet,0,0
+1666,3,April,10,,St John Zachary,0,0
+1666,3,April,10,,St Michael Bassishaw,2,0
+1666,3,April,10,,Alhallows Staining,0,0
+1666,3,April,10,,St Katharine Coleman,1,0
+1666,3,April,10,,St Michael Cornhil,0,0
+1666,3,April,10,,Alhallows the Wall,0,0
+1666,3,April,10,,St Katharine Creechurch,4,0
+1666,3,April,10,,St Michael Crookedlane,0,0
+1666,3,April,10,,St Alphage,0,0
+1666,3,April,10,,St Lawrence Jewry,0,0
+1666,3,April,10,,St Michael Queenhithe,1,0
+1666,3,April,10,,St Andrew Hubbard,0,0
+1666,3,April,10,,St Lawrence Pountney,1,0
+1666,3,April,10,,St Michael Quern,0,0
+1666,3,April,10,,St Andrew Undershaft,0,0
+1666,3,April,10,,St Leonard Eastcheap,0,0
+1666,3,April,10,,St Michael Royal,0,0
+1666,3,April,10,,St Andrew Wardrobe,0,0
+1666,3,April,10,,St Leonard Fosterlane,1,0
+1666,3,April,10,,St Michael Woodstreet,0,0
+1666,3,April,10,,St Ann Aldersgate,1,0
+1666,3,April,10,,St Magnus Parish,0,0
+1666,3,April,10,,St Mildred Breadstreet,0,0
+1666,3,April,10,,St Ann Blackfriers,1,0
+1666,3,April,10,,St Margaret Lothbury,0,0
+1666,3,April,10,,St Mildred Poultry,0,0
+1666,3,April,10,,St Anthony alias Antholin,0,0
+1666,3,April,10,,St Margaret Moses,0,0
+1666,3,April,10,,St Nicholas Acons,0,0
+1666,3,April,10,,St Austins Parish,0,0
+1666,3,April,10,,St Margaret Newfishstreet,0,0
+1666,3,April,10,,St Nicholas Coleabby,0,0
+1666,3,April,10,,St Bartholomew Exchange,0,0
+1666,3,April,10,,St Margaret Pattons,0,0
+1666,3,April,10,,St Nicholas Olaves,0,0
+1666,3,April,10,,St Bennet Finck,0,0
+1666,3,April,10,,St Martin Iremongerlane,0,0
+1666,3,April,10,,St Olave Hartstreet,0,0
+1666,3,April,10,,St Bennet Gracechurch,0,0
+1666,3,April,10,,St Martin Ludgate,1,0
+1666,3,April,10,,St Olave Jewry,1,0
+1666,3,April,10,,St Bennet Paulswharf,1,1
+1666,3,April,10,,St Martin Orgars,1,0
+1666,3,April,10,,St Olave Silverstreet,0,0
+1666,3,April,10,,St Bennet Sherehog,1,0
+1666,3,April,10,,St Martin Outwitch,0,0
+1666,3,April,10,,St Pancras Soperlane,0,0
+1666,3,April,10,,St Botolph Billingsgate,0,0
+1666,3,April,10,,St Martin Vintrey,0,0
+1666,3,April,10,,St Peter Cheap,0,0
+1666,3,April,10,,Christ's Church,3,0
+1666,3,April,10,,St Mary Abchurch,0,0
+1666,3,April,10,,St Peter Cornhil,1,0
+1666,3,April,10,,St Christophers,0,0
+1666,3,April,10,,St Mary Aldermanbury,1,0
+1666,3,April,10,,St Peter Paulswharf,0,0
+1666,3,April,10,,St Clement Eastcheap,0,0
+1666,3,April,10,,St Mary Aldermary,0,0
+1666,3,April,10,,St Peter Poor,0,0
+1666,3,April,10,,St Dionis Backchurch,0,0
+1666,3,April,10,,St Mary-le-bow,0,0
+1666,3,April,10,,St Steven Colemanstreet,1,0
+1666,3,April,10,,St Dunstan East,1,1
+1666,3,April,10,,St Mary Bothaw,1,0
+1666,3,April,10,,St Steven Walbrook,0,0
+1666,3,April,10,,St Edmund Lumbardstr.,0,0
+1666,3,April,10,,St Mary Colechurch,0,0
+1666,3,April,10,,St Swithin,1,0
+1666,3,April,10,,St Ethelburga,0,0
+1666,3,April,10,,St Mary Hill,1,0
+1666,3,April,10,,St Thomas Apostle,0,0
+1666,3,April,10,,St Faith,1,0
+1666,3,April,10,,St Mary Milkstreet,1,0
+1666,3,April,10,,Trinity Parish,0,0
+1666,3,April,10,,St Gabriel Fenchurch,0,0
+1666,3,April,10,,St Mary Mag. Oldfishstreet,0,0
+1666,3,April,10,,St Vedast alias Foster,0,0
+1666,3,April,10,,St George Botolphlane,0,0
+1666,3,April,10,,St Andrew Holborn,6,0
+1666,3,April,10,,St Botolph Aldgate,10,1
+1666,3,April,10,,Saviour Southwark,6,1
+1666,3,April,10,,St Bartholomew the Great,2,1
+1666,3,April,10,,St Botolph Bishopsgate,2,0
+1666,3,April,10,,St Sepulchres Parish,7,0
+1666,3,April,10,,St Bartholomew the Lesse,0,0
+1666,3,April,10,,St Dunstan West,2,0
+1666,3,April,10,,St Thomas Southwark,0,0
+1666,3,April,10,,St Bridget,6,0
+1666,3,April,10,,St George Southwark,3,0
+1666,3,April,10,,Trinity Minories,0,0
+1666,3,April,10,,Bridewel Precinct,1,0
+1666,3,April,10,,St Giles Cripplegate,13,1
+1666,3,April,10,,At the Pesthouse,1,1
+1666,3,April,10,,St Botolph Aldersgate,2,0
+1666,3,April,10,,St Olave Southwark,8,1
+1666,3,April,10,,...hritt Church,0,0
+1666,3,April,10,,St Katharine Tower,4,0
+1666,3,April,10,,St Mary Newington,1,0
+1666,3,April,10,,Dunstan Stepney,21,9
+1666,3,April,10,,Lambeth Parish,6,3
+1666,3,April,10,,St Mary Whitechappel,7,2
+1666,3,April,10,,St Giles in the Fields,3,0
+1666,3,April,10,,St Leonard Shoreditch,1,0
+1666,3,April,10,,St. Paul Shadwel,0,0
+1666,3,April,10,,St James Clerkenwel,3,0
+1666,3,April,10,,St Mary Islington,1,0
+1666,3,April,10,,Rotherhith Parish,1,0
+1666,3,April,10,,John at Hackney,2,1
+1666,3,April,10,,St Mary Magd. Bermondsey,5,0
+1666,3,April,10,,St Ann Westminster,0,0
+1666,3,April,10,,St Margaret Westminster,5,0
+1666,3,April,10,,St Mary Savoy,2,0
+1666,3,April,10,,St Clement Danes,2,0
+1666,3,April,10,,St Martin in the Fields,20,2
+1666,3,April,10,,St Paul Covent Garden,1,0
+1666,3,April,10,,St James Westminster,0,0
+1666,10,April,17,,ALban Woodstreet,0,0
+1666,10,April,17,,St Gregory by St Paul,0,0
+1666,10,April,17,,St Mary Mounthaw,0,0
+1666,10,April,17,,Alhallows Barking,0,0
+1666,10,April,17,,St Hellen,2,0
+1666,10,April,17,,St Mary Sommerset,0,0
+1666,10,April,17,,Alhallows Breadstreet,0,0
+1666,10,April,17,,St James Dukes Place,1,0
+1666,10,April,17,,St Mary Staining,0,0
+1666,10,April,17,,Alhallows the Great,0,0
+1666,10,April,17,,St James Garlickhithe,1,0
+1666,10,April,17,,St Mary Woolchurch,0,0
+1666,10,April,17,,Alhallows Honylane,0,0
+1666,10,April,17,,St John Baptist,0,0
+1666,10,April,17,,St Mary Woolnoth,1,0
+1666,10,April,17,,Alhallows the Less,3,0
+1666,10,April,17,,St John Evangelist,0,0
+1666,10,April,17,,St Matthew Fridaystreet,1,0
+1666,10,April,17,,Alhallows Lombardstreet,0,0
+1666,10,April,17,,St John Zachary,0,0
+1666,10,April,17,,St Michael Bassishaw,1,0
+1666,10,April,17,,Alhallows Staining,0,0
+1666,10,April,17,,St Katharine Coleman,2,1
+1666,10,April,17,,St Michael Cornhil,2,2
+1666,10,April,17,,Alhallows the Wall,3,0
+1666,10,April,17,,St Katharine Creechurch,1,0
+1666,10,April,17,,St Michael Crookedlane,1,0
+1666,10,April,17,,St Alphage,0,0
+1666,10,April,17,,St Lawrence Jewry,1,0
+1666,10,April,17,,St Michael Queenhithe,0,0
+1666,10,April,17,,St Andrew Hubbard,1,0
+1666,10,April,17,,St Lawrence Pountney,2,0
+1666,10,April,17,,St Michael Quern,0,0
+1666,10,April,17,,St Andrew Undershaft,1,0
+1666,10,April,17,,St Leonard Eastcheap,0,0
+1666,10,April,17,,St Michael Royal,0,0
+1666,10,April,17,,St Andrew Wardrobe,1,0
+1666,10,April,17,,St Leonard Fosterlane,0,0
+1666,10,April,17,,St Michael Woodstreet,0,0
+1666,10,April,17,,St Ann Aldersgate,1,0
+1666,10,April,17,,St Magnus Parish,0,0
+1666,10,April,17,,St Mildred Breadstreet,0,0
+1666,10,April,17,,St Ann Blackfriers,1,0
+1666,10,April,17,,St Margaret Lothbury,0,0
+1666,10,April,17,,St Mildred Poultry,0,0
+1666,10,April,17,,St Anthony alias Antholin,0,0
+1666,10,April,17,,St Margaret Moses,1,0
+1666,10,April,17,,St Nicholas Acons,0,0
+1666,10,April,17,,St Austins Parish,0,0
+1666,10,April,17,,St Margaret Newfishstreet,1,0
+1666,10,April,17,,St Nicholas Coleabby,0,0
+1666,10,April,17,,St Bartholomew Exchange,0,0
+1666,10,April,17,,St Margaret Pattons,0,0
+1666,10,April,17,,St Nicholas Olaves,0,0
+1666,10,April,17,,St Bennet Finck,0,0
+1666,10,April,17,,St Martin Iremongerlane,0,0
+1666,10,April,17,,St Olave Hartstreet,2,0
+1666,10,April,17,,St Bennet Gracechurch,0,0
+1666,10,April,17,,St Martin Ludgate,0,0
+1666,10,April,17,,St Olave Jewry,0,0
+1666,10,April,17,,St Bennet Paulswharf,1,0
+1666,10,April,17,,St Martin Orgars,0,0
+1666,10,April,17,,St Olave Silverstreet,0,0
+1666,10,April,17,,St Bennet Sherehog,0,0
+1666,10,April,17,,St Martin Outwitch,1,0
+1666,10,April,17,,St Pancras Soperlane,0,0
+1666,10,April,17,,St Botolph Billingsgate,1,0
+1666,10,April,17,,St Martin Vintrey,2,1
+1666,10,April,17,,St Peter Cheap,0,0
+1666,10,April,17,,Christ's Church,2,0
+1666,10,April,17,,St Mary Abchurch,1,0
+1666,10,April,17,,St Peter Cornhil,0,0
+1666,10,April,17,,St Christophers,0,0
+1666,10,April,17,,St Mary Aldermanbury,0,0
+1666,10,April,17,,St Peter Paulswharf,0,0
+1666,10,April,17,,St Clement Eastcheap,0,0
+1666,10,April,17,,St Mary Aldermary,1,0
+1666,10,April,17,,St Peter Poor,0,0
+1666,10,April,17,,St Dionis Backchurch,0,0
+1666,10,April,17,,St Mary-le-bow,0,0
+1666,10,April,17,,St Steven Colemanstreet,2,0
+1666,10,April,17,,St Dunstan East,2,1
+1666,10,April,17,,St Mary Bothaw,0,0
+1666,10,April,17,,St Steven Walbrook,0,0
+1666,10,April,17,,St Edmund Lumbardstr.,0,0
+1666,10,April,17,,St Mary Colechurch,0,0
+1666,10,April,17,,St Swithin,0,0
+1666,10,April,17,,St Ethelburga,0,0
+1666,10,April,17,,St Mary Hill,0,0
+1666,10,April,17,,St Thomas Apostle,0,0
+1666,10,April,17,,St Faith,0,0
+1666,10,April,17,,St Mary Milkstreet,0,0
+1666,10,April,17,,Trinity Parish,0,0
+1666,10,April,17,,St Gabriel Fenchurch,0,0
+1666,10,April,17,,St Mary Mag. Oldfishstreet,0,0
+1666,10,April,17,,St Vedast alias Foster,0,0
+1666,10,April,17,,St George Botolphlane,0,0
+1666,10,April,17,,St Andrew Holborn,11,3
+1666,10,April,17,,St Botolph Aldgate,11,5
+1666,10,April,17,,Saviour Southwark,11,0
+1666,10,April,17,,St Bartholomew the Great,0,0
+1666,10,April,17,,St Botolph Bishopsgate,5,0
+1666,10,April,17,,St Sepulchres Parish,10,4
+1666,10,April,17,,St Bartholomew the Lesse,0,0
+1666,10,April,17,,St Dunstan West,5,1
+1666,10,April,17,,St Thomas Southwark,1,0
+1666,10,April,17,,St Bridget,7,1
+1666,10,April,17,,St George Southwark,6,1
+1666,10,April,17,,Trinity Minories,0,0
+1666,10,April,17,,Bridewel Precinct,0,0
+1666,10,April,17,,St Giles Cripplegate,7,0
+1666,10,April,17,,At the Pesthouse,2,2
+1666,10,April,17,,St Botolph Aldersgate,1,0
+1666,10,April,17,,St Olave Southwark,8,3
+1666,10,April,17,,...hritt Church,0,0
+1666,10,April,17,,St Katharine Tower,2,1
+1666,10,April,17,,St Mary Newington,2,0
+1666,10,April,17,,Dunstan Stepney,20,6
+1666,10,April,17,,Lambeth Parish,5,2
+1666,10,April,17,,St Mary Whitechappel,3,0
+1666,10,April,17,,St Giles in the Fields,6,1
+1666,10,April,17,,St Leonard Shoreditch,5,0
+1666,10,April,17,,St. Paul Shadwel,0,0
+1666,10,April,17,,St James Clerkenwel,6,0
+1666,10,April,17,,St Mary Islington,0,0
+1666,10,April,17,,Rotherhith Parish,4,3
+1666,10,April,17,,John at Hackney,1,0
+1666,10,April,17,,St Mary Magd. Bermondsey,2,0
+1666,10,April,17,,St Ann Westminster,0,0
+1666,10,April,17,,St Margaret Westminster,10,2
+1666,10,April,17,,St Mary Savoy,1,0
+1666,10,April,17,,St Clement Danes,4,0
+1666,10,April,17,,St Martin in the Fields,14,0
+1666,10,April,17,,St Paul Covent Garden,1,0
+1666,10,April,17,,St James Westminster,0,0
+1666,17,April,24,,ALban Woodstreet,2,1
+1666,17,April,24,,St Gregory by St Paul,3,0
+1666,17,April,24,,St Mary Mounthaw,0,0
+1666,17,April,24,,Alhallows Barking,0,0
+1666,17,April,24,,St Hellen,0,0
+1666,17,April,24,,St Mary Sommerset,0,0
+1666,17,April,24,,Alhallows Breadstreet,0,0
+1666,17,April,24,,St James Dukes Place,0,0
+1666,17,April,24,,St Mary Staining,0,0
+1666,17,April,24,,Alhallows the Great,0,0
+1666,17,April,24,,St James Garlickhithe,0,0
+1666,17,April,24,,St Mary Woolchurch,0,0
+1666,17,April,24,,Alhallows Honylane,0,0
+1666,17,April,24,,St John Baptist,0,0
+1666,17,April,24,,St Mary Woolnoth,0,0
+1666,17,April,24,,Alhallows the Less,0,0
+1666,17,April,24,,St John Evangelist,1,0
+1666,17,April,24,,St Matthew Fridaystreet,0,0
+1666,17,April,24,,Alhallows Lombardstreet,0,0
+1666,17,April,24,,St John Zachary,0,0
+1666,17,April,24,,St Michael Bassishaw,0,0
+1666,17,April,24,,Alhallows Staining,0,0
+1666,17,April,24,,St Katharine Coleman,0,0
+1666,17,April,24,,St Michael Cornhil,0,0
+1666,17,April,24,,Alhallows the Wall,3,1
+1666,17,April,24,,St Katharine Creechurch,2,0
+1666,17,April,24,,St Michael Crookedlane,1,0
+1666,17,April,24,,St Alphage,0,0
+1666,17,April,24,,St Lawrence Jewry,0,0
+1666,17,April,24,,St Michael Queenhithe,0,0
+1666,17,April,24,,St Andrew Hubbard,1,0
+1666,17,April,24,,St Lawrence Pountney,1,0
+1666,17,April,24,,St Michael Quern,1,0
+1666,17,April,24,,St Andrew Undershaft,0,0
+1666,17,April,24,,St Leonard Eastcheap,0,0
+1666,17,April,24,,St Michael Royal,0,0
+1666,17,April,24,,St Andrew Wardrobe,0,0
+1666,17,April,24,,St Leonard Fosterlane,0,0
+1666,17,April,24,,St Michael Woodstreet,0,0
+1666,17,April,24,,St Ann Aldersgate,0,0
+1666,17,April,24,,St Magnus Parish,0,0
+1666,17,April,24,,St Mildred Breadstreet,1,0
+1666,17,April,24,,St Ann Blackfriers,1,0
+1666,17,April,24,,St Margaret Lothbury,0,0
+1666,17,April,24,,St Mildred Poultry,2,0
+1666,17,April,24,,St Anthony alias Antholin,1,0
+1666,17,April,24,,St Margaret Moses,0,0
+1666,17,April,24,,St Nicholas Acons,0,0
+1666,17,April,24,,St Austins Parish,0,0
+1666,17,April,24,,St Margaret Newfishstreet,1,0
+1666,17,April,24,,St Nicholas Coleabby,0,0
+1666,17,April,24,,St Bartholomew Exchange,0,0
+1666,17,April,24,,St Margaret Pattons,0,0
+1666,17,April,24,,St Nicholas Olaves,0,0
+1666,17,April,24,,St Bennet Finck,0,0
+1666,17,April,24,,St Martin Iremongerlane,1,0
+1666,17,April,24,,St Olave Hartstreet,0,0
+1666,17,April,24,,St Bennet Gracechurch,0,0
+1666,17,April,24,,St Martin Ludgate,6,0
+1666,17,April,24,,St Olave Jewry,0,0
+1666,17,April,24,,St Bennet Paulswharf,0,0
+1666,17,April,24,,St Martin Orgars,0,0
+1666,17,April,24,,St Olave Silverstreet,0,0
+1666,17,April,24,,St Bennet Sherehog,1,0
+1666,17,April,24,,St Martin Outwitch,0,0
+1666,17,April,24,,St Pancras Soperlane,0,0
+1666,17,April,24,,St Botolph Billingsgate,0,0
+1666,17,April,24,,St Martin Vintrey,0,0
+1666,17,April,24,,St Peter Cheap,2,0
+1666,17,April,24,,Christ's Church,1,0
+1666,17,April,24,,St Mary Abchurch,0,0
+1666,17,April,24,,St Peter Cornhil,0,0
+1666,17,April,24,,St Christophers,0,0
+1666,17,April,24,,St Mary Aldermanbury,0,0
+1666,17,April,24,,St Peter Paulswharf,0,0
+1666,17,April,24,,St Clement Eastcheap,0,0
+1666,17,April,24,,St Mary Aldermary,0,0
+1666,17,April,24,,St Peter Poor,0,0
+1666,17,April,24,,St Dionis Backchurch,1,0
+1666,17,April,24,,St Mary-le-bow,1,0
+1666,17,April,24,,St Steven Colemanstreet,0,0
+1666,17,April,24,,St Dunstan East,2,0
+1666,17,April,24,,St Mary Bothaw,0,0
+1666,17,April,24,,St Steven Walbrook,0,0
+1666,17,April,24,,St Edmund Lumbardstr.,0,0
+1666,17,April,24,,St Mary Colechurch,0,0
+1666,17,April,24,,St Swithin,0,0
+1666,17,April,24,,St Ethelburga,0,0
+1666,17,April,24,,St Mary Hill,0,0
+1666,17,April,24,,St Thomas Apostle,0,0
+1666,17,April,24,,St Faith,0,0
+1666,17,April,24,,St Mary Milkstreet,1,0
+1666,17,April,24,,Trinity Parish,0,0
+1666,17,April,24,,St Gabriel Fenchurch,1,0
+1666,17,April,24,,St Mary Mag. Oldfishstreet,1,0
+1666,17,April,24,,St Vedast alias Foster,0,0
+1666,17,April,24,,St George Botolphlane,0,0
+1666,17,April,24,,St Andrew Holborn,5,0
+1666,17,April,24,,St Botolph Aldgate,19,2
+1666,17,April,24,,Saviour Southwark,9,1
+1666,17,April,24,,St Bartholomew the Great,2,0
+1666,17,April,24,,St Botolph Bishopsgate,6,0
+1666,17,April,24,,St Sepulchres Parish,11,0
+1666,17,April,24,,St Bartholomew the Lesse,0,0
+1666,17,April,24,,St Dunstan West,2,0
+1666,17,April,24,,St Thomas Southwark,0,0
+1666,17,April,24,,St Bridget,5,0
+1666,17,April,24,,St George Southwark,4,1
+1666,17,April,24,,Trinity Minories,0,0
+1666,17,April,24,,Bridewel Precinct,0,0
+1666,17,April,24,,St Giles Cripplegate,15,1
+1666,17,April,24,,At the Pesthouse,2,2
+1666,17,April,24,,St Botolph Aldersgate,3,0
+1666,17,April,24,,St Olave Southwark,14,2
+1666,17,April,24,,St Katharine Tower,2,1
+1666,17,April,24,,St Mary Newington,1,0
+1666,17,April,24,,Dunstan Stepney,20,5
+1666,17,April,24,,Lambeth Parish,4,0
+1666,17,April,24,,St Mary Whitechappel,12,4
+1666,17,April,24,,St Giles in the Fields,7,0
+1666,17,April,24,,St Leonard Shoreditch,4,0
+1666,17,April,24,,St. Paul Shadwel,0,0
+1666,17,April,24,,St James Clerkenwel,1,0
+1666,17,April,24,,St Mary Islington,0,0
+1666,17,April,24,,Rotherhith Parish,1,0
+1666,17,April,24,,John at Hackney,0,0
+1666,17,April,24,,St Mary Magd. Bermondsey,4,1
+1666,17,April,24,,St Ann Westminster,0,0
+1666,17,April,24,,St Margaret Westminster,6,1
+1666,17,April,24,,St Mary Savoy,0,0
+1666,17,April,24,,St Clement Danes,4,0
+1666,17,April,24,,St Martin in the Fields,13,1
+1666,17,April,24,,St Paul Covent Garden,0,0
+1666,17,April,24,,St James Westminster,0,0
+1666,24,April,1,May,ALban Woodstreet,0,0
+1666,24,April,1,May,St Gregory by St Paul,1,0
+1666,24,April,1,May,St Mary Mounthaw,0,0
+1666,24,April,1,May,Alhallows Barking,1,0
+1666,24,April,1,May,St Hellen,0,0
+1666,24,April,1,May,St Mary Sommerset,0,0
+1666,24,April,1,May,Alhallows Breadstreet,0,0
+1666,24,April,1,May,St James Dukes Place,0,0
+1666,24,April,1,May,St Mary Staining,0,0
+1666,24,April,1,May,Alhallows the Great,0,0
+1666,24,April,1,May,St James Garlickhithe,0,0
+1666,24,April,1,May,St Mary Woolchurch,0,0
+1666,24,April,1,May,Alhallows Honylane,1,0
+1666,24,April,1,May,St John Baptist,0,0
+1666,24,April,1,May,St Mary Woolnoth,1,0
+1666,24,April,1,May,Alhallows the Less,0,0
+1666,24,April,1,May,St John Evangelist,0,0
+1666,24,April,1,May,St Matthew Fridaystreet,2,0
+1666,24,April,1,May,Alhallows Lombardstreet,0,0
+1666,24,April,1,May,St John Zachary,1,0
+1666,24,April,1,May,St Michael Bassishaw,1,0
+1666,24,April,1,May,Alhallows Staining,1,0
+1666,24,April,1,May,St Katharine Coleman,1,0
+1666,24,April,1,May,St Michael Cornhil,1,0
+1666,24,April,1,May,Alhallows the Wall,2,0
+1666,24,April,1,May,St Katharine Creechurch,2,0
+1666,24,April,1,May,St Michael Crookedlane,1,0
+1666,24,April,1,May,St Alphage,1,0
+1666,24,April,1,May,St Lawrence Jewry,0,0
+1666,24,April,1,May,St Michael Queenhithe,2,1
+1666,24,April,1,May,St Andrew Hubbard,3,0
+1666,24,April,1,May,St Lawrence Pountney,0,0
+1666,24,April,1,May,St Michael Quern,0,0
+1666,24,April,1,May,St Andrew Undershaft,0,0
+1666,24,April,1,May,St Leonard Eastcheap,1,0
+1666,24,April,1,May,St Michael Royal,0,0
+1666,24,April,1,May,St Andrew Wardrobe,0,0
+1666,24,April,1,May,St Leonard Fosterlane,0,0
+1666,24,April,1,May,St Michael Woodstreet,1,0
+1666,24,April,1,May,St Ann Aldersgate,2,0
+1666,24,April,1,May,St Magnus Parish,0,0
+1666,24,April,1,May,St Mildred Breadstreet,1,0
+1666,24,April,1,May,St Ann Blackfriers,0,0
+1666,24,April,1,May,St Margaret Lothbury,0,0
+1666,24,April,1,May,St Mildred Poultry,0,0
+1666,24,April,1,May,St Anthony alias Antholin,0,0
+1666,24,April,1,May,St Margaret Moses,1,0
+1666,24,April,1,May,St Nicholas Acons,0,0
+1666,24,April,1,May,St Austins Parish,0,0
+1666,24,April,1,May,St Margaret Newfishstreet,0,0
+1666,24,April,1,May,St Nicholas Coleabby,1,0
+1666,24,April,1,May,St Bartholomew Exchange,0,0
+1666,24,April,1,May,St Margaret Pattons,0,0
+1666,24,April,1,May,St Nicholas Olaves,0,0
+1666,24,April,1,May,St Bennet Finck,0,0
+1666,24,April,1,May,St Martin Iremongerlane,0,0
+1666,24,April,1,May,St Olave Hartstreet,0,0
+1666,24,April,1,May,St Bennet Gracechurch,1,0
+1666,24,April,1,May,St Martin Ludgate,1,0
+1666,24,April,1,May,St Olave Jewry,0,0
+1666,24,April,1,May,St Bennet Paulswharf,2,1
+1666,24,April,1,May,St Martin Orgars,0,0
+1666,24,April,1,May,St Olave Silverstreet,0,0
+1666,24,April,1,May,St Bennet Sherehog,0,0
+1666,24,April,1,May,St Martin Outwitch,0,0
+1666,24,April,1,May,St Pancras Soperlane,0,0
+1666,24,April,1,May,St Botolph Billingsgate,0,0
+1666,24,April,1,May,St Martin Vintrey,0,0
+1666,24,April,1,May,St Peter Cheap,0,0
+1666,24,April,1,May,Christ's Church,4,0
+1666,24,April,1,May,St Mary Abchurch,1,0
+1666,24,April,1,May,St Peter Cornhil,0,0
+1666,24,April,1,May,St Christophers,1,0
+1666,24,April,1,May,St Mary Aldermanbury,0,0
+1666,24,April,1,May,St Peter Paulswharf,0,0
+1666,24,April,1,May,St Clement Eastcheap,0,0
+1666,24,April,1,May,St Mary Aldermary,0,0
+1666,24,April,1,May,St Peter Poor,1,0
+1666,24,April,1,May,St Dionis Backchurch,0,0
+1666,24,April,1,May,St Mary-le-bow,3,0
+1666,24,April,1,May,St Steven Colemanstreet,3,2
+1666,24,April,1,May,St Dunstan East,1,1
+1666,24,April,1,May,St Mary Bothaw,0,0
+1666,24,April,1,May,St Steven Walbrook,0,0
+1666,24,April,1,May,St Edmund Lumbardstr.,1,0
+1666,24,April,1,May,St Mary Colechurch,0,0
+1666,24,April,1,May,St Swithin,1,0
+1666,24,April,1,May,St Ethelburga,0,0
+1666,24,April,1,May,St Mary Hill,0,0
+1666,24,April,1,May,St Thomas Apostle,0,0
+1666,24,April,1,May,St Faith,0,0
+1666,24,April,1,May,St Mary Milkstreet,1,0
+1666,24,April,1,May,Trinity Parish,0,0
+1666,24,April,1,May,St Gabriel Fenchurch,0,0
+1666,24,April,1,May,St Mary Mag. Oldfishstreet,1,0
+1666,24,April,1,May,St Vedast alias Foster,0,0
+1666,24,April,1,May,St George Botolphlane,0,0
+1666,24,April,1,May,St Andrew Holborn,5,1
+1666,24,April,1,May,St Botolph Aldgate,8,1
+1666,24,April,1,May,Saviour Southwark,5,3
+1666,24,April,1,May,St Bartholomew the Great,1,0
+1666,24,April,1,May,St Botolph Bishopsgate,1,0
+1666,24,April,1,May,St Sepulchres Parish,10,0
+1666,24,April,1,May,St Bartholomew the Lesse,0,0
+1666,24,April,1,May,St Dunstan West,2,0
+1666,24,April,1,May,St Thomas Southwark,0,0
+1666,24,April,1,May,St Bridget,2,0
+1666,24,April,1,May,St George Southwark,1,0
+1666,24,April,1,May,Trinity Minories,1,0
+1666,24,April,1,May,Bridewel Precinct,1,0
+1666,24,April,1,May,St Giles Cripplegate,14,2
+1666,24,April,1,May,At the Pesthouse,1,9
+1666,24,April,1,May,St Botolph Aldersgate,0,0
+1666,24,April,1,May,St Olave Southwark,4,1
+1666,24,April,1,May,...hritt Church,0,0
+1666,24,April,1,May,St Katharine Tower,2,1
+1666,24,April,1,May,St Mary Newington,4,0
+1666,24,April,1,May,Dunstan Stepney,23,2
+1666,24,April,1,May,Lambeth Parish,8,7
+1666,24,April,1,May,St Mary Whitechappel,5,0
+1666,24,April,1,May,St Giles in the Fields,6,3
+1666,24,April,1,May,St Leonard Shoreditch,5,1
+1666,24,April,1,May,St. Paul Shadwel,0,0
+1666,24,April,1,May,St James Clerkenwel,6,0
+1666,24,April,1,May,St Mary Islington,3,0
+1666,24,April,1,May,Rotherhith Parish,2,1
+1666,24,April,1,May,John at Hackney,2,1
+1666,24,April,1,May,St Mary Magd. Bermondsey,5,2
+1666,24,April,1,May,St Ann Westminster,0,0
+1666,24,April,1,May,St Margaret Westminster,6,2
+1666,24,April,1,May,St Mary Savoy,5,0
+1666,24,April,1,May,St Clement Danes,7,0
+1666,24,April,1,May,St Martin in the Fields,15,6
+1666,24,April,1,May,St Paul Covent Garden,1,0
+1666,24,April,1,May,St James Westminster,0,0
+1666,1,May,8,,ALban Woodstreet,0,0
+1666,1,May,8,,St Gregory by St Paul,2,0
+1666,1,May,8,,St Mary Mounthaw,1,0
+1666,1,May,8,,Alhallows Barking,0,0
+1666,1,May,8,,St Hellen,0,0
+1666,1,May,8,,St Mary Sommerset,1,0
+1666,1,May,8,,Alhallows Breadstreet,0,0
+1666,1,May,8,,St James Dukes Place,0,0
+1666,1,May,8,,St Mary Staining,0,0
+1666,1,May,8,,Alhallows the Great,1,0
+1666,1,May,8,,St James Garlickhithe,1,1
+1666,1,May,8,,St Mary Woolchurch,2,0
+1666,1,May,8,,Alhallows Honylane,0,0
+1666,1,May,8,,St John Baptist,0,0
+1666,1,May,8,,St Mary Woolnoth,1,0
+1666,1,May,8,,Alhallows the Less,0,0
+1666,1,May,8,,St John Evangelist,0,0
+1666,1,May,8,,St Matthew Fridaystreet,0,0
+1666,1,May,8,,Alhallows Lombardstreet,0,0
+1666,1,May,8,,St John Zachary,0,0
+1666,1,May,8,,St Michael Bassishaw,1,0
+1666,1,May,8,,Alhallows Staining,0,0
+1666,1,May,8,,St Katharine Coleman,1,0
+1666,1,May,8,,St Michael Cornhil,1,0
+1666,1,May,8,,Alhallows the Wall,2,1
+1666,1,May,8,,St Katharine Creechurch,2,0
+1666,1,May,8,,St Michael Crookedlane,0,0
+1666,1,May,8,,St Alphage,0,0
+1666,1,May,8,,St Lawrence Jewry,0,0
+1666,1,May,8,,St Michael Queenhithe,1,1
+1666,1,May,8,,St Andrew Hubbard,2,0
+1666,1,May,8,,St Lawrence Pountney,1,1
+1666,1,May,8,,St Michael Quern,0,0
+1666,1,May,8,,St Andrew Undershaft,1,0
+1666,1,May,8,,St Leonard Eastcheap,1,0
+1666,1,May,8,,St Michael Royal,1,0
+1666,1,May,8,,St Andrew Wardrobe,0,0
+1666,1,May,8,,St Leonard Fosterlane,0,0
+1666,1,May,8,,St Michael Woodstreet,2,0
+1666,1,May,8,,St Ann Aldersgate,1,0
+1666,1,May,8,,St Magnus Parish,0,0
+1666,1,May,8,,St Mildred Breadstreet,0,0
+1666,1,May,8,,St Ann Blackfriers,1,0
+1666,1,May,8,,St Margaret Lothbury,0,0
+1666,1,May,8,,St Mildred Poultry,0,0
+1666,1,May,8,,St Anthony alias Antholin,0,0
+1666,1,May,8,,St Margaret Moses,0,0
+1666,1,May,8,,St Nicholas Acons,0,0
+1666,1,May,8,,St Austins Parish,0,0
+1666,1,May,8,,St Margaret Newfishstreet,2,2
+1666,1,May,8,,St Nicholas Coleabby,0,0
+1666,1,May,8,,St Bartholomew Exchange,0,0
+1666,1,May,8,,St Margaret Pattons,0,0
+1666,1,May,8,,St Nicholas Olaves,0,0
+1666,1,May,8,,St Bennet Finck,0,0
+1666,1,May,8,,St Martin Iremongerlane,0,0
+1666,1,May,8,,St Olave Hartstreet,0,0
+1666,1,May,8,,St Bennet Gracechurch,0,0
+1666,1,May,8,,St Martin Ludgate,0,0
+1666,1,May,8,,St Olave Jewry,0,0
+1666,1,May,8,,St Bennet Paulswharf,0,0
+1666,1,May,8,,St Martin Orgars,1,0
+1666,1,May,8,,St Olave Silverstreet,0,0
+1666,1,May,8,,St Bennet Sherehog,0,0
+1666,1,May,8,,St Martin Outwitch,0,0
+1666,1,May,8,,St Pancras Soperlane,0,0
+1666,1,May,8,,St Botolph Billingsgate,2,0
+1666,1,May,8,,St Martin Vintrey,0,0
+1666,1,May,8,,St Peter Cheap,0,0
+1666,1,May,8,,Christ's Church,1,0
+1666,1,May,8,,St Mary Abchurch,1,0
+1666,1,May,8,,St Peter Cornhil,0,0
+1666,1,May,8,,St Christophers,1,0
+1666,1,May,8,,St Mary Aldermanbury,1,0
+1666,1,May,8,,St Peter Paulswharf,0,0
+1666,1,May,8,,St Clement Eastcheap,0,0
+1666,1,May,8,,St Mary Aldermary,0,0
+1666,1,May,8,,St Peter Poor,0,0
+1666,1,May,8,,St Dionis Backchurch,1,0
+1666,1,May,8,,St Mary-le-bow,0,0
+1666,1,May,8,,St Steven Colemanstreet,0,0
+1666,1,May,8,,St Dunstan East,1,0
+1666,1,May,8,,St Mary Bothaw,0,0
+1666,1,May,8,,St Steven Walbrook,0,0
+1666,1,May,8,,St Edmund Lumbardstr.,0,0
+1666,1,May,8,,St Mary Colechurch,0,0
+1666,1,May,8,,St Swithin,0,0
+1666,1,May,8,,St Ethelburga,0,0
+1666,1,May,8,,St Mary Hill,0,0
+1666,1,May,8,,St Thomas Apostle,0,0
+1666,1,May,8,,St Faith,1,0
+1666,1,May,8,,St Mary Milkstreet,0,0
+1666,1,May,8,,Trinity Parish,0,0
+1666,1,May,8,,St Gabriel Fenchurch,0,0
+1666,1,May,8,,St Mary Mag. Oldfishstreet,1,0
+1666,1,May,8,,St Vedast alias Foster,0,0
+1666,1,May,8,,St George Botolphlane,0,0
+1666,1,May,8,,St Andrew Holborn,6,0
+1666,1,May,8,,St Botolph Aldgate,1,0
+1666,1,May,8,,Saviour Southwark,9,2
+1666,1,May,8,,St Bartholomew the Great,1,0
+1666,1,May,8,,St Botolph Bishopsgate,0,0
+1666,1,May,8,,St Sepulchres Parish,7,0
+1666,1,May,8,,St Bartholomew the Lesse,1,0
+1666,1,May,8,,St Dunstan West,1,1
+1666,1,May,8,,St Thomas Southwark,1,0
+1666,1,May,8,,St Bridget,5,0
+1666,1,May,8,,St George Southwark,1,0
+1666,1,May,8,,Trinity Minories,0,0
+1666,1,May,8,,Bridewel Precinct,0,0
+1666,1,May,8,,St Giles Cripplegate,12,0
+1666,1,May,8,,At the Pesthouse,2,2
+1666,1,May,8,,St Botolph Aldersgate,2,0
+1666,1,May,8,,St Olave Southwark,11,0
+1666,1,May,8,,St Katharine Tower,5,0
+1666,1,May,8,,St Mary Newington,1,1
+1666,1,May,8,,Dunstan Stepney,29,5
+1666,1,May,8,,Lambeth Parish,19,14
+1666,1,May,8,,St Mary Whitechappel,8,3
+1666,1,May,8,,St Giles in the Fields,7,3
+1666,1,May,8,,St Leonard Shoreditch,2,0
+1666,1,May,8,,St. Paul Shadwel,0,0
+1666,1,May,8,,St James Clerkenwel,3,0
+1666,1,May,8,,St Mary Islington,12,5
+1666,1,May,8,,Rotherhith Parish,6,5
+1666,1,May,8,,John at Hackney,1,0
+1666,1,May,8,,St Mary Magd. Bermondsey,1,0
+1666,1,May,8,,St Ann Westminster,0,0
+1666,1,May,8,,St Margaret Westminster,6,3
+1666,1,May,8,,St Mary Savoy,2,1
+1666,1,May,8,,St Clement Danes,3,0
+1666,1,May,8,,St Martin in the Fields,22,2
+1666,1,May,8,,St Paul Covent Garden,2,0
+1666,1,May,8,,St James Westminster,0,0
+1666,8,May,15,,ALban Woodstreet,1,0
+1666,8,May,15,,St Gregory by St Paul,0,0
+1666,8,May,15,,St Mary Mounthaw,0,0
+1666,8,May,15,,Alhallows Barking,3,0
+1666,8,May,15,,St Hellen,1,0
+1666,8,May,15,,St Mary Sommerset,2,0
+1666,8,May,15,,Alhallows Breadstreet,0,0
+1666,8,May,15,,St James Dukes Place,2,1
+1666,8,May,15,,St Mary Staining,0,0
+1666,8,May,15,,Alhallows the Great,2,1
+1666,8,May,15,,St James Garlickhithe,1,1
+1666,8,May,15,,St Mary Woolchurch,1,0
+1666,8,May,15,,Alhallows Honylane,1,0
+1666,8,May,15,,St John Baptist,0,0
+1666,8,May,15,,St Mary Woolnoth,0,0
+1666,8,May,15,,Alhallows the Less,0,0
+1666,8,May,15,,St John Evangelist,0,0
+1666,8,May,15,,St Matthew Fridaystreet,0,0
+1666,8,May,15,,Alhallows Lombardstreet,0,0
+1666,8,May,15,,St John Zachary,0,0
+1666,8,May,15,,St Michael Bassishaw,0,0
+1666,8,May,15,,Alhallows Staining,0,0
+1666,8,May,15,,St Katharine Coleman,2,0
+1666,8,May,15,,St Michael Cornhil,0,0
+1666,8,May,15,,Alhallows the Wall,2,0
+1666,8,May,15,,St Katharine Creechurch,2,1
+1666,8,May,15,,St Michael Crookedlane,2,1
+1666,8,May,15,,St Alphage,0,0
+1666,8,May,15,,St Lawrence Jewry,1,0
+1666,8,May,15,,St Michael Queenhithe,1,0
+1666,8,May,15,,St Andrew Hubbard,0,0
+1666,8,May,15,,St Lawrence Pountney,0,0
+1666,8,May,15,,St Michael Quern,0,0
+1666,8,May,15,,St Andrew Undershaft,0,0
+1666,8,May,15,,St Leonard Eastcheap,0,0
+1666,8,May,15,,St Michael Royal,0,0
+1666,8,May,15,,St Andrew Wardrobe,1,0
+1666,8,May,15,,St Leonard Fosterlane,2,0
+1666,8,May,15,,St Michael Woodstreet,1,0
+1666,8,May,15,,St Ann Aldersgate,1,0
+1666,8,May,15,,St Magnus Parish,0,0
+1666,8,May,15,,St Mildred Breadstreet,0,0
+1666,8,May,15,,St Ann Blackfriers,1,1
+1666,8,May,15,,St Margaret Lothbury,0,0
+1666,8,May,15,,St Mildred Poultry,0,0
+1666,8,May,15,,St Anthony alias Antholin,0,0
+1666,8,May,15,,St Margaret Moses,0,0
+1666,8,May,15,,St Nicholas Acons,0,0
+1666,8,May,15,,St Austins Parish,1,1
+1666,8,May,15,,St Margaret Newfishstreet,0,0
+1666,8,May,15,,St Nicholas Coleabby,0,0
+1666,8,May,15,,St Bartholomew Exchange,1,0
+1666,8,May,15,,St Margaret Pattons,0,0
+1666,8,May,15,,St Nicholas Olaves,0,0
+1666,8,May,15,,St Bennet Finck,0,0
+1666,8,May,15,,St Martin Iremongerlane,0,0
+1666,8,May,15,,St Olave Hartstreet,0,0
+1666,8,May,15,,St Bennet Gracechurch,0,0
+1666,8,May,15,,St Martin Ludgate,0,0
+1666,8,May,15,,St Olave Jewry,0,0
+1666,8,May,15,,St Bennet Paulswharf,2,0
+1666,8,May,15,,St Martin Orgars,1,0
+1666,8,May,15,,St Olave Silverstreet,1,0
+1666,8,May,15,,St Bennet Sherehog,0,0
+1666,8,May,15,,St Martin Outwitch,0,0
+1666,8,May,15,,St Pancras Soperlane,0,0
+1666,8,May,15,,St Botolph Billingsgate,0,0
+1666,8,May,15,,St Martin Vintrey,0,0
+1666,8,May,15,,St Peter Cheap,0,0
+1666,8,May,15,,Christ's Church,2,0
+1666,8,May,15,,St Mary Abchurch,1,0
+1666,8,May,15,,St Peter Cornhil,0,0
+1666,8,May,15,,St Christophers,0,0
+1666,8,May,15,,St Mary Aldermanbury,0,0
+1666,8,May,15,,St Peter Paulswharf,0,0
+1666,8,May,15,,St Clement Eastcheap,0,0
+1666,8,May,15,,St Mary Aldermary,0,0
+1666,8,May,15,,St Peter Poor,2,0
+1666,8,May,15,,St Dionis Backchurch,1,0
+1666,8,May,15,,St Mary-le-bow,0,0
+1666,8,May,15,,St Steven Colemanstreet,0,0
+1666,8,May,15,,St Dunstan East,2,0
+1666,8,May,15,,St Mary Bothaw,0,0
+1666,8,May,15,,St Steven Walbrook,0,0
+1666,8,May,15,,St Edmund Lumbardstr.,0,0
+1666,8,May,15,,St Mary Colechurch,0,0
+1666,8,May,15,,St Swithin,0,0
+1666,8,May,15,,St Ethelburga,0,0
+1666,8,May,15,,St Mary Hill,0,0
+1666,8,May,15,,St Thomas Apostle,0,0
+1666,8,May,15,,St Faith,0,0
+1666,8,May,15,,St Mary Milkstreet,0,0
+1666,8,May,15,,Trinity Parish,0,0
+1666,8,May,15,,St Gabriel Fenchurch,0,0
+1666,8,May,15,,St Mary Mag. Oldfishstreet,0,0
+1666,8,May,15,,St Vedast alias Foster,0,0
+1666,8,May,15,,St George Botolphlane,0,0
+1666,8,May,15,,St Andrew Holborn,7,0
+1666,8,May,15,,St Botolph Aldgate,12,2
+1666,8,May,15,,Saviour Southwark,10,2
+1666,8,May,15,,St Bartholomew the Great,2,0
+1666,8,May,15,,St Botolph Bishopsgate,6,0
+1666,8,May,15,,St Sepulchres Parish,3,1
+1666,8,May,15,,St Bartholomew the Lesse,0,0
+1666,8,May,15,,St Dunstan West,4,0
+1666,8,May,15,,St Thomas Southwark,1,0
+1666,8,May,15,,St Bridget,0,0
+1666,8,May,15,,St George Southwark,7,2
+1666,8,May,15,,Trinity Minories,0,0
+1666,8,May,15,,Bridewel Precinct,0,0
+1666,8,May,15,,St Giles Cripplegate,6,1
+1666,8,May,15,,At the Pesthouse,4,4
+1666,8,May,15,,St Botolph Aldersgate,1,1
+1666,8,May,15,,St Olave Southwark,7,0
+1666,8,May,15,,...hritt Church,0,0
+1666,8,May,15,,St Katharine Tower,4,0
+1666,8,May,15,,St Mary Newington,2,2
+1666,8,May,15,,Dunstan Stepney,21,5
+1666,8,May,15,,Lambeth Parish,16,12
+1666,8,May,15,,St Mary Whitechappel,4,0
+1666,8,May,15,,St Giles in the Fields,7,1
+1666,8,May,15,,St Leonard Shoreditch,3,1
+1666,8,May,15,,St. Paul Shadwel,0,0
+1666,8,May,15,,St James Clerkenwel,3,0
+1666,8,May,15,,St Mary Islington,0,0
+1666,8,May,15,,Rotherhith Parish,0,0
+1666,8,May,15,,John at Hackney,3,0
+1666,8,May,15,,St Mary Magd. Bermondsey,11,5
+1666,8,May,15,,St Ann Westminster,0,0
+1666,8,May,15,,St Margaret Westminster,15,5
+1666,8,May,15,,St Mary Savoy,2,1
+1666,8,May,15,,St Clement Danes,8,2
+1666,8,May,15,,St Martin in the Fields,19,3
+1666,8,May,15,,St Paul Covent Garden,3,1
+1666,8,May,15,,St James Westminster,0,0
+1666,15,May,22,,ALban Woodstreet,1,0
+1666,15,May,22,,St Gregory by St Paul,0,0
+1666,15,May,22,,St Mary Mounthaw,0,0
+1666,15,May,22,,Alhallows Barking,0,0
+1666,15,May,22,,St Hellen,0,0
+1666,15,May,22,,St Mary Sommerset,0,0
+1666,15,May,22,,Alhallows Breadstreet,1,0
+1666,15,May,22,,St James Dukes Place,1,0
+1666,15,May,22,,St Mary Staining,0,0
+1666,15,May,22,,Alhallows the Great,0,0
+1666,15,May,22,,St James Garlickhithe,0,0
+1666,15,May,22,,St Mary Woolchurch,2,0
+1666,15,May,22,,Alhallows Honylane,0,0
+1666,15,May,22,,St John Baptist,1,0
+1666,15,May,22,,St Mary Woolnoth,0,0
+1666,15,May,22,,Alhallows the Less,1,0
+1666,15,May,22,,St John Evangelist,1,0
+1666,15,May,22,,St Matthew Fridaystreet,0,0
+1666,15,May,22,,Alhallows Lombardstreet,0,0
+1666,15,May,22,,St John Zachary,1,0
+1666,15,May,22,,St Michael Bassishaw,0,0
+1666,15,May,22,,Alhallows Staining,1,0
+1666,15,May,22,,St Katharine Coleman,0,0
+1666,15,May,22,,St Michael Cornhil,0,0
+1666,15,May,22,,Alhallows the Wall,0,0
+1666,15,May,22,,St Katharine Creechurch,1,0
+1666,15,May,22,,St Michael Crookedlane,0,0
+1666,15,May,22,,St Alphage,1,0
+1666,15,May,22,,St Lawrence Jewry,0,0
+1666,15,May,22,,St Michael Queenhithe,1,1
+1666,15,May,22,,St Andrew Hubbard,0,0
+1666,15,May,22,,St Lawrence Pountney,1,0
+1666,15,May,22,,St Michael Quern,0,0
+1666,15,May,22,,St Andrew Undershaft,0,0
+1666,15,May,22,,St Leonard Eastcheap,0,0
+1666,15,May,22,,St Michael Royal,0,0
+1666,15,May,22,,St Andrew Wardrobe,0,0
+1666,15,May,22,,St Leonard Fosterlane,0,0
+1666,15,May,22,,St Michael Woodstreet,0,0
+1666,15,May,22,,St Ann Aldersgate,0,0
+1666,15,May,22,,St Magnus Parish,0,0
+1666,15,May,22,,St Mildred Breadstreet,0,0
+1666,15,May,22,,St Ann Blackfriers,2,1
+1666,15,May,22,,St Margaret Lothbury,0,0
+1666,15,May,22,,St Mildred Poultry,1,0
+1666,15,May,22,,St Anthony alias Antholin,0,0
+1666,15,May,22,,St Margaret Moses,0,0
+1666,15,May,22,,St Nicholas Acons,0,0
+1666,15,May,22,,St Austins Parish,0,0
+1666,15,May,22,,St Margaret Newfishstreet,1,0
+1666,15,May,22,,St Nicholas Coleabby,1,0
+1666,15,May,22,,St Bartholomew Exchange,0,0
+1666,15,May,22,,St Margaret Pattons,0,0
+1666,15,May,22,,St Nicholas Olaves,0,0
+1666,15,May,22,,St Bennet Finck,0,0
+1666,15,May,22,,St Martin Iremongerlane,0,0
+1666,15,May,22,,St Olave Hartstreet,0,0
+1666,15,May,22,,St Bennet Gracechurch,0,0
+1666,15,May,22,,St Martin Ludgate,0,0
+1666,15,May,22,,St Olave Jewry,0,0
+1666,15,May,22,,St Bennet Paulswharf,0,0
+1666,15,May,22,,St Martin Orgars,0,0
+1666,15,May,22,,St Olave Silverstreet,0,0
+1666,15,May,22,,St Bennet Sherehog,0,0
+1666,15,May,22,,St Martin Outwitch,0,0
+1666,15,May,22,,St Pancras Soperlane,0,0
+1666,15,May,22,,St Botolph Billingsgate,1,0
+1666,15,May,22,,St Martin Vintrey,1,0
+1666,15,May,22,,St Peter Cheap,0,0
+1666,15,May,22,,Christ's Church,6,0
+1666,15,May,22,,St Mary Abchurch,0,0
+1666,15,May,22,,St Peter Cornhil,0,0
+1666,15,May,22,,St Christophers,0,0
+1666,15,May,22,,St Mary Aldermanbury,2,0
+1666,15,May,22,,St Peter Paulswharf,1,0
+1666,15,May,22,,St Clement Eastcheap,0,0
+1666,15,May,22,,St Mary Aldermary,0,0
+1666,15,May,22,,St Peter Poor,0,0
+1666,15,May,22,,St Dionis Backchurch,0,0
+1666,15,May,22,,St Mary-le-bow,0,0
+1666,15,May,22,,St Steven Colemanstreet,3,1
+1666,15,May,22,,St Dunstan East,2,0
+1666,15,May,22,,St Mary Bothaw,0,0
+1666,15,May,22,,St Steven Walbrook,0,0
+1666,15,May,22,,St Edmund Lumbardstr.,0,0
+1666,15,May,22,,St Mary Colechurch,0,0
+1666,15,May,22,,St Swithin,0,0
+1666,15,May,22,,St Ethelburga,0,0
+1666,15,May,22,,St Mary Hill,2,0
+1666,15,May,22,,St Thomas Apostle,0,0
+1666,15,May,22,,St Faith,1,0
+1666,15,May,22,,St Mary Milkstreet,1,0
+1666,15,May,22,,Trinity Parish,0,0
+1666,15,May,22,,St Gabriel Fenchurch,0,0
+1666,15,May,22,,St Mary Mag. Oldfishstreet,1,0
+1666,15,May,22,,St Vedast alias Foster,0,0
+1666,15,May,22,,St George Botolphlane,0,0
+1666,15,May,22,,St Andrew Holborn,4,0
+1666,15,May,22,,St Botolph Aldgate,6,0
+1666,15,May,22,,Saviour Southwark,6,2
+1666,15,May,22,,St Bartholomew the Great,0,0
+1666,15,May,22,,St Botolph Bishopsgate,3,0
+1666,15,May,22,,St Sepulchres Parish,10,0
+1666,15,May,22,,St Bartholomew the Lesse,0,0
+1666,15,May,22,,St Dunstan West,1,0
+1666,15,May,22,,St Thomas Southwark,0,0
+1666,15,May,22,,St Bridget,6,1
+1666,15,May,22,,St George Southwark,7,0
+1666,15,May,22,,Trinity Minories,2,1
+1666,15,May,22,,Bridewel Precinct,0,0
+1666,15,May,22,,St Giles Cripplegate,13,0
+1666,15,May,22,,At the Pesthouse,4,4
+1666,15,May,22,,St Botolph Aldersgate,5,0
+1666,15,May,22,,St Olave Southwark,8,0
+1666,15,May,22,,...hritt Church,0,0
+1666,15,May,22,,St Katharine Tower,6,1
+1666,15,May,22,,St Mary Newington,2,0
+1666,15,May,22,,Dunstan Stepney,15,2
+1666,15,May,22,,Lambeth Parish,10,7
+1666,15,May,22,,St Mary Whitechappel,6,2
+1666,15,May,22,,St Giles in the Fields,7,0
+1666,15,May,22,,St Leonard Shoreditch,3,0
+1666,15,May,22,,St. Paul Shadwel,0,0
+1666,15,May,22,,St James Clerkenwel,5,0
+1666,15,May,22,,St Mary Islington,1,0
+1666,15,May,22,,Rotherhith Parish,4,3
+1666,15,May,22,,John at Hackney,4,0
+1666,15,May,22,,St Mary Magd. Bermondsey,7,1
+1666,15,May,22,,St Ann Westminster,0,0
+1666,15,May,22,,St Margaret Westminster,8,3
+1666,15,May,22,,St Mary Savoy,0,0
+1666,15,May,22,,St Clement Danes,5,0
+1666,15,May,22,,St Martin in the Fields,5,0
+1666,15,May,22,,St Paul Covent Garden,0,0
+1666,15,May,22,,St James Westminster,0,0
+1666,22,May,29,,ALban Woodstreet,1,0
+1666,22,May,29,,St Gregory by St Paul,0,0
+1666,22,May,29,,St Mary Mounthaw,0,0
+1666,22,May,29,,Alhallows Barking,2,0
+1666,22,May,29,,St Hellen,0,0
+1666,22,May,29,,St Mary Sommerset,0,0
+1666,22,May,29,,Alhallows Breadstreet,0,0
+1666,22,May,29,,St James Dukes Place,0,0
+1666,22,May,29,,St Mary Staining,0,0
+1666,22,May,29,,Alhallows the Great,1,0
+1666,22,May,29,,St James Garlickhithe,1,1
+1666,22,May,29,,St Mary Woolchurch,0,0
+1666,22,May,29,,Alhallows Honylane,0,0
+1666,22,May,29,,St John Baptist,1,0
+1666,22,May,29,,St Mary Woolnoth,0,0
+1666,22,May,29,,Alhallows the Less,0,0
+1666,22,May,29,,St John Evangelist,0,0
+1666,22,May,29,,St Matthew Fridaystreet,0,0
+1666,22,May,29,,Alhallows Lombardstreet,1,0
+1666,22,May,29,,St John Zachary,0,0
+1666,22,May,29,,St Michael Bassishaw,0,0
+1666,22,May,29,,Alhallows Staining,1,0
+1666,22,May,29,,St Katharine Coleman,0,0
+1666,22,May,29,,St Michael Cornhil,0,0
+1666,22,May,29,,Alhallows the Wall,3,0
+1666,22,May,29,,St Katharine Creechurch,1,0
+1666,22,May,29,,St Michael Crookedlane,0,0
+1666,22,May,29,,St Alphage,0,0
+1666,22,May,29,,St Lawrence Jewry,1,0
+1666,22,May,29,,St Michael Queenhithe,0,0
+1666,22,May,29,,St Andrew Hubbard,0,0
+1666,22,May,29,,St Lawrence Pountney,1,0
+1666,22,May,29,,St Michael Quern,0,0
+1666,22,May,29,,St Andrew Undershaft,1,0
+1666,22,May,29,,St Leonard Eastcheap,0,0
+1666,22,May,29,,St Michael Royal,0,0
+1666,22,May,29,,St Andrew Wardrobe,0,0
+1666,22,May,29,,St Leonard Fosterlane,1,0
+1666,22,May,29,,St Michael Woodstreet,0,0
+1666,22,May,29,,St Ann Aldersgate,0,0
+1666,22,May,29,,St Magnus Parish,0,0
+1666,22,May,29,,St Mildred Breadstreet,0,0
+1666,22,May,29,,St Ann Blackfriers,5,3
+1666,22,May,29,,St Margaret Lothbury,0,0
+1666,22,May,29,,St Mildred Poultry,0,0
+1666,22,May,29,,St Anthony alias Antholin,0,0
+1666,22,May,29,,St Margaret Moses,1,0
+1666,22,May,29,,St Nicholas Acons,0,0
+1666,22,May,29,,St Austins Parish,1,0
+1666,22,May,29,,St Margaret Newfishstreet,1,0
+1666,22,May,29,,St Nicholas Coleabby,0,0
+1666,22,May,29,,St Bartholomew Exchange,0,0
+1666,22,May,29,,St Margaret Pattons,0,0
+1666,22,May,29,,St Nicholas Olaves,0,0
+1666,22,May,29,,St Bennet Finck,0,0
+1666,22,May,29,,St Martin Iremongerlane,0,0
+1666,22,May,29,,St Olave Hartstreet,0,0
+1666,22,May,29,,St Bennet Gracechurch,0,0
+1666,22,May,29,,St Martin Ludgate,0,0
+1666,22,May,29,,St Olave Jewry,0,0
+1666,22,May,29,,St Bennet Paulswharf,0,0
+1666,22,May,29,,St Martin Orgars,0,0
+1666,22,May,29,,St Olave Silverstreet,0,0
+1666,22,May,29,,St Bennet Sherehog,0,0
+1666,22,May,29,,St Martin Outwitch,1,0
+1666,22,May,29,,St Pancras Soperlane,0,0
+1666,22,May,29,,St Botolph Billingsgate,0,0
+1666,22,May,29,,St Martin Vintrey,1,0
+1666,22,May,29,,St Peter Cheap,0,0
+1666,22,May,29,,Christ's Church,4,0
+1666,22,May,29,,St Mary Abchurch,0,0
+1666,22,May,29,,St Peter Cornhil,2,0
+1666,22,May,29,,St Christophers,0,0
+1666,22,May,29,,St Mary Aldermanbury,0,0
+1666,22,May,29,,St Peter Paulswharf,0,0
+1666,22,May,29,,St Clement Eastcheap,2,0
+1666,22,May,29,,St Mary Aldermary,0,0
+1666,22,May,29,,St Peter Poor,1,0
+1666,22,May,29,,St Dionis Backchurch,0,0
+1666,22,May,29,,St Mary-le-bow,0,0
+1666,22,May,29,,St Steven Colemanstreet,0,0
+1666,22,May,29,,St Dunstan East,0,0
+1666,22,May,29,,St Mary Bothaw,0,0
+1666,22,May,29,,St Steven Walbrook,0,0
+1666,22,May,29,,St Edmund Lumbardstr.,0,0
+1666,22,May,29,,St Mary Colechurch,1,0
+1666,22,May,29,,St Swithin,0,0
+1666,22,May,29,,St Ethelburga,0,0
+1666,22,May,29,,St Mary Hill,0,0
+1666,22,May,29,,St Thomas Apostle,0,0
+1666,22,May,29,,St Faith,1,0
+1666,22,May,29,,St Mary Milkstreet,0,0
+1666,22,May,29,,Trinity Parish,0,0
+1666,22,May,29,,St Gabriel Fenchurch,0,0
+1666,22,May,29,,St Mary Mag. Oldfishstreet,1,0
+1666,22,May,29,,St Vedast alias Foster,0,0
+1666,22,May,29,,St George Botolphlane,0,0
+1666,22,May,29,,St Andrew Holborn,5,0
+1666,22,May,29,,St Botolph Aldgate,11,2
+1666,22,May,29,,Saviour Southwark,6,2
+1666,22,May,29,,St Bartholomew the Great,0,0
+1666,22,May,29,,St Botolph Bishopsgate,3,0
+1666,22,May,29,,St Sepulchres Parish,8,0
+1666,22,May,29,,St Bartholomew the Lesse,0,0
+1666,22,May,29,,St Dunstan West,3,0
+1666,22,May,29,,St Thomas Southwark,0,0
+1666,22,May,29,,St Bridget,5,0
+1666,22,May,29,,St George Southwark,1,0
+1666,22,May,29,,Trinity Minories,0,0
+1666,22,May,29,,Bridewel Precinct,0,0
+1666,22,May,29,,St Giles Cripplegate,13,0
+1666,22,May,29,,At the Pesthouse,0,0
+1666,22,May,29,,St Botolph Aldersgate,1,0
+1666,22,May,29,,St Olave Southwark,12,0
+1666,22,May,29,,St Katharine Tower,0,0
+1666,22,May,29,,St Mary Newington,3,0
+1666,22,May,29,,Dunstan Stepney,24,3
+1666,22,May,29,,Lambeth Parish,10,1
+1666,22,May,29,,St Mary Whitechappel,9,1
+1666,22,May,29,,St Giles in the Fields,3,0
+1666,22,May,29,,St Leonard Shoreditch,4,0
+1666,22,May,29,,St. Paul Shadwel,0,0
+1666,22,May,29,,St James Clerkenwel,2,0
+1666,22,May,29,,St Mary Islington,4,0
+1666,22,May,29,,Rotherhith Parish,7,2
+1666,22,May,29,,John at Hackney,3,0
+1666,22,May,29,,St Mary Magd. Bermondsey,5,4
+1666,22,May,29,,St Ann Westminster,0,0
+1666,22,May,29,,St Margaret Westminster,4,0
+1666,22,May,29,,St Mary Savoy,0,0
+1666,22,May,29,,St Clement Danes,5,0
+1666,22,May,29,,St Martin in the Fields,11,1
+1666,22,May,29,,St Paul Covent Garden,1,0
+1666,22,May,29,,St James Westminster,0,0
+1666,29,May,5,June,ALban Woodstreet,0,0
+1666,29,May,5,June,St Gregory by St Paul,1,0
+1666,29,May,5,June,St Mary Mounthaw,0,0
+1666,29,May,5,June,Alhallows Barking,2,0
+1666,29,May,5,June,St Hellen,0,0
+1666,29,May,5,June,St Mary Sommerset,1,0
+1666,29,May,5,June,Alhallows Breadstreet,0,0
+1666,29,May,5,June,St James Dukes Place,1,0
+1666,29,May,5,June,St Mary Staining,0,0
+1666,29,May,5,June,Alhallows the Great,0,0
+1666,29,May,5,June,St James Garlickhithe,0,0
+1666,29,May,5,June,St Mary Woolchurch,0,0
+1666,29,May,5,June,Alhallows Honylane,0,0
+1666,29,May,5,June,St John Baptist,1,0
+1666,29,May,5,June,St Mary Woolnoth,0,0
+1666,29,May,5,June,Alhallows the Less,0,0
+1666,29,May,5,June,St John Evangelist,0,0
+1666,29,May,5,June,St Matthew Fridaystreet,0,0
+1666,29,May,5,June,Alhallows Lombardstreet,0,0
+1666,29,May,5,June,St John Zachary,0,0
+1666,29,May,5,June,St Michael Bassishaw,0,0
+1666,29,May,5,June,Alhallows Staining,0,0
+1666,29,May,5,June,St Katharine Coleman,1,0
+1666,29,May,5,June,St Michael Cornhil,0,0
+1666,29,May,5,June,Alhallows the Wall,2,0
+1666,29,May,5,June,St Katharine Creechurch,1,0
+1666,29,May,5,June,St Michael Crookedlane,0,0
+1666,29,May,5,June,St Alphage,0,0
+1666,29,May,5,June,St Lawrence Jewry,0,0
+1666,29,May,5,June,St Michael Queenhithe,0,0
+1666,29,May,5,June,St Andrew Hubbard,2,0
+1666,29,May,5,June,St Lawrence Pountney,1,0
+1666,29,May,5,June,St Michael Quern,0,0
+1666,29,May,5,June,St Andrew Undershaft,2,0
+1666,29,May,5,June,St Leonard Eastcheap,0,0
+1666,29,May,5,June,St Michael Royal,0,0
+1666,29,May,5,June,St Andrew Wardrobe,1,0
+1666,29,May,5,June,St Leonard Fosterlane,0,0
+1666,29,May,5,June,St Michael Woodstreet,0,0
+1666,29,May,5,June,St Ann Aldersgate,1,0
+1666,29,May,5,June,St Magnus Parish,0,0
+1666,29,May,5,June,St Mildred Breadstreet,0,0
+1666,29,May,5,June,St Ann Blackfriers,2,0
+1666,29,May,5,June,St Margaret Lothbury,0,0
+1666,29,May,5,June,St Mildred Poultry,0,0
+1666,29,May,5,June,St Anthony alias Antholin,1,0
+1666,29,May,5,June,St Margaret Moses,0,0
+1666,29,May,5,June,St Nicholas Acons,0,0
+1666,29,May,5,June,St Austins Parish,0,0
+1666,29,May,5,June,St Margaret Newfishstreet,0,0
+1666,29,May,5,June,St Nicholas Coleabby,0,0
+1666,29,May,5,June,St Bartholomew Exchange,0,0
+1666,29,May,5,June,St Margaret Pattons,0,0
+1666,29,May,5,June,St Nicholas Olaves,0,0
+1666,29,May,5,June,St Bennet Finck,1,0
+1666,29,May,5,June,St Martin Iremongerlane,0,0
+1666,29,May,5,June,St Olave Hartstreet,0,0
+1666,29,May,5,June,St Bennet Gracechurch,0,0
+1666,29,May,5,June,St Martin Ludgate,0,0
+1666,29,May,5,June,St Olave Jewry,0,0
+1666,29,May,5,June,St Bennet Paulswharf,1,0
+1666,29,May,5,June,St Martin Orgars,1,0
+1666,29,May,5,June,St Olave Silverstreet,0,0
+1666,29,May,5,June,St Bennet Sherehog,0,0
+1666,29,May,5,June,St Martin Outwitch,0,0
+1666,29,May,5,June,St Pancras Soperlane,0,0
+1666,29,May,5,June,St Botolph Billingsgate,0,0
+1666,29,May,5,June,St Martin Vintrey,1,0
+1666,29,May,5,June,St Peter Cheap,0,0
+1666,29,May,5,June,Christ's Church,2,0
+1666,29,May,5,June,St Mary Abchurch,1,0
+1666,29,May,5,June,St Peter Cornhil,1,0
+1666,29,May,5,June,St Christophers,2,0
+1666,29,May,5,June,St Mary Aldermanbury,1,0
+1666,29,May,5,June,St Peter Paulswharf,0,0
+1666,29,May,5,June,St Clement Eastcheap,0,0
+1666,29,May,5,June,St Mary Aldermary,0,0
+1666,29,May,5,June,St Peter Poor,1,1
+1666,29,May,5,June,St Dionis Backchurch,0,0
+1666,29,May,5,June,St Mary-le-bow,0,0
+1666,29,May,5,June,St Steven Colemanstreet,1,0
+1666,29,May,5,June,St Dunstan East,1,0
+1666,29,May,5,June,St Mary Bothaw,0,0
+1666,29,May,5,June,St Steven Walbrook,0,0
+1666,29,May,5,June,St Edmund Lumbardstr.,0,0
+1666,29,May,5,June,St Mary Colechurch,0,0
+1666,29,May,5,June,St Swithin,1,0
+1666,29,May,5,June,St Ethelburga,0,0
+1666,29,May,5,June,St Mary Hill,1,0
+1666,29,May,5,June,St Thomas Apostle,0,0
+1666,29,May,5,June,St Faith,0,0
+1666,29,May,5,June,St Mary Milkstreet,0,0
+1666,29,May,5,June,Trinity Parish,0,0
+1666,29,May,5,June,St Gabriel Fenchurch,0,0
+1666,29,May,5,June,St Mary Mag. Oldfishstreet,1,0
+1666,29,May,5,June,St Vedast alias Foster,0,0
+1666,29,May,5,June,St George Botolphlane,0,0
+1666,29,May,5,June,St Andrew Holborn,10,0
+1666,29,May,5,June,St Botolph Aldgate,9,2
+1666,29,May,5,June,Saviour Southwark,5,1
+1666,29,May,5,June,St Bartholomew the Great,1,0
+1666,29,May,5,June,St Botolph Bishopsgate,4,0
+1666,29,May,5,June,St Sepulchres Parish,10,0
+1666,29,May,5,June,St Bartholomew the Lesse,0,0
+1666,29,May,5,June,St Dunstan West,3,1
+1666,29,May,5,June,St Thomas Southwark,0,0
+1666,29,May,5,June,St Bridget,2,1
+1666,29,May,5,June,St George Southwark,6,2
+1666,29,May,5,June,Trinity Minories,1,0
+1666,29,May,5,June,Bridewel Precinct,0,0
+1666,29,May,5,June,St Giles Cripplegate,8,0
+1666,29,May,5,June,At the Pesthouse,2,1
+1666,29,May,5,June,St Botolph Aldersgate,3,0
+1666,29,May,5,June,St Olave Southwark,6,0
+1666,29,May,5,June,...hritt Church,0,0
+1666,29,May,5,June,St Katharine Tower,0,0
+1666,29,May,5,June,St Mary Newington,2,0
+1666,29,May,5,June,Dunstan Stepney,17,2
+1666,29,May,5,June,Lambeth Parish,10,7
+1666,29,May,5,June,St Mary Whitechappel,6,1
+1666,29,May,5,June,St Giles in the Fields,6,2
+1666,29,May,5,June,St Leonard Shoreditch,1,0
+1666,29,May,5,June,St. Paul Shadwel,0,0
+1666,29,May,5,June,St James Clerkenwel,1,0
+1666,29,May,5,June,St Mary Islington,0,0
+1666,29,May,5,June,Rotherhith Parish,2,0
+1666,29,May,5,June,John at Hackney,5,2
+1666,29,May,5,June,St Mary Magd. Bermondsey,7,2
+1666,29,May,5,June,St Ann Westminster,0,0
+1666,29,May,5,June,St Margaret Westminster,6,1
+1666,29,May,5,June,St Mary Savoy,1,0
+1666,29,May,5,June,St Clement Danes,8,0
+1666,29,May,5,June,St Martin in the Fields,8,1
+1666,29,May,5,June,St Paul Covent Garden,0,0
+1666,29,May,5,June,St James Westminster,0,0
+1666,5,June,12,,ALban Woodstreet,0,0
+1666,5,June,12,,St Gregory by St Paul,0,0
+1666,5,June,12,,St Mary Mounthaw,0,0
+1666,5,June,12,,Alhallows Barking,2,0
+1666,5,June,12,,St Hellen,0,0
+1666,5,June,12,,St Mary Sommerset,0,0
+1666,5,June,12,,Alhallows Breadstreet,0,0
+1666,5,June,12,,St James Dukes Place,0,0
+1666,5,June,12,,St Mary Staining,0,0
+1666,5,June,12,,Alhallows the Great,0,0
+1666,5,June,12,,St James Garlickhithe,1,0
+1666,5,June,12,,St Mary Woolchurch,0,0
+1666,5,June,12,,Alhallows Honylane,0,0
+1666,5,June,12,,St John Baptist,1,0
+1666,5,June,12,,St Mary Woolnoth,0,0
+1666,5,June,12,,Alhallows the Less,0,0
+1666,5,June,12,,St John Evangelist,0,0
+1666,5,June,12,,St Matthew Fridaystreet,0,0
+1666,5,June,12,,Alhallows Lombardstreet,0,0
+1666,5,June,12,,St John Zachary,0,0
+1666,5,June,12,,St Michael Bassishaw,1,0
+1666,5,June,12,,Alhallows Staining,0,0
+1666,5,June,12,,St Katharine Coleman,0,0
+1666,5,June,12,,St Michael Cornhil,1,0
+1666,5,June,12,,Alhallows the Wall,3,0
+1666,5,June,12,,St Katharine Creechurch,0,0
+1666,5,June,12,,St Michael Crookedlane,1,0
+1666,5,June,12,,St Alphage,3,1
+1666,5,June,12,,St Lawrence Jewry,1,0
+1666,5,June,12,,St Michael Queenhithe,0,0
+1666,5,June,12,,St Andrew Hubbard,1,1
+1666,5,June,12,,St Lawrence Pountney,0,0
+1666,5,June,12,,St Michael Quern,0,0
+1666,5,June,12,,St Andrew Undershaft,0,0
+1666,5,June,12,,St Leonard Eastcheap,0,0
+1666,5,June,12,,St Michael Royal,0,0
+1666,5,June,12,,St Andrew Wardrobe,2,0
+1666,5,June,12,,St Leonard Fosterlane,0,0
+1666,5,June,12,,St Michael Woodstreet,0,0
+1666,5,June,12,,St Ann Aldersgate,0,0
+1666,5,June,12,,St Magnus Parish,2,0
+1666,5,June,12,,St Mildred Breadstreet,0,0
+1666,5,June,12,,St Ann Blackfriers,1,1
+1666,5,June,12,,St Margaret Lothbury,1,0
+1666,5,June,12,,St Mildred Poultry,0,0
+1666,5,June,12,,St Anthony alias Antholin,1,0
+1666,5,June,12,,St Margaret Moses,0,0
+1666,5,June,12,,St Nicholas Acons,0,0
+1666,5,June,12,,St Austins Parish,0,0
+1666,5,June,12,,St Margaret Newfishstreet,0,0
+1666,5,June,12,,St Nicholas Coleabby,1,0
+1666,5,June,12,,St Bartholomew Exchange,0,0
+1666,5,June,12,,St Margaret Pattons,1,0
+1666,5,June,12,,St Nicholas Olaves,0,0
+1666,5,June,12,,St Bennet Finck,0,0
+1666,5,June,12,,St Martin Iremongerlane,0,0
+1666,5,June,12,,St Olave Hartstreet,0,0
+1666,5,June,12,,St Bennet Gracechurch,0,0
+1666,5,June,12,,St Martin Ludgate,0,0
+1666,5,June,12,,St Olave Jewry,0,0
+1666,5,June,12,,St Bennet Paulswharf,1,0
+1666,5,June,12,,St Martin Orgars,0,0
+1666,5,June,12,,St Olave Silverstreet,1,0
+1666,5,June,12,,St Bennet Sherehog,0,0
+1666,5,June,12,,St Martin Outwitch,0,0
+1666,5,June,12,,St Pancras Soperlane,0,0
+1666,5,June,12,,St Botolph Billingsgate,0,0
+1666,5,June,12,,St Martin Vintrey,0,0
+1666,5,June,12,,St Peter Cheap,0,0
+1666,5,June,12,,Christ's Church,0,0
+1666,5,June,12,,St Mary Abchurch,0,0
+1666,5,June,12,,St Peter Cornhil,0,0
+1666,5,June,12,,St Christophers,0,0
+1666,5,June,12,,St Mary Aldermanbury,1,0
+1666,5,June,12,,St Peter Paulswharf,0,0
+1666,5,June,12,,St Clement Eastcheap,0,0
+1666,5,June,12,,St Mary Aldermary,0,0
+1666,5,June,12,,St Peter Poor,0,0
+1666,5,June,12,,St Dionis Backchurch,0,0
+1666,5,June,12,,St Mary-le-bow,0,0
+1666,5,June,12,,St Steven Colemanstreet,4,0
+1666,5,June,12,,St Dunstan East,1,1
+1666,5,June,12,,St Mary Bothaw,0,0
+1666,5,June,12,,St Steven Walbrook,1,0
+1666,5,June,12,,St Edmund Lumbardstr.,0,0
+1666,5,June,12,,St Mary Colechurch,0,0
+1666,5,June,12,,St Swithin,0,0
+1666,5,June,12,,St Ethelburga,0,0
+1666,5,June,12,,St Mary Hill,0,0
+1666,5,June,12,,St Thomas Apostle,4,3
+1666,5,June,12,,St Faith,0,0
+1666,5,June,12,,St Mary Milkstreet,0,0
+1666,5,June,12,,Trinity Parish,0,0
+1666,5,June,12,,St Gabriel Fenchurch,0,0
+1666,5,June,12,,St Mary Mag. Oldfishstreet,0,0
+1666,5,June,12,,St Vedast alias Foster,0,0
+1666,5,June,12,,St George Botolphlane,0,0
+1666,5,June,12,,St Andrew Holborn,12,0
+1666,5,June,12,,St Botolph Aldgate,6,3
+1666,5,June,12,,Saviour Southwark,8,0
+1666,5,June,12,,St Bartholomew the Great,1,0
+1666,5,June,12,,St Botolph Bishopsgate,8,2
+1666,5,June,12,,St Sepulchres Parish,4,0
+1666,5,June,12,,St Bartholomew the Lesse,0,0
+1666,5,June,12,,St Dunstan West,2,0
+1666,5,June,12,,St Thomas Southwark,0,0
+1666,5,June,12,,St Bridget,4,0
+1666,5,June,12,,St George Southwark,1,0
+1666,5,June,12,,Trinity Minories,0,0
+1666,5,June,12,,Bridewel Precinct,0,0
+1666,5,June,12,,St Giles Cripplegate,10,0
+1666,5,June,12,,At the Pesthouse,0,0
+1666,5,June,12,,St Botolph Aldersgate,1,0
+1666,5,June,12,,St Olave Southwark,10,0
+1666,5,June,12,,...hritt Church,0,0
+1666,5,June,12,,St Katharine Tower,5,1
+1666,5,June,12,,St Mary Newington,1,0
+1666,5,June,12,,Dunstan Stepney,20,2
+1666,5,June,12,,Lambeth Parish,13,9
+1666,5,June,12,,St Mary Whitechappel,10,0
+1666,5,June,12,,St Giles in the Fields,5,0
+1666,5,June,12,,St Leonard Shoreditch,0,0
+1666,5,June,12,,St. Paul Shadwel,0,0
+1666,5,June,12,,St James Clerkenwel,4,0
+1666,5,June,12,,St Mary Islington,3,1
+1666,5,June,12,,Rotherhith Parish,4,1
+1666,5,June,12,,John at Hackney,2,0
+1666,5,June,12,,St Mary Magd. Bermondsey,5,2
+1666,5,June,12,,St Ann Westminster,0,0
+1666,5,June,12,,St Margaret Westminster,10,1
+1666,5,June,12,,St Mary Savoy,0,0
+1666,5,June,12,,St Clement Danes,3,0
+1666,5,June,12,,St Martin in the Fields,6,2
+1666,5,June,12,,St Paul Covent Garden,0,0
+1666,5,June,12,,St James Westminster,0,0
+1666,12,June,19,,ALban Woodstreet,0,0
+1666,12,June,19,,St Gregory by St Paul,0,0
+1666,12,June,19,,St Mary Mounthaw,0,0
+1666,12,June,19,,Alhallows Barking,1,0
+1666,12,June,19,,St Hellen,0,0
+1666,12,June,19,,St Mary Sommerset,1,0
+1666,12,June,19,,Alhallows Breadstreet,0,0
+1666,12,June,19,,St James Dukes Place,0,0
+1666,12,June,19,,St Mary Staining,0,0
+1666,12,June,19,,Alhallows the Great,1,0
+1666,12,June,19,,St James Garlickhithe,0,0
+1666,12,June,19,,St Mary Woolchurch,0,0
+1666,12,June,19,,Alhallows Honylane,0,0
+1666,12,June,19,,St John Baptist,0,0
+1666,12,June,19,,St Mary Woolnoth,0,0
+1666,12,June,19,,Alhallows the Less,0,0
+1666,12,June,19,,St John Evangelist,0,0
+1666,12,June,19,,St Matthew Fridaystreet,0,0
+1666,12,June,19,,Alhallows Lombardstreet,0,0
+1666,12,June,19,,St John Zachary,2,0
+1666,12,June,19,,St Michael Bassishaw,1,0
+1666,12,June,19,,Alhallows Staining,2,0
+1666,12,June,19,,St Katharine Coleman,0,0
+1666,12,June,19,,St Michael Cornhil,0,0
+1666,12,June,19,,Alhallows the Wall,0,0
+1666,12,June,19,,St Katharine Creechurch,0,0
+1666,12,June,19,,St Michael Crookedlane,0,0
+1666,12,June,19,,St Alphage,0,0
+1666,12,June,19,,St Lawrence Jewry,0,0
+1666,12,June,19,,St Michael Queenhithe,0,0
+1666,12,June,19,,St Andrew Hubbard,0,0
+1666,12,June,19,,St Lawrence Pountney,0,0
+1666,12,June,19,,St Michael Quern,0,0
+1666,12,June,19,,St Andrew Undershaft,0,0
+1666,12,June,19,,St Leonard Eastcheap,0,0
+1666,12,June,19,,St Michael Royal,0,0
+1666,12,June,19,,St Andrew Wardrobe,0,0
+1666,12,June,19,,St Leonard Fosterlane,0,0
+1666,12,June,19,,St Michael Woodstreet,0,0
+1666,12,June,19,,St Ann Aldersgate,0,0
+1666,12,June,19,,St Magnus Parish,0,0
+1666,12,June,19,,St Mildred Breadstreet,0,0
+1666,12,June,19,,St Ann Blackfriers,1,1
+1666,12,June,19,,St Margaret Lothbury,1,0
+1666,12,June,19,,St Mildred Poultry,0,0
+1666,12,June,19,,St Anthony alias Antholin,1,0
+1666,12,June,19,,St Margaret Moses,0,0
+1666,12,June,19,,St Nicholas Acons,0,0
+1666,12,June,19,,St Austins Parish,0,0
+1666,12,June,19,,St Margaret Newfishstreet,0,0
+1666,12,June,19,,St Nicholas Coleabby,0,0
+1666,12,June,19,,St Bartholomew Exchange,1,0
+1666,12,June,19,,St Margaret Pattons,0,0
+1666,12,June,19,,St Nicholas Olaves,0,0
+1666,12,June,19,,St Bennet Finck,0,0
+1666,12,June,19,,St Martin Iremongerlane,0,0
+1666,12,June,19,,St Olave Hartstreet,1,0
+1666,12,June,19,,St Bennet Gracechurch,0,0
+1666,12,June,19,,St Martin Ludgate,3,0
+1666,12,June,19,,St Olave Jewry,1,1
+1666,12,June,19,,St Bennet Paulswharf,0,0
+1666,12,June,19,,St Martin Orgars,0,0
+1666,12,June,19,,St Olave Silverstreet,0,0
+1666,12,June,19,,St Bennet Sherehog,0,0
+1666,12,June,19,,St Martin Outwitch,0,0
+1666,12,June,19,,St Pancras Soperlane,0,0
+1666,12,June,19,,St Botolph Billingsgate,0,0
+1666,12,June,19,,St Martin Vintrey,0,0
+1666,12,June,19,,St Peter Cheap,0,0
+1666,12,June,19,,Christ's Church,1,0
+1666,12,June,19,,St Mary Abchurch,0,0
+1666,12,June,19,,St Peter Cornhil,0,0
+1666,12,June,19,,St Christophers,0,0
+1666,12,June,19,,St Mary Aldermanbury,1,0
+1666,12,June,19,,St Peter Paulswharf,0,0
+1666,12,June,19,,St Clement Eastcheap,0,0
+1666,12,June,19,,St Mary Aldermary,1,0
+1666,12,June,19,,St Peter Poor,0,0
+1666,12,June,19,,St Dionis Backchurch,0,0
+1666,12,June,19,,St Mary-le-bow,1,1
+1666,12,June,19,,St Steven Colemanstreet,1,0
+1666,12,June,19,,St Dunstan East,0,0
+1666,12,June,19,,St Mary Bothaw,0,0
+1666,12,June,19,,St Steven Walbrook,0,0
+1666,12,June,19,,St Edmund Lumbardstr.,1,0
+1666,12,June,19,,St Mary Colechurch,0,0
+1666,12,June,19,,St Swithin,0,0
+1666,12,June,19,,St Ethelburga,0,0
+1666,12,June,19,,St Mary Hill,0,0
+1666,12,June,19,,St Thomas Apostle,1,0
+1666,12,June,19,,St Faith,0,0
+1666,12,June,19,,St Mary Milkstreet,0,0
+1666,12,June,19,,Trinity Parish,1,0
+1666,12,June,19,,St Gabriel Fenchurch,1,0
+1666,12,June,19,,St Mary Mag. Oldfishstreet,1,0
+1666,12,June,19,,St Vedast alias Foster,1,0
+1666,12,June,19,,St George Botolphlane,0,0
+1666,12,June,19,,St Andrew Holborn,3,0
+1666,12,June,19,,St Botolph Aldgate,11,0
+1666,12,June,19,,Saviour Southwark,13,1
+1666,12,June,19,,St Bartholomew the Great,0,0
+1666,12,June,19,,St Botolph Bishopsgate,3,0
+1666,12,June,19,,St Sepulchres Parish,4,0
+1666,12,June,19,,St Bartholomew the Lesse,0,0
+1666,12,June,19,,St Dunstan West,3,0
+1666,12,June,19,,St Thomas Southwark,0,0
+1666,12,June,19,,St Bridget,4,0
+1666,12,June,19,,St George Southwark,0,0
+1666,12,June,19,,Trinity Minories,1,0
+1666,12,June,19,,Bridewel Precinct,0,0
+1666,12,June,19,,St Giles Cripplegate,8,0
+1666,12,June,19,,At the Pesthouse,0,0
+1666,12,June,19,,St Botolph Aldersgate,0,0
+1666,12,June,19,,St Olave Southwark,15,0
+1666,12,June,19,,...hritt Church,0,0
+1666,12,June,19,,St Katharine Tower,3,0
+1666,12,June,19,,St Mary Newington,3,0
+1666,12,June,19,,Dunstan Stepney,15,0
+1666,12,June,19,,Lambeth Parish,10,9
+1666,12,June,19,,St Mary Whitechappel,6,1
+1666,12,June,19,,St Giles in the Fields,5,0
+1666,12,June,19,,St Leonard Shoreditch,6,1
+1666,12,June,19,,St. Paul Shadwel,0,0
+1666,12,June,19,,St James Clerkenwel,4,0
+1666,12,June,19,,St Mary Islington,0,0
+1666,12,June,19,,Rotherhith Parish,2,0
+1666,12,June,19,,John at Hackney,0,0
+1666,12,June,19,,St Mary Magd. Bermondsey,8,4
+1666,12,June,19,,St Ann Westminster,0,0
+1666,12,June,19,,St Margaret Westminster,9,1
+1666,12,June,19,,St Mary Savoy,0,0
+1666,12,June,19,,St Clement Danes,5,3
+1666,12,June,19,,St Martin in the Fields,6,0
+1666,12,June,19,,St Paul Covent Garden,2,0
+1666,12,June,19,,St James Westminster,0,0
+1666,19,June,26,,ALban Woodstreet,0,0
+1666,19,June,26,,St Gregory by St Paul,1,0
+1666,19,June,26,,St Mary Mounthaw,0,0
+1666,19,June,26,,Alhallows Barking,0,0
+1666,19,June,26,,St Hellen,0,0
+1666,19,June,26,,St Mary Sommerset,0,0
+1666,19,June,26,,Alhallows Breadstreet,1,0
+1666,19,June,26,,St James Dukes Place,0,0
+1666,19,June,26,,St Mary Staining,0,0
+1666,19,June,26,,Alhallows the Great,1,0
+1666,19,June,26,,St James Garlickhithe,0,0
+1666,19,June,26,,St Mary Woolchurch,0,0
+1666,19,June,26,,Alhallows Honylane,0,0
+1666,19,June,26,,St John Baptist,0,0
+1666,19,June,26,,St Mary Woolnoth,0,0
+1666,19,June,26,,Alhallows the Less,0,0
+1666,19,June,26,,St John Evangelist,0,0
+1666,19,June,26,,St Matthew Fridaystreet,0,0
+1666,19,June,26,,Alhallows Lombardstreet,0,0
+1666,19,June,26,,St John Zachary,0,0
+1666,19,June,26,,St Michael Bassishaw,0,0
+1666,19,June,26,,Alhallows Staining,0,0
+1666,19,June,26,,St Katharine Coleman,0,0
+1666,19,June,26,,St Michael Cornhil,0,0
+1666,19,June,26,,Alhallows the Wall,2,0
+1666,19,June,26,,St Katharine Creechurch,0,0
+1666,19,June,26,,St Michael Crookedlane,0,0
+1666,19,June,26,,St Alphage,1,0
+1666,19,June,26,,St Lawrence Jewry,0,0
+1666,19,June,26,,St Michael Queenhithe,1,0
+1666,19,June,26,,St Andrew Hubbard,0,0
+1666,19,June,26,,St Lawrence Pountney,1,0
+1666,19,June,26,,St Michael Quern,0,0
+1666,19,June,26,,St Andrew Undershaft,1,0
+1666,19,June,26,,St Leonard Eastcheap,0,0
+1666,19,June,26,,St Michael Royal,1,0
+1666,19,June,26,,St Andrew Wardrobe,1,0
+1666,19,June,26,,St Leonard Fosterlane,2,0
+1666,19,June,26,,St Michael Woodstreet,0,0
+1666,19,June,26,,St Ann Aldersgate,0,0
+1666,19,June,26,,St Magnus Parish,0,0
+1666,19,June,26,,St Mildred Breadstreet,0,0
+1666,19,June,26,,St Ann Blackfriers,1,0
+1666,19,June,26,,St Margaret Lothbury,0,0
+1666,19,June,26,,St Mildred Poultry,0,0
+1666,19,June,26,,St Anthony alias Antholin,3,1
+1666,19,June,26,,St Margaret Moses,0,0
+1666,19,June,26,,St Nicholas Acons,0,0
+1666,19,June,26,,St Austins Parish,0,0
+1666,19,June,26,,St Margaret Newfishstreet,0,0
+1666,19,June,26,,St Nicholas Coleabby,0,0
+1666,19,June,26,,St Bartholomew Exchange,0,0
+1666,19,June,26,,St Margaret Pattons,0,0
+1666,19,June,26,,St Nicholas Olaves,0,0
+1666,19,June,26,,St Bennet Finck,0,0
+1666,19,June,26,,St Martin Iremongerlane,0,0
+1666,19,June,26,,St Olave Hartstreet,1,0
+1666,19,June,26,,St Bennet Gracechurch,0,0
+1666,19,June,26,,St Martin Ludgate,1,0
+1666,19,June,26,,St Olave Jewry,0,0
+1666,19,June,26,,St Bennet Paulswharf,0,0
+1666,19,June,26,,St Martin Orgars,1,0
+1666,19,June,26,,St Olave Silverstreet,1,0
+1666,19,June,26,,St Bennet Sherehog,0,0
+1666,19,June,26,,St Martin Outwitch,0,0
+1666,19,June,26,,St Pancras Soperlane,0,0
+1666,19,June,26,,St Botolph Billingsgate,0,0
+1666,19,June,26,,St Martin Vintrey,0,0
+1666,19,June,26,,St Peter Cheap,0,0
+1666,19,June,26,,Christ's Church,0,0
+1666,19,June,26,,St Mary Abchurch,0,0
+1666,19,June,26,,St Peter Cornhil,0,0
+1666,19,June,26,,St Christophers,1,0
+1666,19,June,26,,St Mary Aldermanbury,0,0
+1666,19,June,26,,St Peter Paulswharf,0,0
+1666,19,June,26,,St Clement Eastcheap,0,0
+1666,19,June,26,,St Mary Aldermary,0,0
+1666,19,June,26,,St Peter Poor,0,0
+1666,19,June,26,,St Dionis Backchurch,0,0
+1666,19,June,26,,St Mary-le-bow,0,0
+1666,19,June,26,,St Steven Colemanstreet,0,0
+1666,19,June,26,,St Dunstan East,2,1
+1666,19,June,26,,St Mary Bothaw,2,0
+1666,19,June,26,,St Steven Walbrook,0,0
+1666,19,June,26,,St Edmund Lumbardstr.,0,0
+1666,19,June,26,,St Mary Colechurch,0,0
+1666,19,June,26,,St Swithin,0,0
+1666,19,June,26,,St Ethelburga,1,0
+1666,19,June,26,,St Mary Hill,0,0
+1666,19,June,26,,St Thomas Apostle,0,0
+1666,19,June,26,,St Faith,1,0
+1666,19,June,26,,St Mary Milkstreet,0,0
+1666,19,June,26,,Trinity Parish,0,0
+1666,19,June,26,,St Gabriel Fenchurch,0,0
+1666,19,June,26,,St Mary Mag. Oldfishstreet,1,0
+1666,19,June,26,,St Vedast alias Foster,0,0
+1666,19,June,26,,St George Botolphlane,0,0
+1666,19,June,26,,St Andrew Holborn,5,0
+1666,19,June,26,,St Botolph Aldgate,15,7
+1666,19,June,26,,Saviour Southwark,12,1
+1666,19,June,26,,St Bartholomew the Great,0,0
+1666,19,June,26,,St Botolph Bishopsgate,5,0
+1666,19,June,26,,St Sepulchres Parish,8,0
+1666,19,June,26,,St Bartholomew the Lesse,0,0
+1666,19,June,26,,St Dunstan West,0,0
+1666,19,June,26,,St Thomas Southwark,1,0
+1666,19,June,26,,St Bridget,11,0
+1666,19,June,26,,St George Southwark,2,0
+1666,19,June,26,,Trinity Minories,2,1
+1666,19,June,26,,Bridewel Precinct,0,0
+1666,19,June,26,,St Giles Cripplegate,5,0
+1666,19,June,26,,At the Pesthouse,2,2
+1666,19,June,26,,St Botolph Aldersgate,3,0
+1666,19,June,26,,St Olave Southwark,9,0
+1666,19,June,26,,...hritt Church,0,0
+1666,19,June,26,,St Katharine Tower,5,0
+1666,19,June,26,,St Mary Newington,2,0
+1666,19,June,26,,Dunstan Stepney,20,1
+1666,19,June,26,,Lambeth Parish,9,6
+1666,19,June,26,,St Mary Whitechappel,7,2
+1666,19,June,26,,St Giles in the Fields,8,1
+1666,19,June,26,,St Leonard Shoreditch,9,0
+1666,19,June,26,,St. Paul Shadwel,0,0
+1666,19,June,26,,St James Clerkenwel,7,0
+1666,19,June,26,,St Mary Islington,0,0
+1666,19,June,26,,Rotherhith Parish,1,1
+1666,19,June,26,,John at Hackney,2,0
+1666,19,June,26,,St Mary Magd. Bermondsey,10,6
+1666,19,June,26,,St Ann Westminster,0,0
+1666,19,June,26,,St Margaret Westminster,10,3
+1666,19,June,26,,St Mary Savoy,2,0
+1666,19,June,26,,St Clement Danes,4,0
+1666,19,June,26,,St Martin in the Fields,16,0
+1666,19,June,26,,St Paul Covent Garden,0,0
+1666,19,June,26,,St James Westminster,0,0
+1666,26,June,3,July,ALban Woodstreet,0,0
+1666,26,June,3,July,St Gregory by St Paul,1,0
+1666,26,June,3,July,St Mary Mounthaw,0,0
+1666,26,June,3,July,Alhallows Barking,1,0
+1666,26,June,3,July,St Hellen,1,0
+1666,26,June,3,July,St Mary Sommerset,2,0
+1666,26,June,3,July,Alhallows Breadstreet,0,0
+1666,26,June,3,July,St James Dukes Place,0,0
+1666,26,June,3,July,St Mary Staining,0,0
+1666,26,June,3,July,Alhallows the Great,0,0
+1666,26,June,3,July,St James Garlickhithe,0,0
+1666,26,June,3,July,St Mary Woolchurch,0,0
+1666,26,June,3,July,Alhallows Honylane,0,0
+1666,26,June,3,July,St John Baptist,0,0
+1666,26,June,3,July,St Mary Woolnoth,0,0
+1666,26,June,3,July,Alhallows the Less,0,0
+1666,26,June,3,July,St John Evangelist,0,0
+1666,26,June,3,July,St Matthew Fridaystreet,0,0
+1666,26,June,3,July,Alhallows Lombardstreet,0,0
+1666,26,June,3,July,St John Zachary,0,0
+1666,26,June,3,July,St Michael Bassishaw,0,0
+1666,26,June,3,July,Alhallows Staining,1,0
+1666,26,June,3,July,St Katharine Coleman,2,0
+1666,26,June,3,July,St Michael Cornhil,0,0
+1666,26,June,3,July,Alhallows the Wall,1,0
+1666,26,June,3,July,St Katharine Creechurch,1,0
+1666,26,June,3,July,St Michael Crookedlane,0,0
+1666,26,June,3,July,St Alphage,0,0
+1666,26,June,3,July,St Lawrence Jewry,0,0
+1666,26,June,3,July,St Michael Queenhithe,1,0
+1666,26,June,3,July,St Andrew Hubbard,0,0
+1666,26,June,3,July,St Lawrence Pountney,1,0
+1666,26,June,3,July,St Michael Quern,1,0
+1666,26,June,3,July,St Andrew Undershaft,3,0
+1666,26,June,3,July,St Leonard Eastcheap,1,0
+1666,26,June,3,July,St Michael Royal,1,0
+1666,26,June,3,July,St Andrew Wardrobe,0,0
+1666,26,June,3,July,St Leonard Fosterlane,0,0
+1666,26,June,3,July,St Michael Woodstreet,0,0
+1666,26,June,3,July,St Ann Aldersgate,0,0
+1666,26,June,3,July,St Magnus Parish,0,0
+1666,26,June,3,July,St Mildred Breadstreet,0,0
+1666,26,June,3,July,St Ann Blackfriers,3,0
+1666,26,June,3,July,St Margaret Lothbury,0,0
+1666,26,June,3,July,St Mildred Poultry,0,0
+1666,26,June,3,July,St Anthony alias Antholin,0,0
+1666,26,June,3,July,St Margaret Moses,0,0
+1666,26,June,3,July,St Nicholas Acons,1,0
+1666,26,June,3,July,St Austins Parish,0,0
+1666,26,June,3,July,St Margaret Newfishstreet,1,0
+1666,26,June,3,July,St Nicholas Coleabby,0,0
+1666,26,June,3,July,St Bartholomew Exchange,0,0
+1666,26,June,3,July,St Margaret Pattons,1,0
+1666,26,June,3,July,St Nicholas Olaves,0,0
+1666,26,June,3,July,St Bennet Finck,0,0
+1666,26,June,3,July,St Martin Iremongerlane,1,0
+1666,26,June,3,July,St Olave Hartstreet,0,0
+1666,26,June,3,July,St Bennet Gracechurch,1,0
+1666,26,June,3,July,St Martin Ludgate,0,0
+1666,26,June,3,July,St Olave Jewry,0,0
+1666,26,June,3,July,St Bennet Paulswharf,1,0
+1666,26,June,3,July,St Martin Orgars,0,0
+1666,26,June,3,July,St Olave Silverstreet,1,1
+1666,26,June,3,July,St Bennet Sherehog,0,0
+1666,26,June,3,July,St Martin Outwitch,0,0
+1666,26,June,3,July,St Pancras Soperlane,2,0
+1666,26,June,3,July,St Botolph Billingsgate,0,0
+1666,26,June,3,July,St Martin Vintrey,0,0
+1666,26,June,3,July,St Peter Cheap,0,0
+1666,26,June,3,July,Christ's Church,0,0
+1666,26,June,3,July,St Mary Abchurch,0,0
+1666,26,June,3,July,St Peter Cornhil,1,1
+1666,26,June,3,July,St Christophers,0,0
+1666,26,June,3,July,St Mary Aldermanbury,0,0
+1666,26,June,3,July,St Peter Paulswharf,0,0
+1666,26,June,3,July,St Clement Eastcheap,0,0
+1666,26,June,3,July,St Mary Aldermary,0,0
+1666,26,June,3,July,St Peter Poor,2,1
+1666,26,June,3,July,St Dionis Backchurch,0,0
+1666,26,June,3,July,St Mary-le-bow,0,0
+1666,26,June,3,July,St Steven Colemanstreet,0,0
+1666,26,June,3,July,St Dunstan East,4,0
+1666,26,June,3,July,St Mary Bothaw,0,0
+1666,26,June,3,July,St Steven Walbrook,0,0
+1666,26,June,3,July,St Edmund Lumbardstr.,0,0
+1666,26,June,3,July,St Mary Colechurch,0,0
+1666,26,June,3,July,St Swithin,0,0
+1666,26,June,3,July,St Ethelburga,0,0
+1666,26,June,3,July,St Mary Hill,1,0
+1666,26,June,3,July,St Thomas Apostle,1,0
+1666,26,June,3,July,St Faith,0,0
+1666,26,June,3,July,St Mary Milkstreet,0,0
+1666,26,June,3,July,Trinity Parish,2,0
+1666,26,June,3,July,St Gabriel Fenchurch,0,0
+1666,26,June,3,July,St Mary Mag. Oldfishstreet,0,0
+1666,26,June,3,July,St Vedast alias Foster,0,0
+1666,26,June,3,July,St George Botolphlane,0,0
+1666,26,June,3,July,St Andrew Holborn,8,1
+1666,26,June,3,July,St Botolph Aldgate,7,3
+1666,26,June,3,July,Saviour Southwark,8,3
+1666,26,June,3,July,St Bartholomew the Great,1,0
+1666,26,June,3,July,St Botolph Bishopsgate,8,0
+1666,26,June,3,July,St Sepulchres Parish,7,0
+1666,26,June,3,July,St Bartholomew the Lesse,2,0
+1666,26,June,3,July,St Dunstan West,0,0
+1666,26,June,3,July,St Thomas Southwark,2,0
+1666,26,June,3,July,St Bridget,3,0
+1666,26,June,3,July,St George Southwark,6,0
+1666,26,June,3,July,Trinity Minories,0,0
+1666,26,June,3,July,Bridewel Precinct,0,0
+1666,26,June,3,July,St Giles Cripplegate,6,0
+1666,26,June,3,July,At the Pesthouse,0,0
+1666,26,June,3,July,St Botolph Aldersgate,1,0
+1666,26,June,3,July,St Olave Southwark,9,0
+1666,26,June,3,July,...hritt Church,0,0
+1666,26,June,3,July,St Katharine Tower,7,0
+1666,26,June,3,July,St Mary Newington,1,0
+1666,26,June,3,July,Dunstan Stepney,27,3
+1666,26,June,3,July,Lambeth Parish,16,11
+1666,26,June,3,July,St Mary Whitechappel,8,1
+1666,26,June,3,July,St Giles in the Fields,10,2
+1666,26,June,3,July,St Leonard Shoreditch,3,0
+1666,26,June,3,July,St. Paul Shadwel,2,1
+1666,26,June,3,July,St James Clerkenwel,2,0
+1666,26,June,3,July,St Mary Islington,1,0
+1666,26,June,3,July,Rotherhith Parish,0,0
+1666,26,June,3,July,John at Hackney,1,0
+1666,26,June,3,July,St Mary Magd. Bermondsey,11,4
+1666,26,June,3,July,St Ann Westminster,0,0
+1666,26,June,3,July,St Margaret Westminster,10,1
+1666,26,June,3,July,St Mary Savoy,0,0
+1666,26,June,3,July,St Clement Danes,5,2
+1666,26,June,3,July,St Martin in the Fields,9,0
+1666,26,June,3,July,St Paul Covent Garden,0,0
+1666,26,June,3,July,St James Westminster,0,0
+1666,3,July,10,,ALban Woodstreet,1,0
+1666,3,July,10,,St Gregory by St Paul,0,0
+1666,3,July,10,,St Mary Mounthaw,0,0
+1666,3,July,10,,Alhallows Barking,1,0
+1666,3,July,10,,St Hellen,1,0
+1666,3,July,10,,St Mary Sommerset,1,0
+1666,3,July,10,,Alhallows Breadstreet,0,0
+1666,3,July,10,,St James Dukes Place,0,0
+1666,3,July,10,,St Mary Staining,0,0
+1666,3,July,10,,Alhallows the Great,0,0
+1666,3,July,10,,St James Garlickhithe,0,0
+1666,3,July,10,,St Mary Woolchurch,0,0
+1666,3,July,10,,Alhallows Honylane,0,0
+1666,3,July,10,,St John Baptist,2,0
+1666,3,July,10,,St Mary Woolnoth,1,0
+1666,3,July,10,,Alhallows the Less,0,0
+1666,3,July,10,,St John Evangelist,0,0
+1666,3,July,10,,St Matthew Fridaystreet,0,0
+1666,3,July,10,,Alhallows Lombardstreet,0,0
+1666,3,July,10,,St John Zachary,1,0
+1666,3,July,10,,St Michael Bassishaw,0,0
+1666,3,July,10,,Alhallows Staining,0,0
+1666,3,July,10,,St Katharine Coleman,0,0
+1666,3,July,10,,St Michael Cornhil,1,0
+1666,3,July,10,,Alhallows the Wall,0,0
+1666,3,July,10,,St Katharine Creechurch,3,0
+1666,3,July,10,,St Michael Crookedlane,1,0
+1666,3,July,10,,St Alphage,0,0
+1666,3,July,10,,St Lawrence Jewry,0,0
+1666,3,July,10,,St Michael Queenhithe,1,0
+1666,3,July,10,,St Andrew Hubbard,0,0
+1666,3,July,10,,St Lawrence Pountney,1,0
+1666,3,July,10,,St Michael Quern,1,0
+1666,3,July,10,,St Andrew Undershaft,1,0
+1666,3,July,10,,St Leonard Eastcheap,0,0
+1666,3,July,10,,St Michael Royal,0,0
+1666,3,July,10,,St Andrew Wardrobe,1,0
+1666,3,July,10,,St Leonard Fosterlane,1,0
+1666,3,July,10,,St Michael Woodstreet,1,0
+1666,3,July,10,,St Ann Aldersgate,1,0
+1666,3,July,10,,St Magnus Parish,0,0
+1666,3,July,10,,St Mildred Breadstreet,0,0
+1666,3,July,10,,St Ann Blackfriers,1,0
+1666,3,July,10,,St Margaret Lothbury,2,0
+1666,3,July,10,,St Mildred Poultry,1,0
+1666,3,July,10,,St Anthony alias Antholin,1,1
+1666,3,July,10,,St Margaret Moses,0,0
+1666,3,July,10,,St Nicholas Acons,0,0
+1666,3,July,10,,St Austins Parish,1,0
+1666,3,July,10,,St Margaret Newfishstreet,1,0
+1666,3,July,10,,St Nicholas Coleabby,0,0
+1666,3,July,10,,St Bartholomew Exchange,0,0
+1666,3,July,10,,St Margaret Pattons,0,0
+1666,3,July,10,,St Nicholas Olaves,0,0
+1666,3,July,10,,St Bennet Finck,0,0
+1666,3,July,10,,St Martin Iremongerlane,0,0
+1666,3,July,10,,St Olave Hartstreet,0,0
+1666,3,July,10,,St Bennet Gracechurch,0,0
+1666,3,July,10,,St Martin Ludgate,0,0
+1666,3,July,10,,St Olave Jewry,1,0
+1666,3,July,10,,St Bennet Paulswharf,1,0
+1666,3,July,10,,St Martin Orgars,0,0
+1666,3,July,10,,St Olave Silverstreet,1,0
+1666,3,July,10,,St Bennet Sherehog,0,0
+1666,3,July,10,,St Martin Outwitch,0,0
+1666,3,July,10,,St Pancras Soperlane,0,0
+1666,3,July,10,,St Botolph Billingsgate,0,0
+1666,3,July,10,,St Martin Vintrey,3,1
+1666,3,July,10,,St Peter Cheap,1,0
+1666,3,July,10,,Christ's Church,3,1
+1666,3,July,10,,St Mary Abchurch,0,0
+1666,3,July,10,,St Peter Cornhil,2,0
+1666,3,July,10,,St Christophers,0,0
+1666,3,July,10,,St Mary Aldermanbury,0,0
+1666,3,July,10,,St Peter Paulswharf,0,0
+1666,3,July,10,,St Clement Eastcheap,0,0
+1666,3,July,10,,St Mary Aldermary,0,0
+1666,3,July,10,,St Peter Poor,0,0
+1666,3,July,10,,St Dionis Backchurch,1,0
+1666,3,July,10,,St Mary-le-bow,0,0
+1666,3,July,10,,St Steven Colemanstreet,1,1
+1666,3,July,10,,St Dunstan East,5,0
+1666,3,July,10,,St Mary Bothaw,0,0
+1666,3,July,10,,St Steven Walbrook,2,0
+1666,3,July,10,,St Edmund Lumbardstr.,0,0
+1666,3,July,10,,St Mary Colechurch,0,0
+1666,3,July,10,,St Swithin,0,0
+1666,3,July,10,,St Ethelburga,0,0
+1666,3,July,10,,St Mary Hill,0,0
+1666,3,July,10,,St Thomas Apostle,0,0
+1666,3,July,10,,St Faith,0,0
+1666,3,July,10,,St Mary Milkstreet,0,0
+1666,3,July,10,,Trinity Parish,0,0
+1666,3,July,10,,St Gabriel Fenchurch,0,0
+1666,3,July,10,,St Mary Mag. Oldfishstreet,1,0
+1666,3,July,10,,St Vedast alias Foster,0,0
+1666,3,July,10,,St George Botolphlane,0,0
+1666,3,July,10,,St Andrew Holborn,8,0
+1666,3,July,10,,St Botolph Aldgate,13,4
+1666,3,July,10,,Saviour Southwark,6,2
+1666,3,July,10,,St Bartholomew the Great,0,0
+1666,3,July,10,,St Botolph Bishopsgate,2,0
+1666,3,July,10,,St Sepulchres Parish,6,0
+1666,3,July,10,,St Bartholomew the Lesse,0,0
+1666,3,July,10,,St Dunstan West,1,0
+1666,3,July,10,,St Thomas Southwark,1,0
+1666,3,July,10,,St Bridget,5,0
+1666,3,July,10,,St George Southwark,2,0
+1666,3,July,10,,Trinity Minories,1,0
+1666,3,July,10,,Bridewel Precinct,1,0
+1666,3,July,10,,St Giles Cripplegate,15,1
+1666,3,July,10,,At the Pesthouse,2,2
+1666,3,July,10,,St Botolph Aldersgate,1,0
+1666,3,July,10,,St Olave Southwark,8,1
+1666,3,July,10,,...hritt Church,0,0
+1666,3,July,10,,St Katharine Tower,1,0
+1666,3,July,10,,St Mary Newington,2,0
+1666,3,July,10,,Dunstan Stepney,35,1
+1666,3,July,10,,Lambeth Parish,9,4
+1666,3,July,10,,St Mary Whitechappel,12,4
+1666,3,July,10,,St Giles in the Fields,8,1
+1666,3,July,10,,St Leonard Shoreditch,4,0
+1666,3,July,10,,St. Paul Shadwel,0,0
+1666,3,July,10,,St James Clerkenwel,5,0
+1666,3,July,10,,St Mary Islington,0,0
+1666,3,July,10,,Rotherhith Parish,2,0
+1666,3,July,10,,John at Hackney,2,1
+1666,3,July,10,,St Mary Magd. Bermondsey,10,2
+1666,3,July,10,,St Ann Westminster,0,0
+1666,3,July,10,,St Margaret Westminster,9,1
+1666,3,July,10,,St Mary Savoy,0,0
+1666,3,July,10,,St Clement Danes,9,5
+1666,3,July,10,,St Martin in the Fields,15,0
+1666,3,July,10,,St Paul Covent Garden,1,0
+1666,3,July,10,,St James Westminster,0,0
+1666,10,July,17,,ALban Woodstreet,1,0
+1666,10,July,17,,St Gregory by St Paul,1,0
+1666,10,July,17,,St Mary Mounthaw,2,0
+1666,10,July,17,,Alhallows Barking,4,0
+1666,10,July,17,,St Hellen,0,0
+1666,10,July,17,,St Mary Sommerset,0,0
+1666,10,July,17,,Alhallows Breadstreet,0,0
+1666,10,July,17,,St James Dukes Place,1,1
+1666,10,July,17,,St Mary Staining,0,0
+1666,10,July,17,,Alhallows the Great,1,0
+1666,10,July,17,,St James Garlickhithe,0,0
+1666,10,July,17,,St Mary Woolchurch,0,0
+1666,10,July,17,,Alhallows Honylane,0,0
+1666,10,July,17,,St John Baptist,1,0
+1666,10,July,17,,St Mary Woolnoth,0,0
+1666,10,July,17,,Alhallows the Less,0,0
+1666,10,July,17,,St John Evangelist,0,0
+1666,10,July,17,,St Matthew Fridaystreet,0,0
+1666,10,July,17,,Alhallows Lombardstreet,2,0
+1666,10,July,17,,St John Zachary,2,0
+1666,10,July,17,,St Michael Bassishaw,0,0
+1666,10,July,17,,Alhallows Staining,0,0
+1666,10,July,17,,St Katharine Coleman,0,0
+1666,10,July,17,,St Michael Cornhil,1,0
+1666,10,July,17,,Alhallows the Wall,0,0
+1666,10,July,17,,St Katharine Creechurch,3,0
+1666,10,July,17,,St Michael Crookedlane,0,0
+1666,10,July,17,,St Alphage,0,0
+1666,10,July,17,,St Lawrence Jewry,0,0
+1666,10,July,17,,St Michael Queenhithe,2,0
+1666,10,July,17,,St Andrew Hubbard,0,0
+1666,10,July,17,,St Lawrence Pountney,0,0
+1666,10,July,17,,St Michael Quern,0,0
+1666,10,July,17,,St Andrew Undershaft,0,0
+1666,10,July,17,,St Leonard Eastcheap,0,0
+1666,10,July,17,,St Michael Royal,0,0
+1666,10,July,17,,St Andrew Wardrobe,3,0
+1666,10,July,17,,St Leonard Fosterlane,0,0
+1666,10,July,17,,St Michael Woodstreet,0,0
+1666,10,July,17,,St Ann Aldersgate,2,0
+1666,10,July,17,,St Magnus Parish,1,0
+1666,10,July,17,,St Mildred Breadstreet,0,0
+1666,10,July,17,,St Ann Blackfriers,2,1
+1666,10,July,17,,St Margaret Lothbury,0,0
+1666,10,July,17,,St Mildred Poultry,1,0
+1666,10,July,17,,St Anthony alias Antholin,0,0
+1666,10,July,17,,St Margaret Moses,0,0
+1666,10,July,17,,St Nicholas Acons,0,0
+1666,10,July,17,,St Austins Parish,0,0
+1666,10,July,17,,St Margaret Newfishstreet,0,0
+1666,10,July,17,,St Nicholas Coleabby,0,0
+1666,10,July,17,,St Bartholomew Exchange,0,0
+1666,10,July,17,,St Margaret Pattons,2,0
+1666,10,July,17,,St Nicholas Olaves,0,0
+1666,10,July,17,,St Bennet Finck,0,0
+1666,10,July,17,,St Martin Iremongerlane,0,0
+1666,10,July,17,,St Olave Hartstreet,0,0
+1666,10,July,17,,St Bennet Gracechurch,0,0
+1666,10,July,17,,St Martin Ludgate,0,0
+1666,10,July,17,,St Olave Jewry,0,0
+1666,10,July,17,,St Bennet Paulswharf,0,0
+1666,10,July,17,,St Martin Orgars,0,0
+1666,10,July,17,,St Olave Silverstreet,0,0
+1666,10,July,17,,St Bennet Sherehog,0,0
+1666,10,July,17,,St Martin Outwitch,0,0
+1666,10,July,17,,St Pancras Soperlane,0,0
+1666,10,July,17,,St Botolph Billingsgate,1,0
+1666,10,July,17,,St Martin Vintrey,1,0
+1666,10,July,17,,St Peter Cheap,0,0
+1666,10,July,17,,Christ's Church,1,0
+1666,10,July,17,,St Mary Abchurch,1,0
+1666,10,July,17,,St Peter Cornhil,0,0
+1666,10,July,17,,St Christophers,0,0
+1666,10,July,17,,St Mary Aldermanbury,0,0
+1666,10,July,17,,St Peter Paulswharf,1,0
+1666,10,July,17,,St Clement Eastcheap,0,0
+1666,10,July,17,,St Mary Aldermary,1,0
+1666,10,July,17,,St Peter Poor,1,0
+1666,10,July,17,,St Dionis Backchurch,0,0
+1666,10,July,17,,St Mary-le-bow,2,0
+1666,10,July,17,,St Steven Colemanstreet,2,0
+1666,10,July,17,,St Dunstan East,0,0
+1666,10,July,17,,St Mary Bothaw,1,0
+1666,10,July,17,,St Steven Walbrook,0,0
+1666,10,July,17,,St Edmund Lumbardstr.,0,0
+1666,10,July,17,,St Mary Colechurch,0,0
+1666,10,July,17,,St Swithin,0,0
+1666,10,July,17,,St Ethelburga,0,0
+1666,10,July,17,,St Mary Hill,0,0
+1666,10,July,17,,St Thomas Apostle,0,0
+1666,10,July,17,,St Faith,1,0
+1666,10,July,17,,St Mary Milkstreet,0,0
+1666,10,July,17,,Trinity Parish,1,0
+1666,10,July,17,,St Gabriel Fenchurch,0,0
+1666,10,July,17,,St Mary Mag. Oldfishstreet,0,0
+1666,10,July,17,,St Vedast alias Foster,0,0
+1666,10,July,17,,St George Botolphlane,0,0
+1666,10,July,17,,St Andrew Holborn,6,0
+1666,10,July,17,,St Botolph Aldgate,12,2
+1666,10,July,17,,Saviour Southwark,12,2
+1666,10,July,17,,St Bartholomew the Great,3,3
+1666,10,July,17,,St Botolph Bishopsgate,5,0
+1666,10,July,17,,St Sepulchres Parish,6,0
+1666,10,July,17,,St Bartholomew the Lesse,0,0
+1666,10,July,17,,St Dunstan West,1,0
+1666,10,July,17,,St Thomas Southwark,0,0
+1666,10,July,17,,St Bridget,2,0
+1666,10,July,17,,St George Southwark,6,0
+1666,10,July,17,,Trinity Minories,0,0
+1666,10,July,17,,Bridewel Precinct,0,0
+1666,10,July,17,,St Giles Cripplegate,14,0
+1666,10,July,17,,At the Pesthouse,1,1
+1666,10,July,17,,St Botolph Aldersgate,3,0
+1666,10,July,17,,St Olave Southwark,13,0
+1666,10,July,17,,...hritt Church,0,0
+1666,10,July,17,,St Katharine Tower,8,1
+1666,10,July,17,,St Mary Newington,2,0
+1666,10,July,17,,Dunstan Stepney,36,2
+1666,10,July,17,,Lambeth Parish,21,16
+1666,10,July,17,,St Mary Whitechappel,12,3
+1666,10,July,17,,St Giles in the Fields,15,2
+1666,10,July,17,,St Leonard Shoreditch,7,2
+1666,10,July,17,,St. Paul Shadwel,0,0
+1666,10,July,17,,St James Clerkenwel,5,0
+1666,10,July,17,,St Mary Islington,0,0
+1666,10,July,17,,Rotherhith Parish,10,4
+1666,10,July,17,,John at Hackney,1,1
+1666,10,July,17,,St Mary Magd. Bermondsey,13,7
+1666,10,July,17,,St Ann Westminster,0,0
+1666,10,July,17,,St Margaret Westminster,8,3
+1666,10,July,17,,St Mary Savoy,2,0
+1666,10,July,17,,St Clement Danes,6,0
+1666,10,July,17,,St Martin in the Fields,13,0
+1666,10,July,17,,St Paul Covent Garden,3,0
+1666,10,July,17,,St James Westminster,0,0
+1666,17,July,24,,ALban Woodstreet,2,0
+1666,17,July,24,,St Gregory by St Paul,0,0
+1666,17,July,24,,St Mary Mounthaw,0,0
+1666,17,July,24,,Alhallows Barking,2,0
+1666,17,July,24,,St Hellen,1,0
+1666,17,July,24,,St Mary Sommerset,1,0
+1666,17,July,24,,Alhallows Breadstreet,0,0
+1666,17,July,24,,St James Dukes Place,3,1
+1666,17,July,24,,St Mary Staining,0,0
+1666,17,July,24,,Alhallows the Great,2,0
+1666,17,July,24,,St James Garlickhithe,2,0
+1666,17,July,24,,St Mary Woolchurch,0,0
+1666,17,July,24,,Alhallows Honylane,0,0
+1666,17,July,24,,St John Baptist,0,0
+1666,17,July,24,,St Mary Woolnoth,0,0
+1666,17,July,24,,Alhallows the Less,0,0
+1666,17,July,24,,St John Evangelist,0,0
+1666,17,July,24,,St Matthew Fridaystreet,0,0
+1666,17,July,24,,Alhallows Lombardstreet,0,0
+1666,17,July,24,,St John Zachary,0,0
+1666,17,July,24,,St Michael Bassishaw,0,0
+1666,17,July,24,,Alhallows Staining,3,2
+1666,17,July,24,,St Katharine Coleman,0,0
+1666,17,July,24,,St Michael Cornhil,0,0
+1666,17,July,24,,Alhallows the Wall,1,0
+1666,17,July,24,,St Katharine Creechurch,2,0
+1666,17,July,24,,St Michael Crookedlane,1,0
+1666,17,July,24,,St Alphage,0,0
+1666,17,July,24,,St Lawrence Jewry,0,0
+1666,17,July,24,,St Michael Queenhithe,0,0
+1666,17,July,24,,St Andrew Hubbard,2,0
+1666,17,July,24,,St Lawrence Pountney,0,0
+1666,17,July,24,,St Michael Quern,1,0
+1666,17,July,24,,St Andrew Undershaft,0,0
+1666,17,July,24,,St Leonard Eastcheap,0,0
+1666,17,July,24,,St Michael Royal,1,0
+1666,17,July,24,,St Andrew Wardrobe,2,1
+1666,17,July,24,,St Leonard Fosterlane,0,0
+1666,17,July,24,,St Michael Woodstreet,1,0
+1666,17,July,24,,St Ann Aldersgate,2,0
+1666,17,July,24,,St Magnus Parish,0,0
+1666,17,July,24,,St Mildred Breadstreet,0,0
+1666,17,July,24,,St Ann Blackfriers,3,0
+1666,17,July,24,,St Margaret Lothbury,0,0
+1666,17,July,24,,St Mildred Poultry,2,0
+1666,17,July,24,,St Anthony alias Antholin,1,0
+1666,17,July,24,,St Margaret Moses,0,0
+1666,17,July,24,,St Nicholas Acons,0,0
+1666,17,July,24,,St Austins Parish,0,0
+1666,17,July,24,,St Margaret Newfishstreet,0,0
+1666,17,July,24,,St Nicholas Coleabby,0,0
+1666,17,July,24,,St Bartholomew Exchange,1,1
+1666,17,July,24,,St Margaret Pattons,2,0
+1666,17,July,24,,St Nicholas Olaves,0,0
+1666,17,July,24,,St Bennet Finck,0,0
+1666,17,July,24,,St Martin Iremongerlane,0,0
+1666,17,July,24,,St Olave Hartstreet,0,0
+1666,17,July,24,,St Bennet Gracechurch,0,0
+1666,17,July,24,,St Martin Ludgate,1,0
+1666,17,July,24,,St Olave Jewry,0,0
+1666,17,July,24,,St Bennet Paulswharf,0,0
+1666,17,July,24,,St Martin Orgars,0,0
+1666,17,July,24,,St Olave Silverstreet,0,0
+1666,17,July,24,,St Bennet Sherehog,0,0
+1666,17,July,24,,St Martin Outwitch,0,0
+1666,17,July,24,,St Pancras Soperlane,1,0
+1666,17,July,24,,St Botolph Billingsgate,1,0
+1666,17,July,24,,St Martin Vintrey,3,1
+1666,17,July,24,,St Peter Cheap,1,0
+1666,17,July,24,,Christ's Church,3,1
+1666,17,July,24,,St Mary Abchurch,1,0
+1666,17,July,24,,St Peter Cornhil,0,0
+1666,17,July,24,,St Christophers,0,0
+1666,17,July,24,,St Mary Aldermanbury,1,0
+1666,17,July,24,,St Peter Paulswharf,0,0
+1666,17,July,24,,St Clement Eastcheap,0,0
+1666,17,July,24,,St Mary Aldermary,0,0
+1666,17,July,24,,St Peter Poor,0,0
+1666,17,July,24,,St Dionis Backchurch,0,0
+1666,17,July,24,,St Mary-le-bow,0,0
+1666,17,July,24,,St Steven Colemanstreet,0,0
+1666,17,July,24,,St Dunstan East,4,1
+1666,17,July,24,,St Mary Bothaw,0,0
+1666,17,July,24,,St Steven Walbrook,0,0
+1666,17,July,24,,St Edmund Lumbardstr.,0,0
+1666,17,July,24,,St Mary Colechurch,0,0
+1666,17,July,24,,St Swithin,1,0
+1666,17,July,24,,St Ethelburga,0,0
+1666,17,July,24,,St Mary Hill,0,0
+1666,17,July,24,,St Thomas Apostle,0,0
+1666,17,July,24,,St Faith,1,0
+1666,17,July,24,,St Mary Milkstreet,0,0
+1666,17,July,24,,Trinity Parish,1,0
+1666,17,July,24,,St Gabriel Fenchurch,0,0
+1666,17,July,24,,St Mary Mag. Oldfishstreet,1,0
+1666,17,July,24,,St Vedast alias Foster,0,0
+1666,17,July,24,,St George Botolphlane,0,0
+1666,17,July,24,,St Andrew Holborn,10,0
+1666,17,July,24,,St Botolph Aldgate,17,0
+1666,17,July,24,,Saviour Southwark,13,3
+1666,17,July,24,,St Bartholomew the Great,2,0
+1666,17,July,24,,St Botolph Bishopsgate,6,1
+1666,17,July,24,,St Sepulchres Parish,8,0
+1666,17,July,24,,St Bartholomew the Lesse,1,0
+1666,17,July,24,,St Dunstan West,2,0
+1666,17,July,24,,St Thomas Southwark,4,0
+1666,17,July,24,,St Bridget,5,0
+1666,17,July,24,,St George Southwark,2,1
+1666,17,July,24,,Trinity Minories,1,0
+1666,17,July,24,,Bridewel Precinct,0,0
+1666,17,July,24,,St Giles Cripplegate,28,2
+1666,17,July,24,,At the Pesthouse,1,0
+1666,17,July,24,,St Botolph Aldersgate,4,0
+1666,17,July,24,,St Olave Southwark,13,2
+1666,17,July,24,,...hritt Church,0,0
+1666,17,July,24,,St Katharine Tower,4,0
+1666,17,July,24,,St Mary Newington,5,0
+1666,17,July,24,,Dunstan Stepney,40,4
+1666,17,July,24,,Lambeth Parish,7,6
+1666,17,July,24,,St Mary Whitechappel,11,2
+1666,17,July,24,,St Giles in the Fields,12,1
+1666,17,July,24,,St Leonard Shoreditch,7,2
+1666,17,July,24,,St. Paul Shadwel,0,0
+1666,17,July,24,,St James Clerkenwel,2,0
+1666,17,July,24,,St Mary Islington,0,0
+1666,17,July,24,,Rotherhith Parish,2,0
+1666,17,July,24,,John at Hackney,2,0
+1666,17,July,24,,St Mary Magd. Bermondsey,19,7
+1666,17,July,24,,St Ann Westminster,0,0
+1666,17,July,24,,St Margaret Westminster,12,2
+1666,17,July,24,,St Mary Savoy,0,0
+1666,17,July,24,,St Clement Danes,14,6
+1666,17,July,24,,St Martin in the Fields,14,0
+1666,17,July,24,,St Paul Covent Garden,0,0
+1666,17,July,24,,St James Westminster,0,0
+1666,24,July,31,,ALban Woodstreet,0,0
+1666,24,July,31,,St Gregory by St Paul,1,0
+1666,24,July,31,,St Mary Mounthaw,1,0
+1666,24,July,31,,Alhallows Barking,4,0
+1666,24,July,31,,St Hellen,0,0
+1666,24,July,31,,St Mary Sommerset,1,0
+1666,24,July,31,,Alhallows Breadstreet,1,0
+1666,24,July,31,,St James Dukes Place,1,0
+1666,24,July,31,,St Mary Staining,1,0
+1666,24,July,31,,Alhallows the Great,1,0
+1666,24,July,31,,St James Garlickhithe,0,0
+1666,24,July,31,,St Mary Woolchurch,0,0
+1666,24,July,31,,Alhallows Honylane,1,0
+1666,24,July,31,,St John Baptist,0,0
+1666,24,July,31,,St Mary Woolnoth,2,0
+1666,24,July,31,,Alhallows the Less,1,0
+1666,24,July,31,,St John Evangelist,0,0
+1666,24,July,31,,St Matthew Fridaystreet,0,0
+1666,24,July,31,,Alhallows Lombardstreet,1,0
+1666,24,July,31,,St John Zachary,0,0
+1666,24,July,31,,St Michael Bassishaw,1,0
+1666,24,July,31,,Alhallows Staining,3,2
+1666,24,July,31,,St Katharine Coleman,0,0
+1666,24,July,31,,St Michael Cornhil,1,0
+1666,24,July,31,,Alhallows the Wall,2,0
+1666,24,July,31,,St Katharine Creechurch,1,1
+1666,24,July,31,,St Michael Crookedlane,1,0
+1666,24,July,31,,St Alphage,0,0
+1666,24,July,31,,St Lawrence Jewry,1,0
+1666,24,July,31,,St Michael Queenhithe,0,0
+1666,24,July,31,,St Andrew Hubbard,1,0
+1666,24,July,31,,St Lawrence Pountney,0,0
+1666,24,July,31,,St Michael Quern,1,0
+1666,24,July,31,,St Andrew Undershaft,2,0
+1666,24,July,31,,St Leonard Eastcheap,1,0
+1666,24,July,31,,St Michael Royal,0,0
+1666,24,July,31,,St Andrew Wardrobe,3,0
+1666,24,July,31,,St Leonard Fosterlane,2,0
+1666,24,July,31,,St Michael Woodstreet,0,0
+1666,24,July,31,,St Ann Aldersgate,3,0
+1666,24,July,31,,St Magnus Parish,0,0
+1666,24,July,31,,St Mildred Breadstreet,0,0
+1666,24,July,31,,St Ann Blackfriers,1,0
+1666,24,July,31,,St Margaret Lothbury,2,0
+1666,24,July,31,,St Mildred Poultry,1,0
+1666,24,July,31,,St Anthony alias Antholin,1,0
+1666,24,July,31,,St Margaret Moses,0,0
+1666,24,July,31,,St Nicholas Acons,0,0
+1666,24,July,31,,St Austins Parish,1,0
+1666,24,July,31,,St Margaret Newfishstreet,0,0
+1666,24,July,31,,St Nicholas Coleabby,1,0
+1666,24,July,31,,St Bartholomew Exchange,2,0
+1666,24,July,31,,St Margaret Pattons,1,0
+1666,24,July,31,,St Nicholas Olaves,0,0
+1666,24,July,31,,St Bennet Finck,0,0
+1666,24,July,31,,St Martin Iremongerlane,2,0
+1666,24,July,31,,St Olave Hartstreet,0,0
+1666,24,July,31,,St Bennet Gracechurch,0,0
+1666,24,July,31,,St Martin Ludgate,1,0
+1666,24,July,31,,St Olave Jewry,0,0
+1666,24,July,31,,St Bennet Paulswharf,0,0
+1666,24,July,31,,St Martin Orgars,1,0
+1666,24,July,31,,St Olave Silverstreet,0,0
+1666,24,July,31,,St Bennet Sherehog,0,0
+1666,24,July,31,,St Martin Outwitch,0,0
+1666,24,July,31,,St Pancras Soperlane,0,0
+1666,24,July,31,,St Botolph Billingsgate,0,0
+1666,24,July,31,,St Martin Vintrey,0,0
+1666,24,July,31,,St Peter Cheap,0,0
+1666,24,July,31,,Christ's Church,9,0
+1666,24,July,31,,St Mary Abchurch,1,0
+1666,24,July,31,,St Peter Cornhil,2,0
+1666,24,July,31,,St Christophers,1,0
+1666,24,July,31,,St Mary Aldermanbury,2,0
+1666,24,July,31,,St Peter Paulswharf,0,0
+1666,24,July,31,,St Clement Eastcheap,0,0
+1666,24,July,31,,St Mary Aldermary,0,0
+1666,24,July,31,,St Peter Poor,0,0
+1666,24,July,31,,St Dionis Backchurch,0,0
+1666,24,July,31,,St Mary-le-bow,1,0
+1666,24,July,31,,St Steven Colemanstreet,1,1
+1666,24,July,31,,St Dunstan East,0,0
+1666,24,July,31,,St Mary Bothaw,0,0
+1666,24,July,31,,St Steven Walbrook,1,0
+1666,24,July,31,,St Edmund Lumbardstr.,1,0
+1666,24,July,31,,St Mary Colechurch,0,0
+1666,24,July,31,,St Swithin,1,0
+1666,24,July,31,,St Ethelburga,1,0
+1666,24,July,31,,St Mary Hill,4,0
+1666,24,July,31,,St Thomas Apostle,1,0
+1666,24,July,31,,St Faith,1,0
+1666,24,July,31,,St Mary Milkstreet,1,1
+1666,24,July,31,,Trinity Parish,1,0
+1666,24,July,31,,St Gabriel Fenchurch,1,0
+1666,24,July,31,,St Mary Mag. Oldfishstreet,0,0
+1666,24,July,31,,St Vedast alias Foster,0,0
+1666,24,July,31,,St George Botolphlane,0,0
+1666,24,July,31,,St Andrew Holborn,19,0
+1666,24,July,31,,St Botolph Aldgate,7,0
+1666,24,July,31,,Saviour Southwark,11,0
+1666,24,July,31,,St Bartholomew the Great,3,2
+1666,24,July,31,,St Botolph Bishopsgate,9,1
+1666,24,July,31,,St Sepulchres Parish,10,1
+1666,24,July,31,,St Bartholomew the Lesse,0,0
+1666,24,July,31,,St Dunstan West,8,0
+1666,24,July,31,,St Thomas Southwark,2,0
+1666,24,July,31,,St Bridget,6,0
+1666,24,July,31,,St George Southwark,2,0
+1666,24,July,31,,Trinity Minories,2,1
+1666,24,July,31,,Bridewel Precinct,0,0
+1666,24,July,31,,St Giles Cripplegate,15,0
+1666,24,July,31,,At the Pesthouse,1,1
+1666,24,July,31,,St Botolph Aldersgate,5,0
+1666,24,July,31,,St Olave Southwark,12,2
+1666,24,July,31,,...hritt Church,0,0
+1666,24,July,31,,St Katharine Tower,9,3
+1666,24,July,31,,St Mary Newington,7,0
+1666,24,July,31,,Dunstan Stepney,30,3
+1666,24,July,31,,Lambeth Parish,9,5
+1666,24,July,31,,St Mary Whitechappel,9,1
+1666,24,July,31,,St Giles in the Fields,13,0
+1666,24,July,31,,St Leonard Shoreditch,3,0
+1666,24,July,31,,St. Paul Shadwel,0,0
+1666,24,July,31,,St James Clerkenwel,2,0
+1666,24,July,31,,St Mary Islington,2,0
+1666,24,July,31,,Rotherhith Parish,7,4
+1666,24,July,31,,John at Hackney,0,0
+1666,24,July,31,,St Mary Magd. Bermondsey,13,3
+1666,24,July,31,,St Ann Westminster,0,0
+1666,24,July,31,,St Margaret Westminster,8,2
+1666,24,July,31,,St Mary Savoy,0,0
+1666,24,July,31,,St Clement Danes,10,1
+1666,24,July,31,,St Martin in the Fields,18,2
+1666,24,July,31,,St Paul Covent Garden,4,1
+1666,24,July,31,,St James Westminster,0,0
+1666,31,July,7,August,ALban Woodstreet,1,0
+1666,31,July,7,August,St Gregory by St Paul,2,0
+1666,31,July,7,August,St Mary Mounthaw,0,0
+1666,31,July,7,August,Alhallows Barking,3,0
+1666,31,July,7,August,St Hellen,0,0
+1666,31,July,7,August,St Mary Sommerset,1,0
+1666,31,July,7,August,Alhallows Breadstreet,0,0
+1666,31,July,7,August,St James Dukes Place,1,0
+1666,31,July,7,August,St Mary Staining,0,0
+1666,31,July,7,August,Alhallows the Great,0,0
+1666,31,July,7,August,St James Garlickhithe,0,0
+1666,31,July,7,August,St Mary Woolchurch,0,0
+1666,31,July,7,August,Alhallows Honylane,0,0
+1666,31,July,7,August,St John Baptist,0,0
+1666,31,July,7,August,St Mary Woolnoth,0,0
+1666,31,July,7,August,Alhallows the Less,0,0
+1666,31,July,7,August,St John Evangelist,0,0
+1666,31,July,7,August,St Matthew Fridaystreet,0,0
+1666,31,July,7,August,Alhallows Lombardstreet,1,0
+1666,31,July,7,August,St John Zachary,0,0
+1666,31,July,7,August,St Michael Bassishaw,0,0
+1666,31,July,7,August,Alhallows Staining,3,3
+1666,31,July,7,August,St Katharine Coleman,0,0
+1666,31,July,7,August,St Michael Cornhil,2,0
+1666,31,July,7,August,Alhallows the Wall,1,1
+1666,31,July,7,August,St Katharine Creechurch,3,0
+1666,31,July,7,August,St Michael Crookedlane,0,0
+1666,31,July,7,August,St Alphage,0,0
+1666,31,July,7,August,St Lawrence Jewry,1,0
+1666,31,July,7,August,St Michael Queenhithe,1,0
+1666,31,July,7,August,St Andrew Hubbard,0,0
+1666,31,July,7,August,St Lawrence Pountney,0,0
+1666,31,July,7,August,St Michael Quern,0,0
+1666,31,July,7,August,St Andrew Undershaft,0,0
+1666,31,July,7,August,St Leonard Eastcheap,0,0
+1666,31,July,7,August,St Michael Royal,2,0
+1666,31,July,7,August,St Andrew Wardrobe,2,0
+1666,31,July,7,August,St Leonard Fosterlane,4,0
+1666,31,July,7,August,St Michael Woodstreet,0,0
+1666,31,July,7,August,St Ann Aldersgate,3,0
+1666,31,July,7,August,St Magnus Parish,2,0
+1666,31,July,7,August,St Mildred Breadstreet,1,0
+1666,31,July,7,August,St Ann Blackfriers,2,0
+1666,31,July,7,August,St Margaret Lothbury,1,0
+1666,31,July,7,August,St Mildred Poultry,0,0
+1666,31,July,7,August,St Anthony alias Antholin,0,0
+1666,31,July,7,August,St Margaret Moses,0,0
+1666,31,July,7,August,St Nicholas Acons,0,0
+1666,31,July,7,August,St Austins Parish,0,0
+1666,31,July,7,August,St Margaret Newfishstreet,0,0
+1666,31,July,7,August,St Nicholas Coleabby,0,0
+1666,31,July,7,August,St Bartholomew Exchange,1,0
+1666,31,July,7,August,St Margaret Pattons,1,0
+1666,31,July,7,August,St Nicholas Olaves,0,0
+1666,31,July,7,August,St Bennet Finck,0,0
+1666,31,July,7,August,St Martin Iremongerlane,0,0
+1666,31,July,7,August,St Olave Hartstreet,3,0
+1666,31,July,7,August,St Bennet Gracechurch,0,0
+1666,31,July,7,August,St Martin Ludgate,0,0
+1666,31,July,7,August,St Olave Jewry,0,0
+1666,31,July,7,August,St Bennet Paulswharf,1,0
+1666,31,July,7,August,St Martin Orgars,0,0
+1666,31,July,7,August,St Olave Silverstreet,0,0
+1666,31,July,7,August,St Bennet Sherehog,0,0
+1666,31,July,7,August,St Martin Outwitch,1,0
+1666,31,July,7,August,St Pancras Soperlane,1,0
+1666,31,July,7,August,St Botolph Billingsgate,1,0
+1666,31,July,7,August,St Martin Vintrey,1,0
+1666,31,July,7,August,St Peter Cheap,1,0
+1666,31,July,7,August,Christ's Church,1,0
+1666,31,July,7,August,St Mary Abchurch,0,0
+1666,31,July,7,August,St Peter Cornhil,1,0
+1666,31,July,7,August,St Christophers,0,0
+1666,31,July,7,August,St Mary Aldermanbury,3,0
+1666,31,July,7,August,St Peter Paulswharf,0,0
+1666,31,July,7,August,St Clement Eastcheap,0,0
+1666,31,July,7,August,St Mary Aldermary,0,0
+1666,31,July,7,August,St Peter Poor,3,1
+1666,31,July,7,August,St Dionis Backchurch,2,1
+1666,31,July,7,August,St Mary-le-bow,2,0
+1666,31,July,7,August,St Steven Colemanstreet,2,0
+1666,31,July,7,August,St Dunstan East,1,0
+1666,31,July,7,August,St Mary Bothaw,0,0
+1666,31,July,7,August,St Steven Walbrook,1,0
+1666,31,July,7,August,St Edmund Lumbardstr.,0,0
+1666,31,July,7,August,St Mary Colechurch,1,0
+1666,31,July,7,August,St Swithin,1,0
+1666,31,July,7,August,St Ethelburga,1,0
+1666,31,July,7,August,St Mary Hill,0,0
+1666,31,July,7,August,St Thomas Apostle,1,0
+1666,31,July,7,August,St Faith,2,0
+1666,31,July,7,August,St Mary Milkstreet,0,0
+1666,31,July,7,August,Trinity Parish,0,0
+1666,31,July,7,August,St Gabriel Fenchurch,0,0
+1666,31,July,7,August,St Mary Mag. Oldfishstreet,0,0
+1666,31,July,7,August,St Vedast alias Foster,0,0
+1666,31,July,7,August,St George Botolphlane,0,0
+1666,31,July,7,August,St Andrew Holborn,12,0
+1666,31,July,7,August,St Botolph Aldgate,9,1
+1666,31,July,7,August,Saviour Southwark,11,2
+1666,31,July,7,August,St Bartholomew the Great,2,0
+1666,31,July,7,August,St Botolph Bishopsgate,8,1
+1666,31,July,7,August,St Sepulchres Parish,12,0
+1666,31,July,7,August,St Bartholomew the Lesse,1,0
+1666,31,July,7,August,St Dunstan West,4,0
+1666,31,July,7,August,St Thomas Southwark,1,0
+1666,31,July,7,August,St Bridget,4,0
+1666,31,July,7,August,St George Southwark,6,0
+1666,31,July,7,August,Trinity Minories,0,0
+1666,31,July,7,August,Bridewel Precinct,0,0
+1666,31,July,7,August,St Giles Cripplegate,13,0
+1666,31,July,7,August,At the Pesthouse,2,2
+1666,31,July,7,August,St Botolph Aldersgate,4,0
+1666,31,July,7,August,St Olave Southwark,12,3
+1666,31,July,7,August,...hritt Church,0,0
+1666,31,July,7,August,St Katharine Tower,10,2
+1666,31,July,7,August,St Mary Newington,5,0
+1666,31,July,7,August,Dunstan Stepney,41,6
+1666,31,July,7,August,Lambeth Parish,3,1
+1666,31,July,7,August,St Mary Whitechappel,16,1
+1666,31,July,7,August,St Giles in the Fields,17,0
+1666,31,July,7,August,St Leonard Shoreditch,7,1
+1666,31,July,7,August,St. Paul Shadwel,0,0
+1666,31,July,7,August,St James Clerkenwel,5,0
+1666,31,July,7,August,St Mary Islington,3,0
+1666,31,July,7,August,Rotherhith Parish,4,0
+1666,31,July,7,August,John at Hackney,0,0
+1666,31,July,7,August,St Mary Magd. Bermondsey,18,13
+1666,31,July,7,August,St Ann Westminster,0,0
+1666,31,July,7,August,St Margaret Westminster,7,0
+1666,31,July,7,August,St Mary Savoy,2,0
+1666,31,July,7,August,St Clement Danes,6,2
+1666,31,July,7,August,St Martin in the Fields,18,0
+1666,31,July,7,August,St Paul Covent Garden,3,1
+1666,31,July,7,August,St James Westminster,0,0
+1666,7,August,14,,ALban Woodstreet,0,0
+1666,7,August,14,,St Gregory by St Paul,0,0
+1666,7,August,14,,St Mary Mounthaw,0,0
+1666,7,August,14,,Alhallows Barking,4,0
+1666,7,August,14,,St Hellen,0,0
+1666,7,August,14,,St Mary Sommerset,2,0
+1666,7,August,14,,Alhallows Breadstreet,1,0
+1666,7,August,14,,St James Dukes Place,2,0
+1666,7,August,14,,St Mary Staining,0,0
+1666,7,August,14,,Alhallows the Great,5,1
+1666,7,August,14,,St James Garlickhithe,0,0
+1666,7,August,14,,St Mary Woolchurch,0,0
+1666,7,August,14,,Alhallows Honylane,0,0
+1666,7,August,14,,St John Baptist,0,0
+1666,7,August,14,,St Mary Woolnoth,0,0
+1666,7,August,14,,Alhallows the Less,1,0
+1666,7,August,14,,St John Evangelist,0,0
+1666,7,August,14,,St Matthew Fridaystreet,0,0
+1666,7,August,14,,Alhallows Lombardstreet,0,0
+1666,7,August,14,,St John Zachary,0,0
+1666,7,August,14,,St Michael Bassishaw,3,0
+1666,7,August,14,,Alhallows Staining,0,0
+1666,7,August,14,,St Katharine Coleman,0,0
+1666,7,August,14,,St Michael Cornhil,1,0
+1666,7,August,14,,Alhallows the Wall,2,0
+1666,7,August,14,,St Katharine Creechurch,1,0
+1666,7,August,14,,St Michael Crookedlane,1,0
+1666,7,August,14,,St Alphage,1,0
+1666,7,August,14,,St Lawrence Jewry,2,0
+1666,7,August,14,,St Michael Queenhithe,0,0
+1666,7,August,14,,St Andrew Hubbard,0,0
+1666,7,August,14,,St Lawrence Pountney,0,0
+1666,7,August,14,,St Michael Quern,0,0
+1666,7,August,14,,St Andrew Undershaft,0,0
+1666,7,August,14,,St Leonard Eastcheap,0,0
+1666,7,August,14,,St Michael Royal,1,0
+1666,7,August,14,,St Andrew Wardrobe,1,0
+1666,7,August,14,,St Leonard Fosterlane,0,0
+1666,7,August,14,,St Michael Woodstreet,2,0
+1666,7,August,14,,St Ann Aldersgate,1,0
+1666,7,August,14,,St Magnus Parish,1,0
+1666,7,August,14,,St Mildred Breadstreet,0,0
+1666,7,August,14,,St Ann Blackfriers,3,1
+1666,7,August,14,,St Margaret Lothbury,0,0
+1666,7,August,14,,St Mildred Poultry,1,0
+1666,7,August,14,,St Anthony alias Antholin,0,0
+1666,7,August,14,,St Margaret Moses,0,0
+1666,7,August,14,,St Nicholas Acons,0,0
+1666,7,August,14,,St Austins Parish,1,0
+1666,7,August,14,,St Margaret Newfishstreet,0,0
+1666,7,August,14,,St Nicholas Coleabby,0,0
+1666,7,August,14,,St Bartholomew Exchange,0,0
+1666,7,August,14,,St Margaret Pattons,1,0
+1666,7,August,14,,St Nicholas Olaves,0,0
+1666,7,August,14,,St Bennet Finck,1,0
+1666,7,August,14,,St Martin Iremongerlane,0,0
+1666,7,August,14,,St Olave Hartstreet,3,0
+1666,7,August,14,,St Bennet Gracechurch,1,0
+1666,7,August,14,,St Martin Ludgate,0,0
+1666,7,August,14,,St Olave Jewry,0,0
+1666,7,August,14,,St Bennet Paulswharf,2,0
+1666,7,August,14,,St Martin Orgars,1,0
+1666,7,August,14,,St Olave Silverstreet,0,0
+1666,7,August,14,,St Bennet Sherehog,0,0
+1666,7,August,14,,St Martin Outwitch,1,0
+1666,7,August,14,,St Pancras Soperlane,0,0
+1666,7,August,14,,St Botolph Billingsgate,0,0
+1666,7,August,14,,St Martin Vintrey,3,0
+1666,7,August,14,,St Peter Cheap,1,0
+1666,7,August,14,,Christ's Church,2,0
+1666,7,August,14,,St Mary Abchurch,0,0
+1666,7,August,14,,St Peter Cornhil,1,0
+1666,7,August,14,,St Christophers,1,0
+1666,7,August,14,,St Mary Aldermanbury,0,0
+1666,7,August,14,,St Peter Paulswharf,0,0
+1666,7,August,14,,St Clement Eastcheap,2,0
+1666,7,August,14,,St Mary Aldermary,1,0
+1666,7,August,14,,St Peter Poor,0,0
+1666,7,August,14,,St Dionis Backchurch,2,2
+1666,7,August,14,,St Mary-le-bow,0,0
+1666,7,August,14,,St Steven Colemanstreet,3,1
+1666,7,August,14,,St Dunstan East,2,0
+1666,7,August,14,,St Mary Bothaw,0,0
+1666,7,August,14,,St Steven Walbrook,0,0
+1666,7,August,14,,St Edmund Lumbardstr.,0,0
+1666,7,August,14,,St Mary Colechurch,0,0
+1666,7,August,14,,St Swithin,0,0
+1666,7,August,14,,St Ethelburga,0,0
+1666,7,August,14,,St Mary Hill,0,0
+1666,7,August,14,,St Thomas Apostle,0,0
+1666,7,August,14,,St Faith,0,0
+1666,7,August,14,,St Mary Milkstreet,0,0
+1666,7,August,14,,Trinity Parish,0,0
+1666,7,August,14,,St Gabriel Fenchurch,1,1
+1666,7,August,14,,St Mary Mag. Oldfishstreet,0,0
+1666,7,August,14,,St Vedast alias Foster,0,0
+1666,7,August,14,,St George Botolphlane,0,0
+1666,7,August,14,,St Andrew Holborn,10,1
+1666,7,August,14,,St Botolph Aldgate,14,3
+1666,7,August,14,,Saviour Southwark,18,1
+1666,7,August,14,,St Bartholomew the Great,2,0
+1666,7,August,14,,St Botolph Bishopsgate,12,0
+1666,7,August,14,,St Sepulchres Parish,18,0
+1666,7,August,14,,St Bartholomew the Lesse,1,0
+1666,7,August,14,,St Dunstan West,7,0
+1666,7,August,14,,St Thomas Southwark,0,0
+1666,7,August,14,,St Bridget,5,0
+1666,7,August,14,,St George Southwark,1,0
+1666,7,August,14,,Trinity Minories,0,0
+1666,7,August,14,,Bridewel Precinct,0,0
+1666,7,August,14,,St Giles Cripplegate,14,1
+1666,7,August,14,,At the Pesthouse,0,0
+1666,7,August,14,,St Botolph Aldersgate,1,0
+1666,7,August,14,,St Olave Southwark,12,3
+1666,7,August,14,,...hritt Church,0,0
+1666,7,August,14,,St Katharine Tower,6,1
+1666,7,August,14,,St Mary Newington,4,0
+1666,7,August,14,,Dunstan Stepney,19,3
+1666,7,August,14,,Lambeth Parish,11,5
+1666,7,August,14,,St Mary Whitechappel,14,0
+1666,7,August,14,,St Giles in the Fields,15,1
+1666,7,August,14,,St Leonard Shoreditch,9,1
+1666,7,August,14,,St. Paul Shadwel,0,0
+1666,7,August,14,,St James Clerkenwel,2,0
+1666,7,August,14,,St Mary Islington,3,0
+1666,7,August,14,,Rotherhith Parish,4,3
+1666,7,August,14,,John at Hackney,3,0
+1666,7,August,14,,St Mary Magd. Bermondsey,11,5
+1666,7,August,14,,St Ann Westminster,0,0
+1666,7,August,14,,St Margaret Westminster,16,5
+1666,7,August,14,,St Mary Savoy,1,0
+1666,7,August,14,,St Clement Danes,11,5
+1666,7,August,14,,St Martin in the Fields,17,1
+1666,7,August,14,,St Paul Covent Garden,5,3
+1666,7,August,14,,St James Westminster,0,0
+1666,14,August,21,,ALban Woodstreet,0,0
+1666,14,August,21,,St Gregory by St Paul,1,0
+1666,14,August,21,,St Mary Mounthaw,0,0
+1666,14,August,21,,Alhallows Barking,0,0
+1666,14,August,21,,St Hellen,0,0
+1666,14,August,21,,St Mary Sommerset,0,0
+1666,14,August,21,,Alhallows Breadstreet,0,0
+1666,14,August,21,,St James Dukes Place,1,0
+1666,14,August,21,,St Mary Staining,1,0
+1666,14,August,21,,Alhallows the Great,3,0
+1666,14,August,21,,St James Garlickhithe,0,0
+1666,14,August,21,,St Mary Woolchurch,1,0
+1666,14,August,21,,Alhallows Honylane,0,0
+1666,14,August,21,,St John Baptist,1,0
+1666,14,August,21,,St Mary Woolnoth,0,0
+1666,14,August,21,,Alhallows the Less,0,0
+1666,14,August,21,,St John Evangelist,0,0
+1666,14,August,21,,St Matthew Fridaystreet,0,0
+1666,14,August,21,,Alhallows Lombardstreet,0,0
+1666,14,August,21,,St John Zachary,0,0
+1666,14,August,21,,St Michael Bassishaw,0,0
+1666,14,August,21,,Alhallows Staining,0,0
+1666,14,August,21,,St Katharine Coleman,0,0
+1666,14,August,21,,St Michael Cornhil,1,0
+1666,14,August,21,,Alhallows the Wall,3,0
+1666,14,August,21,,St Katharine Creechurch,5,2
+1666,14,August,21,,St Michael Crookedlane,1,0
+1666,14,August,21,,St Alphage,1,0
+1666,14,August,21,,St Lawrence Jewry,1,0
+1666,14,August,21,,St Michael Queenhithe,0,0
+1666,14,August,21,,St Andrew Hubbard,4,0
+1666,14,August,21,,St Lawrence Pountney,0,0
+1666,14,August,21,,St Michael Quern,0,0
+1666,14,August,21,,St Andrew Undershaft,0,0
+1666,14,August,21,,St Leonard Eastcheap,1,0
+1666,14,August,21,,St Michael Royal,0,0
+1666,14,August,21,,St Andrew Wardrobe,1,0
+1666,14,August,21,,St Leonard Fosterlane,2,0
+1666,14,August,21,,St Michael Woodstreet,2,0
+1666,14,August,21,,St Ann Aldersgate,2,2
+1666,14,August,21,,St Magnus Parish,1,0
+1666,14,August,21,,St Mildred Breadstreet,2,0
+1666,14,August,21,,St Ann Blackfriers,0,0
+1666,14,August,21,,St Margaret Lothbury,0,0
+1666,14,August,21,,St Mildred Poultry,0,0
+1666,14,August,21,,St Anthony alias Antholin,0,0
+1666,14,August,21,,St Margaret Moses,0,0
+1666,14,August,21,,St Nicholas Acons,0,0
+1666,14,August,21,,St Austins Parish,0,0
+1666,14,August,21,,St Margaret Newfishstreet,0,0
+1666,14,August,21,,St Nicholas Coleabby,0,0
+1666,14,August,21,,St Bartholomew Exchange,1,0
+1666,14,August,21,,St Margaret Pattons,0,0
+1666,14,August,21,,St Nicholas Olaves,0,0
+1666,14,August,21,,St Bennet Finck,0,0
+1666,14,August,21,,St Martin Iremongerlane,0,0
+1666,14,August,21,,St Olave Hartstreet,1,0
+1666,14,August,21,,St Bennet Gracechurch,0,0
+1666,14,August,21,,St Martin Ludgate,2,0
+1666,14,August,21,,St Olave Jewry,0,0
+1666,14,August,21,,St Bennet Paulswharf,0,0
+1666,14,August,21,,St Martin Orgars,0,0
+1666,14,August,21,,St Olave Silverstreet,1,0
+1666,14,August,21,,St Bennet Sherehog,0,0
+1666,14,August,21,,St Martin Outwitch,0,0
+1666,14,August,21,,St Pancras Soperlane,0,0
+1666,14,August,21,,St Botolph Billingsgate,0,0
+1666,14,August,21,,St Martin Vintrey,2,0
+1666,14,August,21,,St Peter Cheap,1,0
+1666,14,August,21,,Christ's Church,3,0
+1666,14,August,21,,St Mary Abchurch,0,0
+1666,14,August,21,,St Peter Cornhil,0,0
+1666,14,August,21,,St Christophers,2,0
+1666,14,August,21,,St Mary Aldermanbury,2,0
+1666,14,August,21,,St Peter Paulswharf,0,0
+1666,14,August,21,,St Clement Eastcheap,0,0
+1666,14,August,21,,St Mary Aldermary,1,0
+1666,14,August,21,,St Peter Poor,1,1
+1666,14,August,21,,St Dionis Backchurch,1,0
+1666,14,August,21,,St Mary-le-bow,0,0
+1666,14,August,21,,St Steven Colemanstreet,1,0
+1666,14,August,21,,St Dunstan East,3,0
+1666,14,August,21,,St Mary Bothaw,0,0
+1666,14,August,21,,St Steven Walbrook,0,0
+1666,14,August,21,,St Edmund Lumbardstr.,0,0
+1666,14,August,21,,St Mary Colechurch,0,0
+1666,14,August,21,,St Swithin,1,0
+1666,14,August,21,,St Ethelburga,0,0
+1666,14,August,21,,St Mary Hill,1,0
+1666,14,August,21,,St Thomas Apostle,1,0
+1666,14,August,21,,St Faith,1,0
+1666,14,August,21,,St Mary Milkstreet,0,0
+1666,14,August,21,,Trinity Parish,2,0
+1666,14,August,21,,St Gabriel Fenchurch,0,0
+1666,14,August,21,,St Mary Mag. Oldfishstreet,0,0
+1666,14,August,21,,St Vedast alias Foster,0,0
+1666,14,August,21,,St George Botolphlane,1,0
+1666,14,August,21,,St Andrew Holborn,13,0
+1666,14,August,21,,St Botolph Aldgate,12,3
+1666,14,August,21,,Saviour Southwark,10,2
+1666,14,August,21,,St Bartholomew the Great,1,0
+1666,14,August,21,,St Botolph Bishopsgate,4,0
+1666,14,August,21,,St Sepulchres Parish,8,0
+1666,14,August,21,,St Bartholomew the Lesse,0,0
+1666,14,August,21,,St Dunstan West,4,0
+1666,14,August,21,,St Thomas Southwark,0,0
+1666,14,August,21,,St Bridget,6,0
+1666,14,August,21,,St George Southwark,2,0
+1666,14,August,21,,Trinity Minories,0,0
+1666,14,August,21,,Bridewel Precinct,0,0
+1666,14,August,21,,St Giles Cripplegate,13,0
+1666,14,August,21,,At the Pesthouse,1,1
+1666,14,August,21,,St Botolph Aldersgate,3,0
+1666,14,August,21,,St Olave Southwark,7,0
+1666,14,August,21,,...hritt Church,0,0
+1666,14,August,21,,St Katharine Tower,9,2
+1666,14,August,21,,St Mary Newington,1,0
+1666,14,August,21,,Dunstan Stepney,29,9
+1666,14,August,21,,Lambeth Parish,1,0
+1666,14,August,21,,St Mary Whitechappel,12,3
+1666,14,August,21,,St Giles in the Fields,13,0
+1666,14,August,21,,St Leonard Shoreditch,12,0
+1666,14,August,21,,St. Paul Shadwel,0,0
+1666,14,August,21,,St James Clerkenwel,1,0
+1666,14,August,21,,St Mary Islington,3,0
+1666,14,August,21,,Rotherhith Parish,0,0
+1666,14,August,21,,John at Hackney,2,1
+1666,14,August,21,,St Mary Magd. Bermondsey,22,10
+1666,14,August,21,,St Ann Westminster,0,0
+1666,14,August,21,,St Margaret Westminster,9,2
+1666,14,August,21,,St Mary Savoy,1,0
+1666,14,August,21,,St Clement Danes,6,1
+1666,14,August,21,,St Martin in the Fields,19,3
+1666,14,August,21,,St Paul Covent Garden,2,0
+1666,14,August,21,,St James Westminster,0,0
+1666,21,August,28,,ALban Woodstreet,0,0
+1666,21,August,28,,St Gregory by St Paul,0,0
+1666,21,August,28,,St Mary Mounthaw,0,0
+1666,21,August,28,,Alhallows Barking,1,0
+1666,21,August,28,,St Hellen,2,0
+1666,21,August,28,,St Mary Sommerset,0,0
+1666,21,August,28,,Alhallows Breadstreet,0,0
+1666,21,August,28,,St James Dukes Place,0,0
+1666,21,August,28,,St Mary Staining,0,0
+1666,21,August,28,,Alhallows the Great,1,0
+1666,21,August,28,,St James Garlickhithe,1,0
+1666,21,August,28,,St Mary Woolchurch,0,0
+1666,21,August,28,,Alhallows Honylane,0,0
+1666,21,August,28,,St John Baptist,0,0
+1666,21,August,28,,St Mary Woolnoth,0,0
+1666,21,August,28,,Alhallows the Less,3,0
+1666,21,August,28,,St John Evangelist,0,0
+1666,21,August,28,,St Matthew Fridaystreet,3,0
+1666,21,August,28,,Alhallows Lombardstreet,0,0
+1666,21,August,28,,St John Zachary,0,0
+1666,21,August,28,,St Michael Bassishaw,1,0
+1666,21,August,28,,Alhallows Staining,1,0
+1666,21,August,28,,St Katharine Coleman,0,0
+1666,21,August,28,,St Michael Cornhil,1,0
+1666,21,August,28,,Alhallows the Wall,0,0
+1666,21,August,28,,St Katharine Creechurch,2,0
+1666,21,August,28,,St Michael Crookedlane,0,0
+1666,21,August,28,,St Alphage,0,0
+1666,21,August,28,,St Lawrence Jewry,0,0
+1666,21,August,28,,St Michael Queenhithe,0,0
+1666,21,August,28,,St Andrew Hubbard,0,0
+1666,21,August,28,,St Lawrence Pountney,0,0
+1666,21,August,28,,St Michael Quern,2,0
+1666,21,August,28,,St Andrew Undershaft,1,0
+1666,21,August,28,,St Leonard Eastcheap,1,0
+1666,21,August,28,,St Michael Royal,0,0
+1666,21,August,28,,St Andrew Wardrobe,1,0
+1666,21,August,28,,St Leonard Fosterlane,0,0
+1666,21,August,28,,St Michael Woodstreet,0,0
+1666,21,August,28,,St Ann Aldersgate,1,0
+1666,21,August,28,,St Magnus Parish,1,0
+1666,21,August,28,,St Mildred Breadstreet,1,0
+1666,21,August,28,,St Ann Blackfriers,1,1
+1666,21,August,28,,St Margaret Lothbury,1,0
+1666,21,August,28,,St Mildred Poultry,0,0
+1666,21,August,28,,St Anthony alias Antholin,0,0
+1666,21,August,28,,St Margaret Moses,0,0
+1666,21,August,28,,St Nicholas Acons,0,0
+1666,21,August,28,,St Austins Parish,0,0
+1666,21,August,28,,St Margaret Newfishstreet,0,0
+1666,21,August,28,,St Nicholas Coleabby,0,0
+1666,21,August,28,,St Bartholomew Exchange,1,0
+1666,21,August,28,,St Margaret Pattons,0,0
+1666,21,August,28,,St Nicholas Olaves,0,0
+1666,21,August,28,,St Bennet Finck,0,0
+1666,21,August,28,,St Martin Iremongerlane,0,0
+1666,21,August,28,,St Olave Hartstreet,0,0
+1666,21,August,28,,St Bennet Gracechurch,1,0
+1666,21,August,28,,St Martin Ludgate,0,0
+1666,21,August,28,,St Olave Jewry,0,0
+1666,21,August,28,,St Bennet Paulswharf,0,0
+1666,21,August,28,,St Martin Orgars,0,0
+1666,21,August,28,,St Olave Silverstreet,0,0
+1666,21,August,28,,St Bennet Sherehog,0,0
+1666,21,August,28,,St Martin Outwitch,1,0
+1666,21,August,28,,St Pancras Soperlane,0,0
+1666,21,August,28,,St Botolph Billingsgate,0,0
+1666,21,August,28,,St Martin Vintrey,1,0
+1666,21,August,28,,St Peter Cheap,0,0
+1666,21,August,28,,Christ's Church,2,0
+1666,21,August,28,,St Mary Abchurch,1,0
+1666,21,August,28,,St Peter Cornhil,2,0
+1666,21,August,28,,St Christophers,0,0
+1666,21,August,28,,St Mary Aldermanbury,1,0
+1666,21,August,28,,St Peter Paulswharf,0,0
+1666,21,August,28,,St Clement Eastcheap,0,0
+1666,21,August,28,,St Mary Aldermary,0,0
+1666,21,August,28,,St Peter Poor,3,2
+1666,21,August,28,,St Dionis Backchurch,0,0
+1666,21,August,28,,St Mary-le-bow,0,0
+1666,21,August,28,,St Steven Colemanstreet,2,0
+1666,21,August,28,,St Dunstan East,1,0
+1666,21,August,28,,St Mary Bothaw,0,0
+1666,21,August,28,,St Steven Walbrook,1,0
+1666,21,August,28,,St Edmund Lumbardstr.,0,0
+1666,21,August,28,,St Mary Colechurch,0,0
+1666,21,August,28,,St Swithin,1,0
+1666,21,August,28,,St Ethelburga,0,0
+1666,21,August,28,,St Mary Hill,1,1
+1666,21,August,28,,St Thomas Apostle,0,0
+1666,21,August,28,,St Faith,0,0
+1666,21,August,28,,St Mary Milkstreet,0,0
+1666,21,August,28,,Trinity Parish,1,0
+1666,21,August,28,,St Gabriel Fenchurch,1,0
+1666,21,August,28,,St Mary Mag. Oldfishstreet,0,0
+1666,21,August,28,,St Vedast alias Foster,0,0
+1666,21,August,28,,St George Botolphlane,0,0
+1666,21,August,28,,St Andrew Holborn,11,1
+1666,21,August,28,,St Botolph Aldgate,16,2
+1666,21,August,28,,Saviour Southwark,12,5
+1666,21,August,28,,St Bartholomew the Great,3,0
+1666,21,August,28,,St Botolph Bishopsgate,4,0
+1666,21,August,28,,St Sepulchres Parish,14,0
+1666,21,August,28,,St Bartholomew the Lesse,0,0
+1666,21,August,28,,St Dunstan West,3,0
+1666,21,August,28,,St Thomas Southwark,0,0
+1666,21,August,28,,St Bridget,9,0
+1666,21,August,28,,St George Southwark,1,0
+1666,21,August,28,,Trinity Minories,0,0
+1666,21,August,28,,Bridewel Precinct,0,0
+1666,21,August,28,,St Giles Cripplegate,19,3
+1666,21,August,28,,At the Pesthouse,0,0
+1666,21,August,28,,St Botolph Aldersgate,5,0
+1666,21,August,28,,St Olave Southwark,7,1
+1666,21,August,28,,...hritt Church,0,0
+1666,21,August,28,,St Katharine Tower,5,0
+1666,21,August,28,,St Mary Newington,0,0
+1666,21,August,28,,Dunstan Stepney,24,1
+1666,21,August,28,,Lambeth Parish,5,4
+1666,21,August,28,,St Mary Whitechappel,12,1
+1666,21,August,28,,St Giles in the Fields,5,0
+1666,21,August,28,,St Leonard Shoreditch,8,0
+1666,21,August,28,,St. Paul Shadwel,0,0
+1666,21,August,28,,St James Clerkenwel,5,0
+1666,21,August,28,,St Mary Islington,3,0
+1666,21,August,28,,Rotherhith Parish,1,0
+1666,21,August,28,,John at Hackney,2,1
+1666,21,August,28,,St Mary Magd. Bermondsey,14,5
+1666,21,August,28,,St Ann Westminster,0,0
+1666,21,August,28,,St Margaret Westminster,8,2
+1666,21,August,28,,St Mary Savoy,3,0
+1666,21,August,28,,St Clement Danes,2,0
+1666,21,August,28,,St Martin in the Fields,16,0
+1666,21,August,28,,St Paul Covent Garden,2,0
+1666,21,August,28,,St James Westminster,0,0
+1666,28,August,18,September,ALban Woodstreet,0,0
+1666,28,August,18,September,St Gregory by St Paul,0,0
+1666,28,August,18,September,St Mary Mounthaw,0,0
+1666,28,August,18,September,Alhallows Barking,2,0
+1666,28,August,18,September,St Hellen,0,0
+1666,28,August,18,September,St Mary Sommerset,0,0
+1666,28,August,18,September,Alhallows Breadstreet,0,0
+1666,28,August,18,September,St James Dukes Place,1,0
+1666,28,August,18,September,St Mary Staining,0,0
+1666,28,August,18,September,Alhallows the Great,0,0
+1666,28,August,18,September,St James Garlickhithe,0,0
+1666,28,August,18,September,St Mary Woolchurch,0,0
+1666,28,August,18,September,Alhallows Honylane,0,0
+1666,28,August,18,September,St John Baptist,0,0
+1666,28,August,18,September,St Mary Woolnoth,0,0
+1666,28,August,18,September,Alhallows the Less,0,0
+1666,28,August,18,September,St John Evangelist,0,0
+1666,28,August,18,September,St Matthew Fridaystreet,0,0
+1666,28,August,18,September,Alhallows Lombardstreet,0,0
+1666,28,August,18,September,St John Zachary,0,0
+1666,28,August,18,September,St Michael Bassishaw,0,0
+1666,28,August,18,September,Alhallows Staining,3,0
+1666,28,August,18,September,St Katharine Coleman,1,0
+1666,28,August,18,September,St Michael Cornhil,0,0
+1666,28,August,18,September,Alhallows the Wall,5,0
+1666,28,August,18,September,St Katharine Creechurch,1,1
+1666,28,August,18,September,St Michael Crookedlane,0,0
+1666,28,August,18,September,St Alphage,0,0
+1666,28,August,18,September,St Lawrence Jewry,0,0
+1666,28,August,18,September,St Michael Queenhithe,0,0
+1666,28,August,18,September,St Andrew Hubbard,0,0
+1666,28,August,18,September,St Lawrence Pountney,0,0
+1666,28,August,18,September,St Michael Quern,0,0
+1666,28,August,18,September,St Andrew Undershaft,2,0
+1666,28,August,18,September,St Leonard Eastcheap,0,0
+1666,28,August,18,September,St Michael Royal,0,0
+1666,28,August,18,September,St Andrew Wardrobe,0,0
+1666,28,August,18,September,St Leonard Fosterlane,0,0
+1666,28,August,18,September,St Michael Woodstreet,0,0
+1666,28,August,18,September,St Ann Aldersgate,0,0
+1666,28,August,18,September,St Magnus Parish,2,0
+1666,28,August,18,September,St Mildred Breadstreet,0,0
+1666,28,August,18,September,St Ann Blackfriers,0,0
+1666,28,August,18,September,St Margaret Lothbury,0,0
+1666,28,August,18,September,St Mildred Poultry,0,0
+1666,28,August,18,September,St Anthony alias Antholin,0,0
+1666,28,August,18,September,St Margaret Moses,0,0
+1666,28,August,18,September,St Nicholas Acons,0,0
+1666,28,August,18,September,St Austins Parish,0,0
+1666,28,August,18,September,St Margaret Newfishstreet,0,0
+1666,28,August,18,September,St Nicholas Coleabby,0,0
+1666,28,August,18,September,St Bartholomew Exchange,0,0
+1666,28,August,18,September,St Margaret Pattons,0,0
+1666,28,August,18,September,St Nicholas Olaves,0,0
+1666,28,August,18,September,St Bennet Finck,0,0
+1666,28,August,18,September,St Martin Iremongerlane,0,0
+1666,28,August,18,September,St Olave Hartstreet,2,0
+1666,28,August,18,September,St Bennet Gracechurch,0,0
+1666,28,August,18,September,St Martin Ludgate,0,0
+1666,28,August,18,September,St Olave Jewry,0,0
+1666,28,August,18,September,St Bennet Paulswharf,0,0
+1666,28,August,18,September,St Martin Orgars,0,0
+1666,28,August,18,September,St Olave Silverstreet,0,0
+1666,28,August,18,September,St Bennet Sherehog,0,0
+1666,28,August,18,September,St Martin Outwitch,2,0
+1666,28,August,18,September,St Pancras Soperlane,0,0
+1666,28,August,18,September,St Botolph Billingsgate,0,0
+1666,28,August,18,September,St Martin Vintrey,0,0
+1666,28,August,18,September,St Peter Cheap,0,0
+1666,28,August,18,September,Christ's Church,0,0
+1666,28,August,18,September,St Mary Abchurch,0,0
+1666,28,August,18,September,St Peter Cornhil,2,0
+1666,28,August,18,September,St Christophers,0,0
+1666,28,August,18,September,St Mary Aldermanbury,0,0
+1666,28,August,18,September,St Peter Paulswharf,0,0
+1666,28,August,18,September,St Clement Eastcheap,0,0
+1666,28,August,18,September,St Mary Aldermary,0,0
+1666,28,August,18,September,St Peter Poor,2,0
+1666,28,August,18,September,St Dionis Backchurch,0,0
+1666,28,August,18,September,St Mary-le-bow,0,0
+1666,28,August,18,September,St Steven Colemanstreet,4,0
+1666,28,August,18,September,St Dunstan East,0,0
+1666,28,August,18,September,St Mary Bothaw,0,0
+1666,28,August,18,September,St Steven Walbrook,0,0
+1666,28,August,18,September,St Edmund Lumbardstr.,0,0
+1666,28,August,18,September,St Mary Colechurch,0,0
+1666,28,August,18,September,St Swithin,0,0
+1666,28,August,18,September,St Ethelburga,1,0
+1666,28,August,18,September,St Mary Hill,0,0
+1666,28,August,18,September,St Thomas Apostle,0,0
+1666,28,August,18,September,St Faith,0,0
+1666,28,August,18,September,St Mary Milkstreet,0,0
+1666,28,August,18,September,Trinity Parish,0,0
+1666,28,August,18,September,St Gabriel Fenchurch,0,0
+1666,28,August,18,September,St Mary Mag. Oldfishstreet,0,0
+1666,28,August,18,September,St Vedast alias Foster,0,0
+1666,28,August,18,September,St George Botolphlane,0,0
+1666,28,August,18,September,St Andrew Holborn,39,0
+1666,28,August,18,September,St Botolph Aldgate,38,7
+1666,28,August,18,September,Saviour Southwark,30,14
+1666,28,August,18,September,St Bartholomew the Great,7,2
+1666,28,August,18,September,St Botolph Bishopsgate,20,0
+1666,28,August,18,September,St Sepulchres Parish,16,0
+1666,28,August,18,September,St Bartholomew the Lesse,1,0
+1666,28,August,18,September,St Dunstan West,10,0
+1666,28,August,18,September,St Thomas Southwark,0,0
+1666,28,August,18,September,St Bridget,0,0
+1666,28,August,18,September,St George Southwark,10,1
+1666,28,August,18,September,Trinity Minories,0,0
+1666,28,August,18,September,Bridewel Precinct,0,0
+1666,28,August,18,September,St Giles Cripplegate,71,2
+1666,28,August,18,September,At the Pesthouse,2,2
+1666,28,August,18,September,St Botolph Aldersgate,9,1
+1666,28,August,18,September,St Olave Southwark,31,0
+1666,28,August,18,September,...hritt Church,0,0
+1666,28,August,18,September,St Katharine Tower,15,3
+1666,28,August,18,September,St Mary Newington,8,0
+1666,28,August,18,September,Dunstan Stepney,89,21
+1666,28,August,18,September,Lambeth Parish,15,5
+1666,28,August,18,September,St Mary Whitechappel,34,4
+1666,28,August,18,September,St Giles in the Fields,26,0
+1666,28,August,18,September,St Leonard Shoreditch,14,0
+1666,28,August,18,September,St. Paul Shadwel,0,0
+1666,28,August,18,September,St James Clerkenwel,14,2
+1666,28,August,18,September,St Mary Islington,5,0
+1666,28,August,18,September,Rotherhith Parish,9,6
+1666,28,August,18,September,John at Hackney,10,0
+1666,28,August,18,September,St Mary Magd. Bermondsey,35,23
+1666,28,August,18,September,St Ann Westminster,0,0
+1666,28,August,18,September,St Margaret Westminster,34,1
+1666,28,August,18,September,St Mary Savoy,2,0
+1666,28,August,18,September,St Clement Danes,14,2
+1666,28,August,18,September,St Martin in the Fields,60,7
+1666,28,August,18,September,St Paul Covent Garden,6,0
+1666,28,August,18,September,St James Westminster,0,0
+1666,18,September,25,,St James Dukes Place,3,0
+1666,18,September,25,,Alhallows Staining,1,0
+1666,18,September,25,,St Olave Hartstreet,2,1
+1666,18,September,25,,St Andrew Holborn,8,1
+1666,18,September,25,,St Botolph Aldgate,15,0
+1666,18,September,25,,Saviour Southwark,11,1
+1666,18,September,25,,St Bartholomew the Great,5,2
+1666,18,September,25,,St Botolph Bishopsgate,7,0
+1666,18,September,25,,St Sepulchres Parish,11,0
+1666,18,September,25,,St Bartholomew the Lesse,0,0
+1666,18,September,25,,St Dunstan West,0,0
+1666,18,September,25,,St Thomas Southwark,0,0
+1666,18,September,25,,St Bridget,0,0
+1666,18,September,25,,St George Southwark,4,0
+1666,18,September,25,,Trinity Minories,1,0
+1666,18,September,25,,Bridewel Precinct,0,0
+1666,18,September,25,,St Giles Cripplegate,19,2
+1666,18,September,25,,At the Pesthouse,1,1
+1666,18,September,25,,St Botolph Aldersgate,6,1
+1666,18,September,25,,St Olave Southwark,14,1
+1666,18,September,25,,St Katharine Tower,3,0
+1666,18,September,25,,St Mary Newington,1,0
+1666,18,September,25,,Dunstan Stepney,27,6
+1666,18,September,25,,Lambeth Parish,5,2
+1666,18,September,25,,St Mary Whitechappel,22,2
+1666,18,September,25,,St Giles in the Fields,10,1
+1666,18,September,25,,St Leonard Shoreditch,8,0
+1666,18,September,25,,St. Paul Shadwel,0,0
+1666,18,September,25,,St James Clerkenwel,3,0
+1666,18,September,25,,St Mary Islington,9,0
+1666,18,September,25,,Rotherhith Parish,2,0
+1666,18,September,25,,John at Hackney,3,0
+1666,18,September,25,,St Mary Magd. Bermondsey,13,3
+1666,18,September,25,,St Ann Westminster,0,0
+1666,18,September,25,,St Margaret Westminster,14,2
+1666,18,September,25,,St Mary Savoy,2,0
+1666,18,September,25,,St Clement Danes,8,1
+1666,18,September,25,,St Martin in the Fields,16,4
+1666,18,September,25,,St Paul Covent Garden,3,0
+1666,18,September,25,,St James Westminster,0,0
+1666,25,September,2,October,Alhallows Barking,2,0
+1666,25,September,2,October,St Hellen,4,0
+1666,25,September,2,October,Alhallows Staining,1,0
+1666,25,September,2,October,Alhallows the Wall,2,0
+1666,25,September,2,October,St Katharine Creechurch,2,0
+1666,25,September,2,October,St Andrew Undershaft,1,0
+1666,25,September,2,October,St Magnus Parish,1,0
+1666,25,September,2,October,St Peter Cornhil,1,0
+1666,25,September,2,October,St Andrew Holborn,18,1
+1666,25,September,2,October,St Botolph Aldgate,17,1
+1666,25,September,2,October,Saviour Southwark,7,1
+1666,25,September,2,October,St Bartholomew the Great,1,0
+1666,25,September,2,October,St Botolph Bishopsgate,4,0
+1666,25,September,2,October,St Sepulchres Parish,7,0
+1666,25,September,2,October,St Bartholomew the Lesse,0,0
+1666,25,September,2,October,St Dunstan West,0,0
+1666,25,September,2,October,St Thomas Southwark,1,0
+1666,25,September,2,October,St Bridget,0,0
+1666,25,September,2,October,St George Southwark,7,0
+1666,25,September,2,October,Trinity Minories,0,0
+1666,25,September,2,October,Bridewel Precinct,0,0
+1666,25,September,2,October,St Giles Cripplegate,21,2
+1666,25,September,2,October,At the Pesthouse,1,1
+1666,25,September,2,October,St Botolph Aldersgate,2,0
+1666,25,September,2,October,St Olave Southwark,11,0
+1666,25,September,2,October,...hritt Church,0,0
+1666,25,September,2,October,St Katharine Tower,0,0
+1666,25,September,2,October,St Mary Newington,2,0
+1666,25,September,2,October,Dunstan Stepney,33,6
+1666,25,September,2,October,Lambeth Parish,7,3
+1666,25,September,2,October,St Mary Whitechappel,4,0
+1666,25,September,2,October,St Giles in the Fields,6,0
+1666,25,September,2,October,St Leonard Shoreditch,10,0
+1666,25,September,2,October,St. Paul Shadwel,0,0
+1666,25,September,2,October,St James Clerkenwel,5,1
+1666,25,September,2,October,St Mary Islington,2,0
+1666,25,September,2,October,Rotherhith Parish,0,0
+1666,25,September,2,October,John at Hackney,1,0
+1666,25,September,2,October,St Mary Magd. Bermondsey,11,5
+1666,25,September,2,October,St Ann Westminster,0,0
+1666,25,September,2,October,St Margaret Westminster,11,1
+1666,25,September,2,October,St Mary Savoy,0,0
+1666,25,September,2,October,St Clement Danes,5,0
+1666,25,September,2,October,St Martin in the Fields,15,1
+1666,25,September,2,October,St Paul Covent Garden,1,0
+1666,25,September,2,October,St James Westminster,0,0
+1666,2,October,9,,Alhallows Barking,1,0
+1666,2,October,9,,St James Dukes Place,2,0
+1666,2,October,9,,St Katharine Coleman,3,2
+1666,2,October,9,,Alhallows the Wall,3,0
+1666,2,October,9,,St Katharine Creechurch,2,0
+1666,2,October,9,,St Andrew Undershaft,1,0
+1666,2,October,9,,St Olave Hartstreet,1,0
+1666,2,October,9,,St Peter Poor,1,0
+1666,2,October,9,,St Andrew Holborn,12,0
+1666,2,October,9,,St Botolph Aldgate,15,0
+1666,2,October,9,,Saviour Southwark,5,1
+1666,2,October,9,,St Bartholomew the Great,4,0
+1666,2,October,9,,St Botolph Bishopsgate,7,0
+1666,2,October,9,,St Sepulchres Parish,8,1
+1666,2,October,9,,St Bartholomew the Lesse,0,0
+1666,2,October,9,,St Dunstan West,0,0
+1666,2,October,9,,St Thomas Southwark,2,0
+1666,2,October,9,,St Bridget,0,0
+1666,2,October,9,,St George Southwark,3,0
+1666,2,October,9,,Trinity Minories,0,0
+1666,2,October,9,,Bridewel Precinct,0,0
+1666,2,October,9,,St Giles Cripplegate,21,0
+1666,2,October,9,,At the Pesthouse,0,0
+1666,2,October,9,,St Botolph Aldersgate,4,0
+1666,2,October,9,,St Olave Southwark,16,0
+1666,2,October,9,,St Katharine Tower,4,0
+1666,2,October,9,,St Mary Newington,1,0
+1666,2,October,9,,Dunstan Stepney,41,3
+1666,2,October,9,,Lambeth Parish,6,1
+1666,2,October,9,,St Mary Whitechappel,16,3
+1666,2,October,9,,St Giles in the Fields,18,0
+1666,2,October,9,,St Leonard Shoreditch,10,0
+1666,2,October,9,,St. Paul Shadwel,0,0
+1666,2,October,9,,St James Clerkenwel,4,0
+1666,2,October,9,,St Mary Islington,1,0
+1666,2,October,9,,Rotherhith Parish,1,1
+1666,2,October,9,,John at Hackney,5,0
+1666,2,October,9,,St Mary Magd. Bermondsey,5,3
+1666,2,October,9,,St Ann Westminster,0,0
+1666,2,October,9,,St Margaret Westminster,11,0
+1666,2,October,9,,St Mary Savoy,3,0
+1666,2,October,9,,St Clement Danes,9,0
+1666,2,October,9,,St Martin in the Fields,11,0
+1666,2,October,9,,St Paul Covent Garden,1,0
+1666,2,October,9,,St James Westminster,0,0
+1666,9,October,16,,Alhallows Barking,5,0
+1666,9,October,16,,St Hellen,1,0
+1666,9,October,16,,St Katharine Coleman,1,0
+1666,9,October,16,,St Alphage,1,0
+1666,9,October,16,,St Andrew Undershaft,1,0
+1666,9,October,16,,St Magnus Parish,1,0
+1666,9,October,16,,St Martin Outwitch,1,0
+1666,9,October,16,,St Peter Poor,1,0
+1666,9,October,16,,St Steven Colemanstreet,1,0
+1666,9,October,16,,St Ethelburga,1,0
+1666,9,October,16,,St Andrew Holborn,10,0
+1666,9,October,16,,St Botolph Aldgate,16,0
+1666,9,October,16,,Saviour Southwark,12,2
+1666,9,October,16,,St Bartholomew the Great,6,2
+1666,9,October,16,,St Botolph Bishopsgate,8,1
+1666,9,October,16,,St Sepulchres Parish,9,0
+1666,9,October,16,,St Bartholomew the Lesse,1,0
+1666,9,October,16,,St Dunstan West,4,0
+1666,9,October,16,,St Thomas Southwark,3,0
+1666,9,October,16,,St Bridget,0,0
+1666,9,October,16,,St George Southwark,3,0
+1666,9,October,16,,Trinity Minories,0,0
+1666,9,October,16,,Bridewel Precinct,0,0
+1666,9,October,16,,St Giles Cripplegate,14,1
+1666,9,October,16,,At the Pesthouse,0,0
+1666,9,October,16,,St Botolph Aldersgate,4,1
+1666,9,October,16,,St Olave Southwark,9,0
+1666,9,October,16,,...hritt Church,0,0
+1666,9,October,16,,St Katharine Tower,7,1
+1666,9,October,16,,St Mary Newington,3,0
+1666,9,October,16,,Dunstan Stepney,24,3
+1666,9,October,16,,Lambeth Parish,7,2
+1666,9,October,16,,St Mary Whitechappel,11,2
+1666,9,October,16,,St Giles in the Fields,15,0
+1666,9,October,16,,St Leonard Shoreditch,2,0
+1666,9,October,16,,St. Paul Shadwel,0,0
+1666,9,October,16,,St James Clerkenwel,4,0
+1666,9,October,16,,St Mary Islington,0,0
+1666,9,October,16,,Rotherhith Parish,3,1
+1666,9,October,16,,John at Hackney,1,0
+1666,9,October,16,,St Mary Magd. Bermondsey,8,3
+1666,9,October,16,,St Ann Westminster,0,0
+1666,9,October,16,,St Margaret Westminster,16,1
+1666,9,October,16,,St Mary Savoy,0,0
+1666,9,October,16,,St Clement Danes,11,3
+1666,9,October,16,,St Martin in the Fields,10,1
+1666,9,October,16,,St Paul Covent Garden,3,0
+1666,9,October,16,,St James Westminster,0,0
+1666,16,October,23,,St Katharine Coleman,1,0
+1666,16,October,23,,Alhallows the Wall,2,0
+1666,16,October,23,,St Katharine Creechurch,1,0
+1666,16,October,23,,St Andrew Undershaft,1,0
+1666,16,October,23,,St Olave Hartstreet,2,0
+1666,16,October,23,,St Steven Colemanstreet,1,0
+1666,16,October,23,,St Andrew Holborn,5,0
+1666,16,October,23,,St Botolph Aldgate,7,0
+1666,16,October,23,,Saviour Southwark,11,4
+1666,16,October,23,,St Bartholomew the Great,2,1
+1666,16,October,23,,St Botolph Bishopsgate,4,0
+1666,16,October,23,,St Sepulchres Parish,4,0
+1666,16,October,23,,St Bartholomew the Lesse,0,0
+1666,16,October,23,,St Dunstan West,1,0
+1666,16,October,23,,St Thomas Southwark,1,0
+1666,16,October,23,,St Bridget,0,0
+1666,16,October,23,,St George Southwark,3,0
+1666,16,October,23,,Trinity Minories,0,0
+1666,16,October,23,,Bridewel Precinct,0,0
+1666,16,October,23,,St Giles Cripplegate,27,1
+1666,16,October,23,,At the Pesthouse,0,0
+1666,16,October,23,,St Botolph Aldersgate,1,0
+1666,16,October,23,,St Olave Southwark,8,0
+1666,16,October,23,,...hritt Church,0,0
+1666,16,October,23,,St Katharine Tower,1,0
+1666,16,October,23,,St Mary Newington,1,0
+1666,16,October,23,,Dunstan Stepney,30,4
+1666,16,October,23,,Lambeth Parish,5,0
+1666,16,October,23,,St Mary Whitechappel,6,0
+1666,16,October,23,,St Giles in the Fields,13,1
+1666,16,October,23,,St Leonard Shoreditch,11,0
+1666,16,October,23,,St. Paul Shadwel,0,0
+1666,16,October,23,,St James Clerkenwel,6,0
+1666,16,October,23,,St Mary Islington,7,0
+1666,16,October,23,,Rotherhith Parish,5,2
+1666,16,October,23,,John at Hackney,1,0
+1666,16,October,23,,St Mary Magd. Bermondsey,11,1
+1666,16,October,23,,St Ann Westminster,0,0
+1666,16,October,23,,St Margaret Westminster,3,2
+1666,16,October,23,,St Mary Savoy,1,0
+1666,16,October,23,,St Clement Danes,2,0
+1666,16,October,23,,St Martin in the Fields,15,0
+1666,16,October,23,,St Paul Covent Garden,5,0
+1666,16,October,23,,St James Westminster,0,0
+1666,23,October,30,,Alhallows Barking,2,0
+1666,23,October,30,,St James Dukes Place,1,0
+1666,23,October,30,,Alhallows Staining,1,0
+1666,23,October,30,,St Katharine Coleman,1,0
+1666,23,October,30,,Alhallows the Wall,2,0
+1666,23,October,30,,St Katharine Creechurch,2,0
+1666,23,October,30,,St Peter Cornhil,1,0
+1666,23,October,30,,St Andrew Holborn,11,0
+1666,23,October,30,,St Botolph Aldgate,9,0
+1666,23,October,30,,Saviour Southwark,12,1
+1666,23,October,30,,St Bartholomew the Great,2,0
+1666,23,October,30,,St Botolph Bishopsgate,3,0
+1666,23,October,30,,St Sepulchres Parish,8,0
+1666,23,October,30,,St Bartholomew the Lesse,0,0
+1666,23,October,30,,St Dunstan West,2,0
+1666,23,October,30,,St Thomas Southwark,1,0
+1666,23,October,30,,St Bridget,0,0
+1666,23,October,30,,St George Southwark,6,0
+1666,23,October,30,,Trinity Minories,0,0
+1666,23,October,30,,Bridewel Precinct,0,0
+1666,23,October,30,,St Giles Cripplegate,22,0
+1666,23,October,30,,At the Pesthouse,0,0
+1666,23,October,30,,St Botolph Aldersgate,7,0
+1666,23,October,30,,St Olave Southwark,8,0
+1666,23,October,30,,...hritt Church,0,0
+1666,23,October,30,,St Katharine Tower,2,0
+1666,23,October,30,,St Mary Newington,2,0
+1666,23,October,30,,Dunstan Stepney,24,4
+1666,23,October,30,,Lambeth Parish,0,0
+1666,23,October,30,,St Mary Whitechappel,10,1
+1666,23,October,30,,St Giles in the Fields,13,1
+1666,23,October,30,,St Leonard Shoreditch,3,0
+1666,23,October,30,,St. Paul Shadwel,0,0
+1666,23,October,30,,St James Clerkenwel,10,2
+1666,23,October,30,,St Mary Islington,1,0
+1666,23,October,30,,Rotherhith Parish,6,2
+1666,23,October,30,,John at Hackney,1,0
+1666,23,October,30,,St Mary Magd. Bermondsey,8,3
+1666,23,October,30,,St Ann Westminster,0,0
+1666,23,October,30,,St Margaret Westminster,13,0
+1666,23,October,30,,St Mary Savoy,2,0
+1666,23,October,30,,St Clement Danes,8,0
+1666,23,October,30,,St Martin in the Fields,15,0
+1666,23,October,30,,St Paul Covent Garden,1,0
+1666,23,October,30,,St James Westminster,0,0
+1666,30,October,6,November,Alhallows Barking,2,0
+1666,30,October,6,November,St James Dukes Place,1,0
+1666,30,October,6,November,St Andrew Undershaft,1,0
+1666,30,October,6,November,St Magnus Parish,1,0
+1666,30,October,6,November,St Peter Poor,1,0
+1666,30,October,6,November,St Steven Colemanstreet,1,0
+1666,30,October,6,November,St Andrew Holborn,7,0
+1666,30,October,6,November,St Botolph Aldgate,10,0
+1666,30,October,6,November,Saviour Southwark,18,4
+1666,30,October,6,November,St Bartholomew the Great,3,2
+1666,30,October,6,November,St Botolph Bishopsgate,5,0
+1666,30,October,6,November,St Sepulchres Parish,10,0
+1666,30,October,6,November,St Bartholomew the Lesse,1,0
+1666,30,October,6,November,St Dunstan West,3,0
+1666,30,October,6,November,St Thomas Southwark,0,0
+1666,30,October,6,November,St Bridget,0,0
+1666,30,October,6,November,St George Southwark,3,0
+1666,30,October,6,November,Trinity Minories,0,0
+1666,30,October,6,November,Bridewel Precinct,0,0
+1666,30,October,6,November,St Giles Cripplegate,25,0
+1666,30,October,6,November,At the Pesthouse,0,0
+1666,30,October,6,November,St Botolph Aldersgate,3,0
+1666,30,October,6,November,St Olave Southwark,9,0
+1666,30,October,6,November,...hritt Church,0,0
+1666,30,October,6,November,St Katharine Tower,4,0
+1666,30,October,6,November,St Mary Newington,2,0
+1666,30,October,6,November,Dunstan Stepney,25,2
+1666,30,October,6,November,Lambeth Parish,3,1
+1666,30,October,6,November,St Mary Whitechappel,12,0
+1666,30,October,6,November,St Giles in the Fields,7,0
+1666,30,October,6,November,St Leonard Shoreditch,2,0
+1666,30,October,6,November,St. Paul Shadwel,0,0
+1666,30,October,6,November,St James Clerkenwel,5,0
+1666,30,October,6,November,St Mary Islington,3,0
+1666,30,October,6,November,Rotherhith Parish,3,1
+1666,30,October,6,November,John at Hackney,0,0
+1666,30,October,6,November,St Mary Magd. Bermondsey,6,0
+1666,30,October,6,November,St Ann Westminster,0,0
+1666,30,October,6,November,St Margaret Westminster,16,0
+1666,30,October,6,November,St Mary Savoy,0,0
+1666,30,October,6,November,St Clement Danes,5,0
+1666,30,October,6,November,St Martin in the Fields,12,0
+1666,30,October,6,November,St Paul Covent Garden,4,0
+1666,30,October,6,November,St James Westminster,0,0
+1666,6,November,13,,Alhallows Barking,2,0
+1666,6,November,13,,St Hellen,1,0
+1666,6,November,13,,St James Dukes Place,1,0
+1666,6,November,13,,St Katharine Coleman,2,0
+1666,6,November,13,,Alhallows the Wall,1,0
+1666,6,November,13,,St Katharine Creechurch,2,0
+1666,6,November,13,,St Andrew Undershaft,2,0
+1666,6,November,13,,St Olave Hartstreet,1,0
+1666,6,November,13,,St Steven Colemanstreet,1,0
+1666,6,November,13,,St Andrew Holborn,9,0
+1666,6,November,13,,St Botolph Aldgate,2,0
+1666,6,November,13,,Saviour Southwark,14,1
+1666,6,November,13,,St Bartholomew the Great,2,0
+1666,6,November,13,,St Botolph Bishopsgate,5,0
+1666,6,November,13,,St Sepulchres Parish,9,0
+1666,6,November,13,,St Bartholomew the Lesse,3,0
+1666,6,November,13,,St George Southwark,8,0
+1666,6,November,13,,Trinity Minories,1,0
+1666,6,November,13,,St Giles Cripplegate,20,0
+1666,6,November,13,,St Botolph Aldersgate,3,0
+1666,6,November,13,,St Olave Southwark,8,0
+1666,6,November,13,,St Katharine Tower,5,0
+1666,6,November,13,,St Mary Newington,1,0
+1666,6,November,13,,Dunstan Stepney,30,0
+1666,6,November,13,,Lambeth Parish,2,0
+1666,6,November,13,,St Mary Whitechappel,19,0
+1666,6,November,13,,St Giles in the Fields,10,0
+1666,6,November,13,,St Leonard Shoreditch,8,0
+1666,6,November,13,,St James Clerkenwel,7,0
+1666,6,November,13,,St Mary Islington,6,0
+1666,6,November,13,,Rotherhith Parish,2,0
+1666,6,November,13,,John at Hackney,4,0
+1666,6,November,13,,St Mary Magd. Bermondsey,8,0
+1666,6,November,13,,St Margaret Westminster,14,0
+1666,6,November,13,,St Mary Savoy,2,0
+1666,6,November,13,,St Clement Danes,5,0
+1666,6,November,13,,St Martin in the Fields,21,0
+1666,6,November,13,,St Paul Covent Garden,2,0
+1666,13,November,20,,Alhallows Barking,2,0
+1666,13,November,20,,St Hellen,1,0
+1666,13,November,20,,St James Dukes Place,1,0
+1666,13,November,20,,Alhallows Staining,1,0
+1666,13,November,20,,St Katharine Coleman,5,0
+1666,13,November,20,,Alhallows the Wall,1,0
+1666,13,November,20,,St Katharine Creechurch,1,0
+1666,13,November,20,,St Martin Outwitch,1,0
+1666,13,November,20,,St Ethelburga,1,0
+1666,13,November,20,,St Andrew Holborn,10,0
+1666,13,November,20,,St Botolph Aldgate,12,0
+1666,13,November,20,,Saviour Southwark,12,3
+1666,13,November,20,,St Bartholomew the Great,1,0
+1666,13,November,20,,St Botolph Bishopsgate,6,0
+1666,13,November,20,,St Sepulchres Parish,7,0
+1666,13,November,20,,St Dunstan West,2,0
+1666,13,November,20,,St Thomas Southwark,1,0
+1666,13,November,20,,St George Southwark,3,0
+1666,13,November,20,,St Giles Cripplegate,21,0
+1666,13,November,20,,St Botolph Aldersgate,3,0
+1666,13,November,20,,St Olave Southwark,14,0
+1666,13,November,20,,St Katharine Tower,6,0
+1666,13,November,20,,St Mary Newington,4,0
+1666,13,November,20,,Dunstan Stepney,27,1
+1666,13,November,20,,Lambeth Parish,6,1
+1666,13,November,20,,St Mary Whitechappel,12,0
+1666,13,November,20,,St Giles in the Fields,10,0
+1666,13,November,20,,St Leonard Shoreditch,10,0
+1666,13,November,20,,St James Clerkenwel,5,0
+1666,13,November,20,,St Mary Islington,3,0
+1666,13,November,20,,Rotherhith Parish,1,0
+1666,13,November,20,,John at Hackney,1,0
+1666,13,November,20,,St Mary Magd. Bermondsey,9,1
+1666,13,November,20,,St Margaret Westminster,14,1
+1666,13,November,20,,St Mary Savoy,2,0
+1666,13,November,20,,St Clement Danes,6,0
+1666,13,November,20,,St Martin in the Fields,15,1
+1666,13,November,20,,St Paul Covent Garden,1,0
+1666,20,November,27,,Alhallows Barking,1,0
+1666,20,November,27,,St James Dukes Place,1,0
+1666,20,November,27,,St Katharine Coleman,2,0
+1666,20,November,27,,Alhallows the Wall,2,0
+1666,20,November,27,,St Katharine Creechurch,1,0
+1666,20,November,27,,St Alphage,1,0
+1666,20,November,27,,St Andrew Undershaft,1,0
+1666,20,November,27,,St Olave Hartstreet,1,0
+1666,20,November,27,,St Ethelburga,1,0
+1666,20,November,27,,St Andrew Holborn,10,0
+1666,20,November,27,,St Botolph Aldgate,14,0
+1666,20,November,27,,Saviour Southwark,14,3
+1666,20,November,27,,St Bartholomew the Great,3,0
+1666,20,November,27,,St Botolph Bishopsgate,3,0
+1666,20,November,27,,St Sepulchres Parish,7,0
+1666,20,November,27,,St Dunstan West,2,0
+1666,20,November,27,,St Thomas Southwark,1,0
+1666,20,November,27,,St George Southwark,2,0
+1666,20,November,27,,Trinity Minories,1,0
+1666,20,November,27,,St Giles Cripplegate,18,0
+1666,20,November,27,,St Botolph Aldersgate,4,0
+1666,20,November,27,,St Olave Southwark,20,0
+1666,20,November,27,,St Katharine Tower,7,0
+1666,20,November,27,,St Mary Newington,6,0
+1666,20,November,27,,Dunstan Stepney,34,1
+1666,20,November,27,,Lambeth Parish,5,1
+1666,20,November,27,,St Mary Whitechappel,16,1
+1666,20,November,27,,St Giles in the Fields,7,0
+1666,20,November,27,,St Leonard Shoreditch,4,0
+1666,20,November,27,,St James Clerkenwel,10,0
+1666,20,November,27,,St Mary Islington,3,0
+1666,20,November,27,,Rotherhith Parish,2,0
+1666,20,November,27,,John at Hackney,2,0
+1666,20,November,27,,St Mary Magd. Bermondsey,4,1
+1666,20,November,27,,St Margaret Westminster,8,0
+1666,20,November,27,,St Mary Savoy,1,0
+1666,20,November,27,,St Clement Danes,6,0
+1666,20,November,27,,St Martin in the Fields,19,0
+1666,20,November,27,,St Paul Covent Garden,3,0
+1666,27,November,4,December,Alhallows Barking,2,0
+1666,27,November,4,December,St Hellen,1,0
+1666,27,November,4,December,Alhallows Staining,1,0
+1666,27,November,4,December,St Katharine Coleman,2,0
+1666,27,November,4,December,Alhallows the Wall,2,0
+1666,27,November,4,December,St Peter Cornhil,1,0
+1666,27,November,4,December,St Ethelburga,1,0
+1666,27,November,4,December,St Andrew Holborn,10,0
+1666,27,November,4,December,St Botolph Aldgate,19,0
+1666,27,November,4,December,Saviour Southwark,15,1
+1666,27,November,4,December,St Bartholomew the Great,3,0
+1666,27,November,4,December,St Botolph Bishopsgate,4,0
+1666,27,November,4,December,St Sepulchres Parish,7,0
+1666,27,November,4,December,St Dunstan West,2,0
+1666,27,November,4,December,St George Southwark,2,0
+1666,27,November,4,December,St Giles Cripplegate,22,0
+1666,27,November,4,December,St Botolph Aldersgate,1,0
+1666,27,November,4,December,St Olave Southwark,12,0
+1666,27,November,4,December,St Katharine Tower,4,0
+1666,27,November,4,December,St Mary Newington,4,0
+1666,27,November,4,December,Dunstan Stepney,25,1
+1666,27,November,4,December,Lambeth Parish,4,0
+1666,27,November,4,December,St Mary Whitechappel,16,0
+1666,27,November,4,December,St Giles in the Fields,19,0
+1666,27,November,4,December,St Leonard Shoreditch,5,0
+1666,27,November,4,December,St James Clerkenwel,5,0
+1666,27,November,4,December,St Mary Islington,2,0
+1666,27,November,4,December,Rotherhith Parish,2,0
+1666,27,November,4,December,John at Hackney,3,0
+1666,27,November,4,December,St Mary Magd. Bermondsey,7,0
+1666,27,November,4,December,St Margaret Westminster,16,0
+1666,27,November,4,December,St Mary Savoy,1,0
+1666,27,November,4,December,St Clement Danes,4,0
+1666,27,November,4,December,St Martin in the Fields,20,0
+1666,27,November,4,December,St Paul Covent Garden,2,0
+1666,4,December,11,,Alhallows Barking,3,0
+1666,4,December,11,,Alhallows Staining,3,0
+1666,4,December,11,,St Katharine Coleman,2,0
+1666,4,December,11,,Alhallows the Wall,1,0
+1666,4,December,11,,St Katharine Creechurch,1,0
+1666,4,December,11,,St Alphage,1,0
+1666,4,December,11,,St Olave Hartstreet,2,0
+1666,4,December,11,,St Andrew Holborn,16,0
+1666,4,December,11,,St Botolph Aldgate,21,0
+1666,4,December,11,,Saviour Southwark,16,2
+1666,4,December,11,,St Bartholomew the Great,2,0
+1666,4,December,11,,St Botolph Bishopsgate,8,0
+1666,4,December,11,,St Sepulchres Parish,6,0
+1666,4,December,11,,St Bartholomew the Lesse,1,0
+1666,4,December,11,,St Dunstan West,6,0
+1666,4,December,11,,St George Southwark,3,0
+1666,4,December,11,,St Giles Cripplegate,23,0
+1666,4,December,11,,St Botolph Aldersgate,1,0
+1666,4,December,11,,St Olave Southwark,11,0
+1666,4,December,11,,St Katharine Tower,3,0
+1666,4,December,11,,St Mary Newington,4,0
+1666,4,December,11,,Dunstan Stepney,29,1
+1666,4,December,11,,Lambeth Parish,3,0
+1666,4,December,11,,St Mary Whitechappel,15,0
+1666,4,December,11,,St Giles in the Fields,13,1
+1666,4,December,11,,St Leonard Shoreditch,10,0
+1666,4,December,11,,St James Clerkenwel,5,0
+1666,4,December,11,,Rotherhith Parish,1,0
+1666,4,December,11,,John at Hackney,4,0
+1666,4,December,11,,St Mary Magd. Bermondsey,5,0
+1666,4,December,11,,St Margaret Westminster,11,0
+1666,4,December,11,,St Mary Savoy,3,0
+1666,4,December,11,,St Clement Danes,7,0
+1666,4,December,11,,St Martin in the Fields,13,0
+1666,4,December,11,,St Paul Covent Garden,7,0
+1666,11,December,18,,Alhallows Barking,4,0
+1666,11,December,18,,St James Dukes Place,1,0
+1666,11,December,18,,St Katharine Coleman,1,0
+1666,11,December,18,,Alhallows the Wall,2,0
+1666,11,December,18,,St Katharine Creechurch,1,0
+1666,11,December,18,,St Andrew Undershaft,1,0
+1666,11,December,18,,St Olave Hartstreet,1,0
+1666,11,December,18,,St Peter Cornhil,2,0
+1666,11,December,18,,St Peter Poor,1,0
+1666,11,December,18,,St Steven Colemanstreet,1,0
+1666,11,December,18,,St Andrew Holborn,14,0
+1666,11,December,18,,St Botolph Aldgate,9,0
+1666,11,December,18,,Saviour Southwark,8,0
+1666,11,December,18,,St Bartholomew the Great,1,0
+1666,11,December,18,,St Botolph Bishopsgate,2,0
+1666,11,December,18,,St Sepulchres Parish,8,0
+1666,11,December,18,,St Dunstan West,6,0
+1666,11,December,18,,St George Southwark,2,0
+1666,11,December,18,,St Giles Cripplegate,14,0
+1666,11,December,18,,St Botolph Aldersgate,4,0
+1666,11,December,18,,St Olave Southwark,10,0
+1666,11,December,18,,St Katharine Tower,6,0
+1666,11,December,18,,St Mary Newington,7,1
+1666,11,December,18,,Dunstan Stepney,39,0
+1666,11,December,18,,Lambeth Parish,5,0
+1666,11,December,18,,St Mary Whitechappel,16,0
+1666,11,December,18,,St Giles in the Fields,10,0
+1666,11,December,18,,St Leonard Shoreditch,3,0
+1666,11,December,18,,St James Clerkenwel,4,0
+1666,11,December,18,,St Mary Islington,2,0
+1666,11,December,18,,Rotherhith Parish,4,0
+1666,11,December,18,,John at Hackney,2,0
+1666,11,December,18,,St Mary Magd. Bermondsey,4,0
+1666,11,December,18,,St Margaret Westminster,9,0
+1666,11,December,18,,St Mary Savoy,2,0
+1666,11,December,18,,St Clement Danes,6,1
+1666,11,December,18,,St Martin in the Fields,12,0

--- a/extract_mortality.py
+++ b/extract_mortality.py
@@ -1,0 +1,220 @@
+"""
+Extract parish burial and plague data from 1665.xlsx and 1666.xlsx
+and combine into a single CSV: 1665-1666-burials-plague.csv
+"""
+import openpyxl
+import csv
+import re
+
+MONTH_LOOKUP = {
+    'jan': 'January', 'feb': 'February', 'mar': 'March',
+    'apr': 'April',   'may': 'May',       'jun': 'June',
+    'jul': 'July',    'aug': 'August',    'sep': 'September',
+    'oct': 'October', 'nov': 'November',  'dec': 'December',
+}
+MONTH_NAMES = ['January','February','March','April','May','June',
+               'July','August','September','October','November','December']
+
+
+def normalize_month(s):
+    """Turn any abbreviated/oddly-spelled month name into a canonical form."""
+    clean = re.sub(r'[.\:\-]+', '', s).strip().lower()
+    prefix = clean[:3]
+    if prefix in MONTH_LOOKUP:
+        return MONTH_LOOKUP[prefix]
+    print(f"    WARNING: could not normalize month {s!r}")
+    return s
+
+
+def infer_from_sheet_name(sheet_name):
+    """
+    Fall-back: derive start/end date from the sheet tab name (MM_DD or MM-DD).
+    Assumes a 7-day week.
+    """
+    parts = re.split(r'[-_]', sheet_name)
+    if len(parts) != 2:
+        return None
+    try:
+        mm, dd = int(parts[0]), int(parts[1])
+        end_month = MONTH_NAMES[mm - 1]
+        end_day   = str(dd)
+        start_day_num = dd - 7
+        if start_day_num <= 0:
+            # Crosses a month boundary
+            prev_mm = mm - 1 if mm > 1 else 12
+            start_month = MONTH_NAMES[prev_mm - 1]
+            days_in_prev = [31,28,31,30,31,30,31,31,30,31,30,31][prev_mm - 1]
+            start_day = str(days_in_prev + start_day_num)
+            final_end_month = end_month
+        else:
+            start_month = end_month
+            start_day   = str(start_day_num)
+            final_end_month = ''   # same month — leave End-Month blank
+        print(f"    Inferred from sheet name '{sheet_name}': "
+              f"{start_day} {start_month} → {end_day} {final_end_month or start_month}")
+        return start_day, start_month, end_day, final_end_month
+    except (ValueError, IndexError) as exc:
+        print(f"    ERROR inferring from sheet name '{sheet_name}': {exc}")
+        return None
+
+
+def parse_header(header_text, sheet_name=None):
+    """
+    Parse the date string in the first cell of each sheet.
+    Returns (start_day, start_month, end_day, end_month) where end_month
+    is '' when the week stays within one calendar month.
+    """
+    if not header_text or not isinstance(header_text, str):
+        return infer_from_sheet_name(sheet_name)
+
+    # Match "From the START_DAY [of] START_MONTH to the REMAINDER"
+    # Handles ordinal suffixes (1st, 2nd, 3rd, 6th) and optional "of"
+    # (e.g. "From the 31 January ..." or "From the 1st of May ...").
+    m = re.search(
+        r'[Ff]rom\s+the\s*(\d+)(?:st|nd|rd|th|t|d)?\.?[^A-Za-z]*(?:of\s+)?'
+        r'([A-Za-z][A-Za-z.\:\-]+?)\s+to\s+the\s+(.+)',
+        header_text
+    )
+    if not m:
+        print(f"    WARNING: header parse failed for {header_text!r}")
+        return infer_from_sheet_name(sheet_name)
+
+    start_day   = m.group(1)
+    start_month = normalize_month(m.group(2))
+    remainder   = m.group(3).strip()
+
+    # Strip trailing year (4 digits) and any trailing punctuation/spaces
+    remainder = re.sub(r'\s*\d{4}\.?\s*$', '', remainder).strip()
+    # Strip editorial annotations like "[sic]" before processing
+    remainder = re.sub(r'\[.*?\]', '', remainder).strip()
+
+    # Extract end day, accounting for ordinal suffixes (st, nd, rd, th, t, d)
+    end_m = re.match(r'(\d+)(?:st|nd|rd|th|t|d)?\.?[^A-Za-z]*', remainder)
+    if not end_m:
+        print(f"    WARNING: cannot extract end day from {remainder!r}")
+        return infer_from_sheet_name(sheet_name)
+
+    end_day    = end_m.group(1)
+    after_day  = remainder[end_m.end():].strip()
+    # Strip leading "of " if present
+    after_day  = re.sub(r'^of\s+', '', after_day, flags=re.IGNORECASE).strip()
+
+    # Whatever alphabetic token remains is the end month (if any)
+    if after_day and re.match(r'^[A-Za-z]', after_day):
+        tok = re.match(r'([A-Za-z][A-Za-z.\:\-]*)', after_day)
+        end_month = normalize_month(tok.group(1)) if tok else ''
+        if end_month == start_month:
+            end_month = ''   # same month — leave End-Month blank in CSV
+    else:
+        end_month = ''
+
+    return start_day, start_month, end_day, end_month
+
+
+def is_skip_row(parish_name):
+    """Return True for rows that should be excluded from output."""
+    if not parish_name or not isinstance(parish_name, str):
+        return True
+    low = parish_name.lower().strip()
+    # Summary totals
+    if low.startswith('buried in'):
+        return True
+    # Christenings rows (any variety)
+    if 'christn' in low or 'christening' in low:
+        return True
+    # Non-parish labels
+    if low.startswith('page') or low.startswith('['):
+        return True
+    if low.startswith('source:') or 'eebo' in low or low.startswith('jmo'):
+        return True
+    if low.startswith('whereof'):
+        return True
+    # Diseases section header (loop stops here anyway, but just in case)
+    if 'diseases and' in low and 'casual' in low:
+        return True
+    return False
+
+
+def extract_sheet(ws, year, sheet_name):
+    """Return a list of record dicts for one worksheet."""
+    rows = list(ws.iter_rows(values_only=True))
+    if not rows:
+        return []
+
+    header_text = rows[0][0] if rows[0] else None
+    date_info   = parse_header(header_text, sheet_name)
+    if date_info is None:
+        print(f"    SKIPPING sheet '{sheet_name}' — cannot determine date")
+        return []
+
+    start_day, start_month, end_day, end_month = date_info
+    records = []
+
+    # rows[0] = date header, rows[1] = "Bur." / "Plag." column labels → skip both
+    for row in rows[2:]:
+        # Stop at "The Diseases and Casualties this Week."
+        row_text = ' '.join(str(v) for v in row if v is not None)
+        if 'diseases and' in row_text.lower() and 'casual' in row_text.lower():
+            break
+
+        # Three column triplets: cols 0-1-2, 3-4-5, 6-7-8
+        for offset in (0, 3, 6):
+            if offset + 2 >= len(row):
+                continue
+            parish = row[offset]
+            bur    = row[offset + 1]
+            plag   = row[offset + 2]
+
+            if not isinstance(parish, str) or not parish.strip():
+                continue
+            if not isinstance(bur, (int, float)):
+                continue
+            if is_skip_row(parish):
+                continue
+
+            bur_val  = int(round(bur))
+            plag_val = int(round(plag)) if isinstance(plag, (int, float)) else 0
+
+            records.append({
+                'Year':                  year,
+                'Start-Day':             start_day,
+                'Start-Month':           start_month,
+                'End-Day':               end_day,
+                'End-Month':             end_month,
+                'Parish Name':           parish.strip(),
+                'Total Parish Burials':  bur_val,
+                'Parish Plague Burials': plag_val,
+            })
+
+    return records
+
+
+def main():
+    base = '/home/user/agentic-experiment'
+    all_records = []
+
+    for year_str in ('1665', '1666'):
+        filepath = f'{base}/{year_str}.xlsx'
+        print(f'\nProcessing {filepath}...')
+        wb = openpyxl.load_workbook(filepath, data_only=True)
+        for sheet_name in wb.sheetnames:
+            ws = wb[sheet_name]
+            recs = extract_sheet(ws, int(year_str), sheet_name)
+            print(f'  {sheet_name}: {len(recs)} records')
+            all_records.extend(recs)
+
+    output = f'{base}/1665-1666-burials-plague.csv'
+    fieldnames = [
+        'Year', 'Start-Day', 'Start-Month', 'End-Day', 'End-Month',
+        'Parish Name', 'Total Parish Burials', 'Parish Plague Burials',
+    ]
+    with open(output, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(all_records)
+
+    print(f'\nDone — wrote {len(all_records)} records to {output}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Extracted parish-level burial and plague death counts from 1665.xlsx and 1666.xlsx (102 weekly sheets total) into a single consolidated CSV. Columns: Year, Start-Day, Start-Month, End-Day, End-Month, Parish Name, Total Parish Burials, Parish Plague Burials.

End-Month is left blank for same-month weeks; populated only when a week crosses a calendar month boundary.

Also adds extract_mortality.py, the script used to generate the CSV. 12,353 parish records written.

https://claude.ai/code/session_01YLUXCdgqBZpstmequUXSqo