### PR TITLE
Add check-widowed widget to update $relationship when spouse dies — b…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.8" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.9" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -2762,6 +2762,7 @@ As morning dawns, a terrible realization settles over your &lt;&lt;defHousehold 
         &lt;&lt;set $NPCsServants to $NPCsServants.slice(0, _keepCount)&gt;&gt;
     &lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
+&lt;&lt;check-widowed&gt;&gt;
 &lt;&lt;/silently&gt;&gt;
 &lt;&lt;/widget&gt;&gt;
 
@@ -2795,6 +2796,7 @@ As morning dawns, a terrible realization settles over your &lt;&lt;defHousehold 
         &lt;&lt;else&gt;&gt;&lt;&lt;set $NPCsExtended[_ei].health to &quot;recovered&quot;&gt;&gt;&lt;&lt;/if&gt;&gt;
     &lt;&lt;/if&gt;&gt;
 &lt;&lt;/for&gt;&gt;
+&lt;&lt;check-widowed&gt;&gt;
 &lt;&lt;/silently&gt;&gt;&lt;&lt;/widget&gt;&gt;
 
 
@@ -5095,6 +5097,7 @@ After the dancing and feasting, you go home with your new spouse at your side.&l
 &lt;&lt;if _cr lte 10&gt;&gt;&lt;&lt;set $NPCsServants[_di].health to &quot;deceased&quot;&gt;&gt;Tragically, your servant $NPCsServants[_di].name has also died of measles.&lt;br&gt;&lt;&lt;funeral-choice $NPCsServants[_di]&gt;&gt;
 &lt;&lt;elseif _cr lte 90&gt;&gt;Your servant $NPCsServants[_di].name has contracted measles but survived.&lt;br&gt;&lt;br&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;servant-master-death&gt;&gt;
+&lt;&lt;check-widowed&gt;&gt;
 &lt;&lt;/if&gt;&gt; /* end _deathYear gt 0 */
 &lt;&lt;/if&gt;&gt; /* end plague/quarantine check */
 &lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="111" name="pregnant" tags="widget" position="2500,75" size="100,100">&lt;&lt;widget &quot;pregnant&quot;&gt;&gt;
@@ -5684,6 +5687,21 @@ You decide to:
 &lt;&lt;else&gt;&gt;/* late context for nobles */
 It&#39;s also not too late to &lt;&lt;if $hoh is 0 and $NPCs.length gt 0&gt;&gt;try and convince your family to &lt;&lt;/if&gt;&gt;[[flee to the countryside with your household-&gt;Fled][_repBefore to $reputation; $fled to 6; $money -= 10000; $reputation to Math.clamp($reputation - 1, 0, 10); $decisions.push({text: &quot;Fled the city with household&quot;, money: -10000, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: null})]]
 &lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;
+
+&lt;&lt;widget &quot;check-widowed&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
+&lt;&lt;if $relationship is &quot;married&quot;&gt;&gt;
+  &lt;&lt;for _cwi = 0; _cwi &lt; $NPCs.length; _cwi++&gt;&gt;
+    &lt;&lt;if ($NPCs[_cwi].relationship is &quot;husband&quot; or $NPCs[_cwi].relationship is &quot;wife&quot;) and $NPCs[_cwi].health is &quot;deceased&quot;&gt;&gt;
+      &lt;&lt;set $relationship to &quot;widowed&quot;&gt;&gt;
+    &lt;&lt;/if&gt;&gt;
+  &lt;&lt;/for&gt;&gt;
+  &lt;&lt;for _cwi = 0; _cwi &lt; $FledFamily.length; _cwi++&gt;&gt;
+    &lt;&lt;if ($FledFamily[_cwi].relationship is &quot;husband&quot; or $FledFamily[_cwi].relationship is &quot;wife&quot;) and $FledFamily[_cwi].health is &quot;deceased&quot;&gt;&gt;
+      &lt;&lt;set $relationship to &quot;widowed&quot;&gt;&gt;
+    &lt;&lt;/if&gt;&gt;
+  &lt;&lt;/for&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;
 </tw-passagedata><tw-passagedata pid="116" name="june-1665-helper-widget" tags="widget" position="1450,350" size="100,100">&lt;&lt;widget &quot;june-1665-helper&quot;&gt;&gt;

--- a/variables.md
+++ b/variables.md
@@ -67,7 +67,7 @@ This document lists all global (story) variables used in **Gaming the Great Plag
 - **Type:** String
 - **Possible values:** `"single"`, `"married"`, `"widowed"`, `"betrothed"`
 - **Set by:** `random-character` widget. Children/adolescents: `weightedEither({"single": 95, "betrothed": 5})`. Adults: `weightedEither({"single": 17, "married": 32, "widowed": 9})`
-- **Can change to:** `"married"` (via wedding event), `"single"` (if spouse dies)
+- **Can change to:** `"married"` (via wedding event), `"widowed"` (if spouse NPC dies, via `check-widowed` widget)
 - **Dependency:** `$age` determines which weight table is used
 
 ### `$religion`


### PR DESCRIPTION
…ump to v2.9

New check-widowed widget (pid 115) scans $NPCs and $FledFamily for a deceased husband/wife and sets $relationship from "married" to "widowed". Called from health-update (plague quarantine deaths), NPC-death (non-plague deaths), and fled-family (deaths during family flight).

https://claude.ai/code/session_015YzLaDS3iNB5KcN2533ZqG