### PR TITLE
Fix 7 bugs across 6 passages — bump to v2.4

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.3" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.4" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -2472,7 +2472,7 @@ You hope it will be enough to tide you through the last hot month of the year, a
 &lt;&lt;if $location is &quot;inside the City walls&quot; or $fireParishes.includes($parish)&gt;&gt;
 Early one Sunday morning, you wake to the frantic ringing of church bells.  This isn&#39;t the ordinary &lt;&lt;defCallToService &quot;call to service&quot;&gt;&gt;—&lt;&lt;if $religion is &quot;member of the Church of England&quot;&gt;&gt;something you were looking forward to attending after you slept in&lt;&lt;else&gt;&gt;as if you&#39;d ever attend a service in the Church of England!&lt;&lt;/if&gt;&gt;—but rather a call to arms.  When you stumble outside, you discover the city has caught fire around you.
 
-&lt;&lt;if $agenum lte 15&gt;&gt;You immediately wake the nearest adult, who takes charge. You grab &lt;&lt;if $age is &quot;child&quot;&gt;&gt;your favorite toy&lt;&lt;else&quot;&gt;&gt;some of your clothes&lt;&lt;/if&quot;&gt;&gt;, then it&#39;s time to flee, with the fire nipping at your heels.  You will have nightmares about this moment for weeks.
+&lt;&lt;if $agenum lte 15&gt;&gt;You immediately wake the nearest adult, who takes charge. You grab &lt;&lt;if $age is &quot;child&quot;&gt;&gt;your favorite toy&lt;&lt;else&gt;&gt;some of your clothes&lt;&lt;/if&gt;&gt;, then it&#39;s time to flee, with the fire nipping at your heels.  You will have nightmares about this moment for weeks.
 &lt;&lt;else&gt;&gt;
 
 &lt;&lt;if $socio is &quot;servants&quot;&gt;&gt;You immediately alert your $masterTitle, who sends you out to find as many additional carts or boats as you can, to carry away their goods.  &lt;&lt;if $reputation lte 2&gt;&gt;Unfortunately, everyone is so busy saving their own households, they have little to spare for you.  All you have is the single cart you already own.  &lt;&lt;else&gt;&gt;Luckily, you have friends and neighbors who hold you in high esteem and are willing to lend you carts.&lt;&lt;/if&gt;&gt; The &lt;&lt;defHousehold &quot;household&quot;&gt;&gt; loads &lt;&lt;if $reputation lte 2&gt;&gt;it&lt;&lt;else&gt;&gt;them&lt;&lt;/if&gt;&gt; up and you all flee with the fire nipping at your heels.
@@ -2573,7 +2573,7 @@ They have decided it will be your job to
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="38" name="July 1665" tags="storyline 1665" position="1450,475" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
 &lt;&lt;if not _randomEventFired&gt;&gt;&lt;span id=&quot;plague-day-replace&quot;&gt;
-Despite the English &lt;&lt;defFleet &quot;fleet&#39;s&quot;&gt;&gt; victory, the war grinds on and rumors begin to circulate that the French are considering siding with the Dutch. &lt;&lt;if $origin is &quot;France&quot; or $origin is &quot;the Dutch republic&quot;&gt;&gt;You make sure to talk loudly of your loyalty to the King and the superiority of the English fleet, whenever your neighbors mention the war.&lt;&lt;/if&gt;&gt;
+Despite the English &lt;&lt;defFleet &quot;fleet&#39;s&quot;&gt;&gt; victory, the war grinds on and rumors begin to circulate that the French are considering siding with the Dutch. &lt;&lt;if $origin is &quot;France&quot; or $origin is &quot;the Dutch Republic&quot;&gt;&gt;You make sure to talk loudly of your loyalty to the King and the superiority of the English fleet, whenever your neighbors mention the war.&lt;&lt;/if&gt;&gt;
 &lt;br&gt;&lt;br&gt;
 &lt;&lt;if $agenum gte 16 and $gender isnot &quot;female&quot;&gt;&gt;&lt;span id=&quot;volunteer&quot;&gt;Do you volunteer to help fight the French?
 &lt;br&gt;&lt;br&gt;
@@ -2905,7 +2905,7 @@ Unfortunately, that&#39;s not how &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; w
 &lt;br&gt;&lt;br&gt;
 Now you just have to figure out how to overcome your disgrace and find your way back into the King&#39;s good graces. Groveling will obviously have to be involved, but that won&#39;t be enough. Do you also:&lt;br&gt;
 &lt;ul&gt;
-&lt;li&gt;&lt;&lt;storyline-return &quot;help him find his next mistress.&quot; 1 -12800 -1&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
+&lt;li&gt;&lt;&lt;storyline-return &quot;help him find his next mistress.&quot; 1 -12800 -1&gt;&gt;&lt;/li&gt;
 &lt;li&gt;&lt;&lt;storyline-return &quot;give him money to fund the war effort&quot; 1 -25600 1&gt;&gt;&lt;/li&gt;
 &lt;/ul&gt;
 &lt;&lt;/if&gt;&gt;
@@ -3073,7 +3073,7 @@ Do you:
 &lt;ul&gt;
 &lt;&lt;if not hasVisited(&quot;May 1665&quot;)&gt;&gt;&lt;li&gt;[[put your trust in the charity of your neighbors-&gt;good-neighbors][$reputation +=1]]&lt;/li&gt;&lt;&lt;/if&gt;&gt;
 &lt;li&gt;&lt;&lt;if random(1,3) == 1&gt;&gt;[[take a risk and pray that God will protect you from harm|impressed][$impressed += 1]]&lt;&lt;else&gt;&gt;[[take a risk and pray that God will protect you from harm-&gt;begging-success][$reputation -=1]]&lt;&lt;/if&gt;&gt;&lt;/li&gt;
-&lt;li&gt;[[hope that you can survive on the resources you have-&gt;survival-mode][$money to Math.clamp($money - 1, 0, 100)]]&lt;/li&gt;
+&lt;li&gt;[[hope that you can survive on the resources you have-&gt;survival-mode][$money to Math.clamp($money - 1, 0, Infinity)]]&lt;/li&gt;
 &lt;/ul&gt;
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="52" name="begging-success" tags="" position="1550,150" size="100,100">&lt;&lt;nobr&gt;&gt;&lt;&lt;set $beggarsluck to random(0,5)&gt;&gt;&lt;&lt;set $money = ($money + $beggarsluck)&gt;&gt;Your begging earned you &lt;&lt;if $beggarsluck eq 0&gt;&gt;0 coins.&lt;&lt;else&gt;&gt;&#39;&#39;$beggarsluck&#39;&#39; coin.&lt;br&gt;&lt;br&gt;&lt;&lt;/if&gt;&gt;
@@ -4613,7 +4613,7 @@ Zounds! The steward of &lt;&lt;if $agenum lte 15&gt;&gt;you and &lt;&lt;/if&gt;&
 &lt;br&gt;&lt;br&gt;
 How long do you stay?&lt;ul&gt;
 	&lt;li&gt;&lt;&lt;storyline-return &quot;One month&quot; 1 1 -1&gt;&gt;&lt;/li&gt;
-	&lt;li&gt;&lt;&lt;storyline-return &quot;Two months&quot; 2 2 -2&gt;&gt;&gt;&lt;/li&gt;
+	&lt;li&gt;&lt;&lt;storyline-return &quot;Two months&quot; 2 2 -2&gt;&gt;&lt;/li&gt;
 	&lt;li&gt;&lt;&lt;storyline-return &quot;Three months&quot; 3 3 -3&gt;&gt;&lt;/li&gt;
 &lt;/ul&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#fondness&quot;&gt;&gt;You weren&#39;t fond of your steward and are looking forward to the opportunity to replace him, but it will still require a great deal of work to find someone capable soon.
@@ -4621,7 +4621,9 @@ How long do you stay?&lt;ul&gt;
 How long do you stay?&lt;ul&gt;
 	&lt;li&gt;&lt;&lt;storyline-return &quot;One month&quot; 1 1 -1&gt;&gt;&lt;/li&gt;
 	&lt;li&gt;&lt;&lt;storyline-return &quot;Two months&quot; 2 2 -2&gt;&gt;&lt;/li&gt;
-	&lt;li&gt;&lt;&lt;storyline-return &quot;Three months&quot; 3 3 -3&gt;&gt;&lt;/li&gt;&lt;/span&gt;
+	&lt;li&gt;&lt;&lt;storyline-return &quot;Three months&quot; 3 3 -3&gt;&gt;&lt;/li&gt;
+&lt;/ul&gt;
+&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="95" name="empty2" tags="" position="2825,1125" size="100,100">leaving this passage extant since it has a pid</tw-passagedata><tw-passagedata pid="96" name="empty4" tags="" position="2950,1025" size="100,100">leaving this passage extant since it has a pid</tw-passagedata><tw-passagedata pid="97" name="empty5" tags="" position="2950,1150" size="100,100">leaving this passage extant since it has a pid</tw-passagedata><tw-passagedata pid="98" name="accident" tags="widget" position="2525,225" size="100,100">&lt;&lt;widget &quot;accident&quot;&gt;&gt;
 &lt;&lt;nobr&gt;&gt;
@@ -4763,8 +4765,8 @@ But regardless, your body meets the same fate of the hundreds of other soldiers 
 [[At least you didn&#39;t die of plague-&gt;stats]].
 &lt;&lt;elseif $death is 2&gt;&gt;
 Unfortunately, you are taken prisoner and spend the rest of the war in a Dutch prison. It&#39;s not pleasant, but [[at least you didn&#39;t die of plague-&gt;stats]].
-&lt;&lt;elseif $death is 3 or 4&gt;&gt;
-You serve in the Navy through the war against the Dutch, leaving service in 1667. Your ship saw a lot of action and you are left &lt;&lt;set $disability to random(1,5)&gt;&gt;&lt;&lt;if $disability is 1&gt;&gt;with a disfiguring scar across your back which pains you occasionally for the rest of your life&lt;&lt;elseif $disability is 2&gt;&gt;with a gangrenous leg that will later need to be amputated&lt;&lt;elseif $disability is 3&gt;&gt;without the use of your right eye, which was lost to a musket ball&lt;&lt;elseif $disability is 4&gt;&gt;without your right arm, which was crushed by falling rigging and had to be amputated&lt;&lt;else&gt;&gt;without your left hand, which was cut off by a Dutch soldier in battle.&lt;&lt;/if&gt;&gt;. &lt;&lt;if $socio is &quot;day labourers&quot; or &quot;artisans&quot; or &quot;servants&quot;&gt;&gt;Your disability will affect your ability to work when you return home&lt;&lt;elseif $socio is &quot;beggars&quot;&gt;&gt;your disability might make your neighbors pity you and earn you more charity when you return home&lt;&lt;else&gt;&gt;It&#39;s not pleasant&lt;&lt;/if&gt;&gt;, but [[at least you didn&#39;t die of plague-&gt;stats]].
+&lt;&lt;elseif $death is 3 or $death is 4&gt;&gt;
+You serve in the Navy through the war against the Dutch, leaving service in 1667. Your ship saw a lot of action and you are left &lt;&lt;set $disability to random(1,5)&gt;&gt;&lt;&lt;if $disability is 1&gt;&gt;with a disfiguring scar across your back which pains you occasionally for the rest of your life&lt;&lt;elseif $disability is 2&gt;&gt;with a gangrenous leg that will later need to be amputated&lt;&lt;elseif $disability is 3&gt;&gt;without the use of your right eye, which was lost to a musket ball&lt;&lt;elseif $disability is 4&gt;&gt;without your right arm, which was crushed by falling rigging and had to be amputated&lt;&lt;else&gt;&gt;without your left hand, which was cut off by a Dutch soldier in battle.&lt;&lt;/if&gt;&gt;. &lt;&lt;if $socio is &quot;day labourers&quot; or $socio is &quot;artisans&quot; or $socio is &quot;servants&quot;&gt;&gt;Your disability will affect your ability to work when you return home&lt;&lt;elseif $socio is &quot;beggars&quot;&gt;&gt;your disability might make your neighbors pity you and earn you more charity when you return home&lt;&lt;else&gt;&gt;It&#39;s not pleasant&lt;&lt;/if&gt;&gt;, but [[at least you didn&#39;t die of plague-&gt;stats]].
 &lt;&lt;else&gt;&gt;
 You serve in the Navy through the war against the Dutch, leaving service in 1667. It was hard work, and not rewarding, but [[at least you didn&#39;t die of plague-&gt;stats]].
 &lt;&lt;/if&gt;&gt;
@@ -5120,7 +5122,7 @@ You have realized you are pregnant! You look forward to adding a new member to t
 &lt;&lt;if $religion is &quot;Catholic&quot;&gt;&gt;As a God-fearing Catholic, you know you are destined to spend time in purgatory before you can ascend to heaven but you hope that will not take too long&lt;&lt;if $reputation lte 0&gt;&gt;, despite your poor reputation on earth.&lt;&lt;/if&gt;&gt;&lt;&lt;else&gt;&gt;As a good Protestant, you know that Christ the Redeemer has died for you and your admittance to heaven is guaranteed.&lt;&lt;/if&gt;&gt;&lt;br&gt;&lt;br&gt;
 [[At least you didn&#39;t die of plague-&gt;stats]]
 &lt;&lt;else&gt;&gt;
-&lt;&lt;if random(1,4) is 1&gt;&gt;After a long, hard labor you are devastated to find your baby was stillborn. You bury &lt;&lt;either &quot;him&quot; &quot;her&quot;&gt;&gt;&lt;&lt;set $money -=9&gt;&gt; and attempt to move on.
+&lt;&lt;if random(1,4) is 1&gt;&gt;After a long, hard labor you are devastated to find your baby was stillborn. You bury &lt;&lt;= either(&quot;him&quot;, &quot;her&quot;)&gt;&gt;&lt;&lt;set $money -=9&gt;&gt; and attempt to move on.
 &lt;&lt;else&gt;&gt;
 &lt;&lt;addNewbornNPC&gt;&gt;After a long, hard labor you are delighted to add a baby to your family. 
 


### PR DESCRIPTION
- pid 31 (September 1666): Fix stray quote in <<else">> and <</if">>
  macros that broke the fire scenario for young players
- pid 43 (banished): Remove orphaned <</link>> after <<storyline-return>>
  which already generates its own link wrapper
- pid 94 (steward): Fix extra > character after "Two months" option, and add missing </ul>, <</replace>>, <</link>> closings in "No" branch
- pid 112 (birth): Replace invalid <<either "him" "her">> macro with <<= either("him", "her")>> (either is a function, not a macro)
- pid 103 (navy-volunteer): Fix two always-true conditions caused by bare values after `or` operator ($socio is "day labourers" or "artisans" and $death is 3 or 4)
- pid 38 (July 1665): Fix case mismatch "the Dutch republic" → "the Dutch Republic" so origin comparison matches correctly
- pid 51 (highway-widget): Fix Math.clamp upper bound from 100 to Infinity so money isn't silently capped at 100 pence

https://claude.ai/code/session_01AnEGDk43rPfG8E635aD6Q9