### PR TITLE
Fix pre-existing 'is gte' syntax errors in bio passage — bump to v1.57

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v1.56" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v1.57" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -1164,7 +1164,7 @@ You were born and raised in &lt;&lt;if $origin is &quot;London&quot;&gt;&gt;Lond
 &lt;&lt;/if&gt;&gt;
 
 /* add family for married YA, MA, elderly adults */
-&lt;&lt;if $agenum is gte 16&gt;&gt;
+&lt;&lt;if $agenum gte 16&gt;&gt;
   &lt;&lt;if $relationship is &quot;married&quot;&gt;&gt;&lt;&lt;addPartnerNPC&gt;&gt;
   &lt;&lt;/if&gt;&gt;
   &lt;&lt;if $relationship is &quot;married&quot; or $relationship is &quot;widowed&quot;&gt;&gt;
@@ -1187,7 +1187,7 @@ You were born and raised in &lt;&lt;if $origin is &quot;London&quot;&gt;&gt;Lond
 &lt;&lt;/if&gt;&gt;
 
 /* add unmarried or widowed adult family */
-&lt;&lt;if $agenum is gte 60&gt;&gt;
+&lt;&lt;if $agenum gte 60&gt;&gt;
     &lt;&lt;if $relationship is &quot;single&quot; or $relationship is &quot;widowed&quot;&gt;&gt;
       &lt;&lt;if $socio is &quot;beggars&quot; or $socio is &quot;day labourers&quot;&gt;&gt;
         &lt;&lt;if random(1,2) is 1&gt;&gt;


### PR DESCRIPTION
Fix two SugarCube syntax errors in the bio passage where `$agenum is gte 16` and `$agenum is gte 60` used the invalid `is gte` operator combination (`is` = `===`, `gte` = `>=`, producing `=== >=`). Changed both to `$agenum gte 16` and `$agenum gte 60`. This was a pre-existing bug, not introduced by recent changes.

Modified pid: 1 (bio)

https://claude.ai/code/session_01Vh8jHh5RHqmyVQDFLxkFGv