### PR TITLE
Make life events, offers, and First Plague Day non-interrupting — bum…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v1.57" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v1.58" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -2201,7 +2201,7 @@ You
             &lt;&lt;if $socio isnot &quot;beggars&quot;&gt;&gt;
         [[You know that plague only grows worse as the weather warms and you dread the coming of June and the first real heat of summer.-&gt;June 1665]]
             &lt;&lt;/if&gt;&gt;
-      &lt;&lt;else&gt;&gt;[[Worse, the first case of plague has appeared in your parish.-&gt;First Plague Day]]
+      &lt;&lt;else&gt;&gt;&lt;&lt;linkappend &quot;Worse, the first case of plague has appeared in your parish.&quot;&gt;&gt;&lt;br&gt;&lt;br&gt;&lt;&lt;include &quot;First Plague Day&quot;&gt;&gt;&lt;&lt;/linkappend&gt;&gt;
     &lt;&lt;/if&gt;&gt;&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/c/c4/Lord_haue_mercy_on_London.jpg&quot; width=&quot;100%&quot;&gt;
 //Lord haue mercy on London, c. 1665.//&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;take their word for it.&quot;&gt;&gt;&lt;&lt;replace &quot;#decision&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;May 1665: Took their word about the plague&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;take their word for it and not investigate further.
     &lt;br&gt;
@@ -2209,7 +2209,7 @@ You
             &lt;&lt;if $socio isnot &quot;beggars&quot;&gt;&gt;
         [[You know that plague only grows worse as the weather warms and you dread the coming of June and the first real heat of summer.-&gt;June 1665]]
             &lt;&lt;/if&gt;&gt;
-      &lt;&lt;else&gt;&gt;[[Worse, the first case of plague has appeared in your parish.-&gt;First Plague Day]]
+      &lt;&lt;else&gt;&gt;&lt;&lt;linkappend &quot;Worse, the first case of plague has appeared in your parish.&quot;&gt;&gt;&lt;br&gt;&lt;br&gt;&lt;&lt;include &quot;First Plague Day&quot;&gt;&gt;&lt;&lt;/linkappend&gt;&gt;
     &lt;&lt;/if&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;
     &lt;/span&gt;
     &lt;&lt;fumigant&gt;&gt;
@@ -5055,7 +5055,7 @@ You died with a good enough reputation that your neighbors say prayers for your 
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="102" name="fever" tags="widget" position="2675,375" size="100,100">&lt;&lt;widget &quot;fever&quot;&gt;&gt;
 &lt;&lt;nobr&gt;&gt;
-&lt;&lt;if random(0,10) is 1&gt;&gt;Send not to know for whom the church bells toll. They toll for you. You have come down with a mysterious fever. &lt;&lt;if $reputation gt 0&gt;&gt;Despite the care of your friends and family,&lt;&lt;else&gt;&gt;Your reputation is so low that no one will lend you aid in your sickness and&lt;&lt;/if&gt;&gt; you die.
+&lt;&lt;if random(0,10) is 1&gt;&gt;&lt;&lt;set _eventCausedDeath to true&gt;&gt;Send not to know for whom the church bells toll. They toll for you. You have come down with a mysterious fever. &lt;&lt;if $reputation gt 0&gt;&gt;Despite the care of your friends and family,&lt;&lt;else&gt;&gt;Your reputation is so low that no one will lend you aid in your sickness and&lt;&lt;/if&gt;&gt; you die.
 &lt;&lt;if hasVisited(&quot;May 1666&quot;)&gt;&gt;
 &lt;&lt;if $reputation lt 0&gt;&gt; You died with such a poor reputation that most of your neighbors didn&#39;t care. The rest of them probably cursed your name and hoped you were suffering in hell. Luckily, 
 &lt;&lt;else&gt;&gt; You died with a good enough reputation that your neighbors say prayers for your soul. Because of the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; ordinances, none of your neighbors could attend your funeral but 
@@ -5078,7 +5078,7 @@ You died with a good enough reputation that your neighbors say prayers for your 
 &lt;&lt;if $religion is &quot;Catholic&quot;&gt;&gt;As a God-fearing Catholic, you know you are destined to spend time in purgatory before you can ascend to heaven but you hope that will not take too long&lt;&lt;if $reputation lte 0&gt;&gt;, despite your poor reputation on earth.&lt;&lt;/if&gt;&gt;&lt;&lt;else&gt;&gt;As a good Protestant, you know that Christ the Redeemer has died for you and your admittance to heaven is guaranteed.&lt;&lt;/if&gt;&gt;&lt;br&gt;&lt;br&gt;
 [[At least you didn&#39;t die of plague-&gt;stats]]
 &lt;&lt;else&gt;&gt;
-&lt;&lt;set $money -=2&gt;&gt;Alack! You have come down with a mysterious fever.&lt;&lt;if $reputation gt 0&gt;&gt; Your reputation is high enough that your friends and family take diligent care of you in your sickness and&lt;&lt;else&gt;&gt; Your reputation is so low that no one lends you aid in your sickness but&lt;&lt;/if&gt;&gt; you slowly recover. &lt;&lt;storyline-return&gt;&gt;
+&lt;&lt;set $money -=2&gt;&gt;Alack! You have come down with a mysterious fever.&lt;&lt;if $reputation gt 0&gt;&gt; Your reputation is high enough that your friends and family take diligent care of you in your sickness and&lt;&lt;else&gt;&gt; Your reputation is so low that no one lends you aid in your sickness but&lt;&lt;/if&gt;&gt; you slowly recover.
 &lt;br&gt;&lt;br&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;
@@ -5113,7 +5113,7 @@ You serve in the Navy through the war against the Dutch, leaving service in 1667
 &lt;&lt;nobr&gt;&gt;
 Despite everything, business continues. A friend from the countryside writes to you&lt;&lt;if $agenum lte 15&gt;&gt;r family&lt;&lt;/if&gt;&gt; and asks if you will take in their son as your apprentice.
 &lt;br&gt;&lt;br&gt;
-&lt;span id=&quot;apprentice&quot;&gt;Will you accept him into your home? &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#apprentice&quot;&gt;&gt;You accept him into your home. It&#39;s another mouth to feed, but you could use the help and are glad to do a friend a favor. &lt;&lt;storyline-return&gt;&gt;&lt;&lt;addApprenticeNPC&gt;&gt;&lt;&lt;set $apprentice to 0&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#apprentice&quot;&gt;&gt;You don&#39;t accept him into your home. Things are too hard right now. You can&#39;t afford another mouth to feed and you don&#39;t have the time to teach someone else your trade. &lt;&lt;storyline-return&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
+&lt;span id=&quot;apprentice&quot;&gt;Will you accept him into your home? &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#apprentice&quot;&gt;&gt;You accept him into your home. It&#39;s another mouth to feed, but you could use the help and are glad to do a friend a favor.&lt;&lt;addApprenticeNPC&gt;&gt;&lt;&lt;set $apprentice to 0&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#apprentice&quot;&gt;&gt;You don&#39;t accept him into your home. Things are too hard right now. You can&#39;t afford another mouth to feed and you don&#39;t have the time to teach someone else your trade.&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;
 
@@ -5284,13 +5284,13 @@ Despite everything, business continues. A friend from the countryside writes to 
 &lt;&lt;nobr&gt;&gt;
 Despite everything, you &lt;&lt;if $socio is &quot;day labourers&quot;&gt;&gt;keep finding opportunities for work&lt;&lt;else&gt;&gt;know you are lucky to be steadily employed as a servant&lt;&lt;/if&gt;&gt;. A friend from the countryside writes to you&lt;&lt;if $agenum lte 15&gt;&gt;r family&lt;&lt;/if&gt;&gt; and asks if you will take in their child so they can also seek work in London. 
 &lt;br&gt;&lt;br&gt;
-&lt;span id=&quot;worker&quot;&gt;Will you accept them into your home? &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#worker&quot;&gt;&gt;You accept them into your home. It&#39;s another mouth to feed, but you are glad to do a friend a favor. &lt;&lt;storyline-return&gt;&gt;&lt;&lt;addWorkerKidNPC&gt;&gt;&lt;&lt;set $worker to 0&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#worker&quot;&gt;&gt;You don&#39;t accept them into your home. Things are too hard right now. You can&#39;t afford another mouth to feed and you don&#39;t have the time to teach someone else the lay of the city. &lt;&lt;storyline-return&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
+&lt;span id=&quot;worker&quot;&gt;Will you accept them into your home? &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#worker&quot;&gt;&gt;You accept them into your home. It&#39;s another mouth to feed, but you are glad to do a friend a favor.&lt;&lt;addWorkerKidNPC&gt;&gt;&lt;&lt;set $worker to 0&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#worker&quot;&gt;&gt;You don&#39;t accept them into your home. Things are too hard right now. You can&#39;t afford another mouth to feed and you don&#39;t have the time to teach someone else the lay of the city.&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="107" name="ward" tags="widget" position="1800,1425" size="100,100">&lt;&lt;widget &quot;ward&quot;&gt;&gt;
 &lt;&lt;nobr&gt;&gt;
 Despite everything, court life proceeds as usual. A friend living the countryside writes to you&lt;&lt;if $agenum lte 15&gt;&gt;r family&lt;&lt;/if&gt;&gt; and asks if you will take in their child as your ward and help them get a place at court - and maybe even an advantageous marriage.
 &lt;br&gt;&lt;br&gt;
-&lt;span id=&quot;ward&quot;&gt;Will you accept them into your home? &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#ward&quot;&gt;&gt;You accept them into your home. It will cost a small fortune to outfit a newcomer to court and provide the king the necessary gifts but you will control their purse strings and are glad to do a friend a favor. &lt;&lt;storyline-return&gt;&gt;&lt;&lt;addWardNPC&gt;&gt;&lt;&lt;set $ward to 0&gt;&gt;&lt;&lt;set $money -=5600&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#ward&quot;&gt;&gt;You don&#39;t accept them into your home. Your own affairs are not quite in order and you need to focus on setting them right before adding another person to the household. You don&#39;t have the time to teach someone else the ways of court. &lt;&lt;storyline-return&gt;&gt;.&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
+&lt;span id=&quot;ward&quot;&gt;Will you accept them into your home? &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#ward&quot;&gt;&gt;You accept them into your home. It will cost a small fortune to outfit a newcomer to court and provide the king the necessary gifts but you will control their purse strings and are glad to do a friend a favor.&lt;&lt;addWardNPC&gt;&gt;&lt;&lt;set $ward to 0&gt;&gt;&lt;&lt;set $money -=5600&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#ward&quot;&gt;&gt;You don&#39;t accept them into your home. Your own affairs are not quite in order and you need to focus on setting them right before adding another person to the household. You don&#39;t have the time to teach someone else the ways of court..&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;
 </tw-passagedata><tw-passagedata pid="108" name="marriage-market" tags="widget" position="2675,175" size="100,100">&lt;&lt;widget &quot;marriage-market&quot;&gt;&gt;
@@ -5314,9 +5314,9 @@ You have found a &lt;&lt;if $gender is &quot;female&quot;&gt;&gt;husband&lt;&lt;
 &lt;span id=&quot;format&quot;&gt;Do you want to 
 &lt;ul&gt;
 &lt;li&gt;&lt;&lt;link &quot;be married in your parish church&quot;&gt;&gt;&lt;&lt;set $money -=48&gt;&gt;&lt;&lt;set $reputation +=2&gt;&gt;&lt;&lt;unset $seeking&gt;&gt;&lt;&lt;unset $wedding&gt;&gt;&lt;&lt;set $relationship to &quot;married&quot;&gt;&gt;&lt;&lt;addPartnerNPC&gt;&gt;&lt;&lt;replace &quot;#format&quot;&gt;&gt;For the three weeks before the wedding, your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; priest reads the banns and then you are married in a nice ceremony in the church of $parish.
-After the dancing and feasting, you go home with your new spouse at your side. &lt;&lt;storyline-return&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
-&lt;li&gt;&lt;&lt;link &quot;pay for a private wedding license&quot;&gt;&gt;&lt;&lt;set $money -=96&gt;&gt;&lt;&lt;unset $seeking&gt;&gt;&lt;&lt;unset $wedding&gt;&gt;&lt;&lt;set $plagueInfection to random(1,30)&gt;&gt;&lt;&lt;set $relationship to &quot;married&quot;&gt;&gt;&lt;&lt;addPartnerNPC&gt;&gt;&lt;&lt;replace &quot;#format&quot;&gt;&gt;Rather than wait for three weeks ot have the banns read, you obtain a license to get married sooner at home.&lt;&lt;storyline-return&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
-&lt;li&gt;&lt;&lt;link &quot;elope at Fleet prison&quot;&gt;&gt;&lt;&lt;set $money -=72&gt;&gt;&lt;&lt;set $reputation -=2&gt;&gt;&lt;&lt;unset $seeking&gt;&gt;&lt;&lt;unset $wedding&gt;&gt;&lt;&lt;set $plagueInfection to random(1,30)&gt;&gt;&lt;&lt;set $relationship to &quot;married&quot;&gt;&gt;&lt;&lt;addPartnerNPC&gt;&gt;&lt;&lt;replace &quot;#format&quot;&gt;&gt;Rather than going through the fuss of a formal wedding, you go to the Fleet prison where you find a priest willing to marry you in a nearby tavern without asking too many questions. &lt;&lt;storyline-return&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/span&gt;
+After the dancing and feasting, you go home with your new spouse at your side.&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
+&lt;li&gt;&lt;&lt;link &quot;pay for a private wedding license&quot;&gt;&gt;&lt;&lt;set $money -=96&gt;&gt;&lt;&lt;unset $seeking&gt;&gt;&lt;&lt;unset $wedding&gt;&gt;&lt;&lt;set $plagueInfection to random(1,30)&gt;&gt;&lt;&lt;set $relationship to &quot;married&quot;&gt;&gt;&lt;&lt;addPartnerNPC&gt;&gt;&lt;&lt;replace &quot;#format&quot;&gt;&gt;Rather than wait for three weeks ot have the banns read, you obtain a license to get married sooner at home.&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
+&lt;li&gt;&lt;&lt;link &quot;elope at Fleet prison&quot;&gt;&gt;&lt;&lt;set $money -=72&gt;&gt;&lt;&lt;set $reputation -=2&gt;&gt;&lt;&lt;unset $seeking&gt;&gt;&lt;&lt;unset $wedding&gt;&gt;&lt;&lt;set $plagueInfection to random(1,30)&gt;&gt;&lt;&lt;set $relationship to &quot;married&quot;&gt;&gt;&lt;&lt;addPartnerNPC&gt;&gt;&lt;&lt;replace &quot;#format&quot;&gt;&gt;Rather than going through the fuss of a formal wedding, you go to the Fleet prison where you find a priest willing to marry you in a nearby tavern without asking too many questions.&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/span&gt;
 
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="110" name="NPC-death widget" tags="widget" position="300,1025" size="100,100">&lt;&lt;widget &quot;NPC-death&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
@@ -5443,11 +5443,11 @@ After the dancing and feasting, you go home with your new spouse at your side. &
 &lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="111" name="pregnant" tags="widget" position="2500,75" size="100,100">&lt;&lt;widget &quot;pregnant&quot;&gt;&gt;
 &lt;&lt;nobr&gt;&gt;
 &lt;&lt;set $pregnant to 4&gt;&gt;
-You have realized you are pregnant! You look forward to adding a new member to the family&lt;&lt;if $socio is &quot;beggars&quot; or $socio is &quot;day labourers&quot;&gt;&gt; even if it means another mouth to feed&lt;&lt;/if&gt;&gt;. In a few months you&#39;ll have a new baby, but until then life continues as usual. &lt;&lt;storyline-return&gt;&gt;
+You have realized you are pregnant! You look forward to adding a new member to the family&lt;&lt;if $socio is &quot;beggars&quot; or $socio is &quot;day labourers&quot;&gt;&gt; even if it means another mouth to feed&lt;&lt;/if&gt;&gt;. In a few months you&#39;ll have a new baby, but until then life continues as usual.
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="112" name="birth" tags="widget" position="2750,500" size="100,100">&lt;&lt;widget &quot;birth&quot;&gt;&gt;
 &lt;&lt;nobr&gt;&gt;
-&lt;&lt;if random(1,30) is 1&gt;&gt;Send not to know for whom the church bells toll. They toll for you. You died in childbirth.
+&lt;&lt;if random(1,30) is 1&gt;&gt;&lt;&lt;set _eventCausedDeath to true&gt;&gt;Send not to know for whom the church bells toll. They toll for you. You died in childbirth.
 &lt;&lt;if $reputation lt 0&gt;&gt; You died with such a poor reputation that most of your neighbors didn&#39;t care. The rest of them probably cursed your name and hoped you were suffering in hell. Luckily, 
 &lt;&lt;else&gt;&gt; You died with a good enough reputation that your neighbors say prayers for your soul. Because of the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; ordinances, none of your neighbors could attend your funeral but 
 &lt;&lt;if $socio is &quot;nobles&quot;&gt;&gt;as a member of the nobility, you were interred in a position of honor in a vault within your family&#39;s private chapel.
@@ -5458,7 +5458,7 @@ You have realized you are pregnant! You look forward to adding a new member to t
 &lt;&lt;if $religion is &quot;Catholic&quot;&gt;&gt;As a God-fearing Catholic, you know you are destined to spend time in purgatory before you can ascend to heaven but you hope that will not take too long&lt;&lt;if $reputation lte 0&gt;&gt;, despite your poor reputation on earth.&lt;&lt;/if&gt;&gt;&lt;&lt;else&gt;&gt;As a good Protestant, you know that Christ the Redeemer has died for you and your admittance to heaven is guaranteed.&lt;&lt;/if&gt;&gt;&lt;br&gt;&lt;br&gt;
 [[At least you didn&#39;t die of plague-&gt;stats]]
 &lt;&lt;else&gt;&gt;
-&lt;&lt;if random(1,4) is 1&gt;&gt;After a long, hard labor you are devastated to find your baby was stillborn. You bury &lt;&lt;either &quot;him&quot; &quot;her&quot;&gt;&gt;&lt;&lt;set $money -=9&gt;&gt; and attempt to move on.&lt;&lt;storyline-return&gt;&gt;
+&lt;&lt;if random(1,4) is 1&gt;&gt;After a long, hard labor you are devastated to find your baby was stillborn. You bury &lt;&lt;either &quot;him&quot; &quot;her&quot;&gt;&gt;&lt;&lt;set $money -=9&gt;&gt; and attempt to move on.
 &lt;&lt;else&gt;&gt;
 &lt;&lt;addNewbornNPC&gt;&gt;After a long, hard labor you are delighted to add a baby to your family. 
 
@@ -5485,7 +5485,6 @@ You quickly baptize them&lt;&lt;set $money -=6&gt;&gt; and pray to God that $NPC
 &lt;&lt;/replace&gt;&gt;
 &lt;&lt;/link&gt;&gt;
 &lt;/span&gt;
-&lt;&lt;storyline-return&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;
@@ -5493,7 +5492,7 @@ You quickly baptize them&lt;&lt;set $money -=6&gt;&gt; and pray to God that $NPC
 </tw-passagedata><tw-passagedata pid="113" name="miscarriage" tags="widget" position="2350,150" size="100,100">&lt;&lt;widget &quot;miscarriage&quot;&gt;&gt;
 &lt;&lt;nobr&gt;&gt;
 &lt;&lt;unset $pregnant&gt;&gt;&lt;&lt;unset $miscarriage&gt;&gt;
-Unfortunately, you have suffered a miscarriage and are no longer pregnant. &lt;&lt;storyline-return&gt;&gt;
+Unfortunately, you have suffered a miscarriage and are no longer pregnant.
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="114" name="random events widget" tags="widget" position="2000,50" size="100,100">&lt;&lt;widget &quot;random-events&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
 &lt;&lt;set _randomEventFired to true&gt;&gt;
@@ -5550,14 +5549,19 @@ Unfortunately, you have suffered a miscarriage and are no longer pregnant. &lt;&
 		&lt;&lt;elderly&gt;&gt;
 	&lt;&lt;elseif $seeking is 1 and $wedding is 1&gt;&gt;
 		&lt;&lt;wedding&gt;&gt;
+	&lt;&lt;set _randomEventFired to false&gt;&gt;
 	&lt;&lt;elseif $pregnant is 4&gt;&gt; /* Pregnancy and Marriage */
 		&lt;&lt;pregnant&gt;&gt;
+	&lt;&lt;set _randomEventFired to false&gt;&gt;
 	&lt;&lt;elseif $pregnant isnot 3 and $pregnant isnot 2 and $pregnant isnot 1 and $pregnant isnot 0 and $miscarriage is 1&gt;&gt;
 		&lt;&lt;miscarriage&gt;&gt;
+	&lt;&lt;set _randomEventFired to false&gt;&gt;
 	&lt;&lt;elseif $pregnant is 9&gt;&gt;
 		&lt;&lt;birth&gt;&gt;
+	&lt;&lt;if not _eventCausedDeath&gt;&gt;&lt;&lt;set _randomEventFired to false&gt;&gt;&lt;&lt;/if&gt;&gt;
 	&lt;&lt;elseif $fever is 1&gt;&gt; /* Random Fevers and Socio dependent events */
 		&lt;&lt;fever&gt;&gt;
+	&lt;&lt;if not _eventCausedDeath&gt;&gt;&lt;&lt;set _randomEventFired to false&gt;&gt;&lt;&lt;/if&gt;&gt;
 	&lt;&lt;elseif $socio is &quot;nobles&quot;&gt;&gt; 
 		&lt;&lt;set $steward to random(1,40)&gt;&gt;
 		&lt;&lt;if $ward isnot 0&gt;&gt;
@@ -5567,6 +5571,7 @@ Unfortunately, you have suffered a miscarriage and are no longer pregnant. &lt;&
 			&lt;&lt;steward&gt;&gt;
 		&lt;&lt;elseif $ward is 1 and hasVisited(&quot;March 1666&quot;)&gt;&gt; /* household additions only occur after height of plague */
 			&lt;&lt;ward&gt;&gt;
+		&lt;&lt;set _randomEventFired to false&gt;&gt;
 		&lt;&lt;else&gt;&gt;
 			&lt;&lt;set _randomEventFired to false&gt;&gt;
 		&lt;&lt;/if&gt;&gt;
@@ -5579,6 +5584,7 @@ Unfortunately, you have suffered a miscarriage and are no longer pregnant. &lt;&
 			&lt;&lt;accident&gt;&gt;
 		&lt;&lt;elseif $worker is 1 and hasVisited(&quot;March 1666&quot;)&gt;&gt;
 			&lt;&lt;worker-kid&gt;&gt;
+		&lt;&lt;set _randomEventFired to false&gt;&gt;
 		&lt;&lt;else&gt;&gt;
 			&lt;&lt;set _randomEventFired to false&gt;&gt;
 		&lt;&lt;/if&gt;&gt;
@@ -5594,6 +5600,7 @@ Unfortunately, you have suffered a miscarriage and are no longer pregnant. &lt;&
 			&lt;&lt;set $apprentice to random(1,10)&gt;&gt;
 			&lt;&lt;if $apprentice is 1 and hasVisited(&quot;March 1666&quot;)&gt;&gt;
 				&lt;&lt;apprentice&gt;&gt;
+			&lt;&lt;set _randomEventFired to false&gt;&gt;
 			&lt;&lt;else&gt;&gt;
 				&lt;&lt;set _randomEventFired to false&gt;&gt;
 			&lt;&lt;/if&gt;&gt;
@@ -5639,7 +5646,7 @@ The &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; grows worse and the streets are
         [[Continue to July 1665-&gt;July 1665]]
         &lt;&lt;/if&gt;&gt;
 /* If not in city walls or western suburbs */
-    &lt;&lt;elseif $location isnot &quot;in another part of the western suburbs&quot;&gt;&gt;[[Worse, the first case of plague has appeared in your parish.-&gt;First Plague Day]]
+    &lt;&lt;elseif $location isnot &quot;in another part of the western suburbs&quot;&gt;&gt;&lt;&lt;linkappend &quot;Worse, the first case of plague has appeared in your parish.&quot;&gt;&gt;&lt;br&gt;&lt;br&gt;&lt;&lt;include &quot;First Plague Day&quot;&gt;&gt;&lt;&lt;/linkappend&gt;&gt;
     &lt;&lt;/if&gt;&gt;
     
 /* If location is western suburbs */


### PR DESCRIPTION
…p to v1.58

Previously, all random events (weddings, pregnancies, fevers, apprentice offers, etc.) completely replaced the month's storyline text, causing players to miss what was happening in the city that month.

Now the following events display inline alongside the month's narrative:
- Life events: wedding, pregnancy announcement, miscarriage, non-fatal birth, non-fatal fever (fatal outcomes still interrupt as before)
- Socio-class offers: ward, worker-kid, apprentice
- First Plague Day: now appears inline via <<linkappend>>/<<include>>
  within the May 1665 and June 1665 passages instead of redirecting

Implementation:
- random-events widget (pid 114): set _randomEventFired to false after inline events so the month passage gate stays open
- 8 event widgets (pids 102,104,106,107,109,111,112,113): removed <<storyline-return>> from non-death paths; added _eventCausedDeath flag to birth and fever death paths
- May 1665 (pid 16) and june-1665-helper (pid 116): replaced [[->First Plague Day]] links with <<linkappend>><<include>>

Events that remain fully interrupting (unchanged):
- All plague events (sickPC, sickFam, sickOtherHH)
- Elderly death, accidents, run-over-by-cart, steward death
- Death paths within birth (1/30) and fever (1/11)

https://claude.ai/code/session_01Uti8wtwYkmjbDmrxvk4WSk