### PR TITLE
Fix infected NPCs getting permanently stuck in $FledFamily/$FledServants

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v1.62" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v1.63" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -2726,6 +2726,7 @@ As morning dawns, a terrible realization settles over your &lt;&lt;defHousehold 
     /* Move everyone except the staying adult to FledFamily */
     &lt;&lt;for _fi = 0; _fi &lt; $NPCs.length; _fi++&gt;&gt;
         &lt;&lt;if _fi isnot _stayIdx&gt;&gt;
+            &lt;&lt;if $NPCs[_fi].health is &quot;infected&quot;&gt;&gt;&lt;&lt;if random(1,2) eq 1&gt;&gt;&lt;&lt;set $NPCs[_fi].health to &quot;deceased&quot;&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $NPCs[_fi].health to &quot;recovered&quot;&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;
             &lt;&lt;set $FledFamily.push($NPCs[_fi])&gt;&gt;
         &lt;&lt;/if&gt;&gt;
     &lt;&lt;/for&gt;&gt;
@@ -2737,12 +2738,14 @@ As morning dawns, a terrible realization settles over your &lt;&lt;defHousehold 
     /* If the child has servants, keep the oldest one */
     &lt;&lt;if $NPCsServants.length gt 0&gt;&gt;
         &lt;&lt;for _fs = 1; _fs &lt; $NPCsServants.length; _fs++&gt;&gt;
+            &lt;&lt;if $NPCsServants[_fs].health is &quot;infected&quot;&gt;&gt;&lt;&lt;if random(1,2) eq 1&gt;&gt;&lt;&lt;set $NPCsServants[_fs].health to &quot;deceased&quot;&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $NPCsServants[_fs].health to &quot;recovered&quot;&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;
             &lt;&lt;set $FledServants.push($NPCsServants[_fs])&gt;&gt;
         &lt;&lt;/for&gt;&gt;
         &lt;&lt;set $NPCsServants to $NPCsServants.slice(0, 1)&gt;&gt;
     &lt;&lt;/if&gt;&gt;
 &lt;&lt;else&gt;&gt;
     &lt;&lt;for _f range $NPCs&gt;&gt;
+            &lt;&lt;if _f.health is &quot;infected&quot;&gt;&gt;&lt;&lt;if random(1,2) eq 1&gt;&gt;&lt;&lt;set _f.health to &quot;deceased&quot;&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set _f.health to &quot;recovered&quot;&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;
             &lt;&lt;set $FledFamily.push(_f)&gt;&gt;
     &lt;&lt;/for&gt;&gt;
     &lt;&lt;set $NPCs to []&gt;&gt;
@@ -2752,6 +2755,7 @@ As morning dawns, a terrible realization settles over your &lt;&lt;defHousehold 
         &lt;&lt;if _keepCount gt $NPCsServants.length&gt;&gt;&lt;&lt;set _keepCount to $NPCsServants.length&gt;&gt;&lt;&lt;/if&gt;&gt;
         &lt;&lt;set _totalServants to $NPCsServants.length&gt;&gt;
         &lt;&lt;for _fs to _keepCount; _fs lt _totalServants; _fs++&gt;&gt;
+            &lt;&lt;if $NPCsServants[_fs].health is &quot;infected&quot;&gt;&gt;&lt;&lt;if random(1,2) eq 1&gt;&gt;&lt;&lt;set $NPCsServants[_fs].health to &quot;deceased&quot;&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $NPCsServants[_fs].health to &quot;recovered&quot;&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;
             &lt;&lt;set $FledServants.push($NPCsServants[_fs])&gt;&gt;
         &lt;&lt;/for&gt;&gt;
         &lt;&lt;set $NPCsServants to $NPCsServants.slice(0, _keepCount)&gt;&gt;
@@ -4411,7 +4415,7 @@ The official Thanksgiving Day for the end of the plague is proclaimed in Novembe
 
 Life may go on for the reckless, but it will not be until 1667 that you&lt;&lt;if $agenum lte 15&gt;&gt; and your family&lt;&lt;/if&gt;&gt; finally make your way [[back to the city-&gt;December 1666]].
 &lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="89" name="Stay" tags="" position="725,1025" size="100,100">&lt;&lt;nobr&gt;&gt;
-&lt;&lt;set _fleeBlocked to false&gt;&gt;&lt;&lt;if $fled is 5&gt;&gt;&lt;&lt;silently&gt;&gt;&lt;&lt;for _npc range $NPCs&gt;&gt;&lt;&lt;if _npc.health is &quot;infected&quot;&gt;&gt;&lt;&lt;set _fleeBlocked to true&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;/silently&gt;&gt;&lt;&lt;if _fleeBlocked&gt;&gt;&lt;&lt;set $fled to 4&gt;&gt;You prepare your household to flee the city. It takes some time to sort out the travel logistics, but finally everything is in order. They will leave tomorrow.&lt;br&gt;&lt;br&gt;
+&lt;&lt;set _fleeBlocked to false&gt;&gt;&lt;&lt;if $fled is 5&gt;&gt;&lt;&lt;silently&gt;&gt;&lt;&lt;for _npc range $NPCs&gt;&gt;&lt;&lt;if _npc.health is &quot;infected&quot;&gt;&gt;&lt;&lt;set _fleeBlocked to true&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;for _sv range $NPCsServants&gt;&gt;&lt;&lt;if _sv.health is &quot;infected&quot;&gt;&gt;&lt;&lt;set _fleeBlocked to true&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;/silently&gt;&gt;&lt;&lt;if _fleeBlocked&gt;&gt;&lt;&lt;set $fled to 4&gt;&gt;You prepare your household to flee the city. It takes some time to sort out the travel logistics, but finally everything is in order. They will leave tomorrow.&lt;br&gt;&lt;br&gt;
 &lt;&lt;sickFam&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;fled-family&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;if not _fleeBlocked&gt;&gt;
     /* Beggars */


### PR DESCRIPTION
The <<fled-family>> widget moved NPCs from $NPCs to $FledFamily (and servants to $FledServants) without checking health status. Once moved, infected NPCs were never processed by <<health-update>>, quarantine passages, or <<infection-program>> — remaining permanently "infected".

Changes (PID 40, PID 89):
- Add health resolution (50/50 deceased/recovered) in <<fled-family>> for all four NPC/servant movement paths before pushing to fled arrays
- Extend the flee-blocked guard in Stay (PID 89) to also check $NPCsServants for infections, not just $NPCs

Bump to v1.63.

https://claude.ai/code/session_01YQzrgooYHNRwbVAV7GmxKn