### PR TITLE
Add <<death-announcement>> widget to consolidate death passage ending…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.11" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.12" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -1285,22 +1285,11 @@ Your home is &lt;&lt;set _location = [&quot;inside the City walls&quot;, &quot;i
 &lt;img src=&quot;https://wesleyan-dac-open-access.s3.amazonaws.com/images/DAC_1940-D1-131_001_OA.jpg&quot; width=&quot;100%&quot;&gt;
 //Map of London, before the Fire of 1666 by Wencelaus Holler. Wesleyan University Davison Art Center.//
 &lt;&lt;/chunkText&gt;&gt;</tw-passagedata><tw-passagedata pid="5" name="death" tags="infection-rates" position="625,775" size="100,100">&lt;&lt;nobr&gt;&gt;
-Send not to know for whom the church bells toll. They toll for you. &lt;&lt;if $religion is &quot;Catholic&quot;&gt;&gt;As a God-fearing Catholic, you know you are destined to spend time in purgatory before you can ascend to heaven but you hope that will not take too long&lt;&lt;if $reputation lte 0&gt;&gt;, despite your poor reputation on earth.&lt;&lt;/if&gt;&gt;&lt;&lt;else&gt;&gt;As a good Protestant, you know that Christ the Redeemer has died for you and your admittance to heaven is guaranteed.&lt;&lt;/if&gt;&gt;
-&lt;br&gt;&lt;br&gt;
-
-&lt;&lt;if $reputation lte 0&gt;&gt;You died with such a poor reputation that most of your neighbors didn&#39;t care. The rest of them probably cursed your name and hoped you were suffering in hell. Luckily, 
-&lt;&lt;else&gt;&gt;You died with a good enough reputation that your neighbors say prayers for your soul. Because of the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; ordinances, none of your neighbors could attend your funeral but 
-&lt;&lt;if $socio is &quot;nobles&quot;&gt;&gt;as a member of the nobility, you were interred in a position of honor in a vault within your family&#39;s private chapel.
-&lt;&lt;elseif $socio is &quot;merchants&quot;&gt;&gt;you were rich enough to be buried within the walls of your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; churchyard. Your heirs, of course, paid extremely well for that privilege.
-&lt;&lt;elseif $socio is &quot;artisans&quot;&gt;&gt;your body was at least carefully wrapped in a burial shroud before being put into the communal plague pits, late at night with no one to witness your burial.
-&lt;&lt;else&gt;&gt;your body was at least put into the communal plague pits, instead of being left out to rot.
-&lt;&lt;/if&gt;&gt;
-&lt;&lt;/if&gt;&gt;
+Send not to know for whom the church bells toll. They toll for you.&lt;br&gt;&lt;br&gt;
+&lt;&lt;death-announcement&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;
 
-/* NTS: This is also what happened to your family. */
-
-[[How typical was your experience of the Great Plague of London? Let&#39;s find out!-&gt;stats]]</tw-passagedata><tw-passagedata pid="6" name="Sickness" tags="infection-rates" position="625,475" size="100,100">&lt;&lt;nobr&gt;&gt;&lt;&lt;set $quarantine +=1&gt;&gt;
+/* NTS: This is also what happened to your family. */</tw-passagedata><tw-passagedata pid="6" name="Sickness" tags="infection-rates" position="625,475" size="100,100">&lt;&lt;nobr&gt;&gt;&lt;&lt;set $quarantine +=1&gt;&gt;
 &lt;&lt;silently&gt;&gt;&lt;&lt;check-NPCs&gt;&gt;&lt;&lt;set _remedyEffect to 0&gt;&gt;
   &lt;&lt;set $plagueInfection to 2&gt;&gt;&lt;&lt;/silently&gt;&gt;
 &lt;&lt;if ndef $textGroup&gt;&gt;&lt;&lt;set $textGroup = 1&gt;&gt;&lt;&lt;/if&gt;&gt;
@@ -3361,7 +3350,9 @@ Do you:
     &lt;&lt;/if&gt;&gt;.
     &lt;&lt;if $disability is 1&gt;&gt;Many of your neighbors begin to flee the city and those who remain curse at you to leave when you try begging at their doors.&lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;
-&lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="55" name="freeze" tags="" position="1975,950" size="100,100">You quietly freeze to death, but at least it was a [[painless way to go-&gt;stats]].</tw-passagedata><tw-passagedata pid="56" name="StoryCaption" tags="" position="200,875" size="100,100">&lt;&lt;if $reputation gt 3&gt;&gt;Your reputation is &lt;span style=&quot;color:#ffffff;&quot;&gt;good&lt;/span&gt;.&lt;&lt;elseif $reputation lt 3&gt;&gt;Your reputation is &lt;span style=&quot;color:red&quot;&gt;bad&lt;/span&gt;.&lt;&lt;/if&gt;&gt;&lt;br&gt;
+&lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="55" name="freeze" tags="" position="1975,950" size="100,100">&lt;&lt;nobr&gt;&gt;You quietly freeze to death, but at least it was a painless way to go.&lt;br&gt;&lt;br&gt;
+&lt;&lt;death-announcement&gt;&gt;
+&lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="56" name="StoryCaption" tags="" position="200,875" size="100,100">&lt;&lt;if $reputation gt 3&gt;&gt;Your reputation is &lt;span style=&quot;color:#ffffff;&quot;&gt;good&lt;/span&gt;.&lt;&lt;elseif $reputation lt 3&gt;&gt;Your reputation is &lt;span style=&quot;color:red&quot;&gt;bad&lt;/span&gt;.&lt;&lt;/if&gt;&gt;&lt;br&gt;
 &lt;&lt;income&gt;&gt;
 /* Wealth at beginning of month: $money */
 Income: $income
@@ -5269,13 +5260,8 @@ One thing is for certain, though. The weather is so hot that &lt;&lt;defPlague &
 &lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="98" name="accident" tags="widget" position="2525,225" size="100,100">&lt;&lt;widget &quot;accident&quot;&gt;&gt;
 &lt;&lt;nobr&gt;&gt;
 &lt;&lt;set $accident to random(0,5)&gt;&gt;&lt;&lt;if $accident is 1&gt;&gt;Send not to know for whom the church bells toll. They toll for you. 
-&lt;br&gt;&lt;br&gt;Unfortunately you have suffered from a fatal accident &lt;&lt;if $socio is &quot;day labourers&quot;&gt;&gt;while out on a job&lt;&lt;/if&gt;&gt;. &lt;&lt;set $death to random(1,5)&gt;&gt;&lt;&lt;if $death is 1&gt;&gt;You drowned in &lt;&lt;if $socio is &quot;day labourers&quot;&gt;&gt;a brewer&#39;s mash&lt;&lt;else&gt;&gt;a well&lt;&lt;/if&gt;&gt;. &lt;&lt;elseif $death is 2&gt;&gt;You were bitten by a dog. &lt;&lt;elseif $death is 3&gt;&gt;You fell from &lt;&lt;if $socio is &quot;day labourers&quot;&gt;&gt;scaffolding&lt;&lt;else&gt;&gt;a window&lt;&lt;/if&gt;&gt;. &lt;&lt;elseif $death is 4&gt;&gt;You were run over by a cart. &lt;&lt;else&gt;&gt;You fell down a flight of stairs.&lt;&lt;/if&gt;&gt;&lt;br&gt;&lt;br&gt;&lt;&lt;if $reputation lte 0&gt;&gt;You died with such a poor reputation that most of your neighbors didn&#39;t care. The rest of them probably cursed your name and hoped you were suffering in hell. Luckily, 
-&lt;&lt;else&gt;&gt;You died with a good enough reputation that your neighbors say prayers for your soul. Because of the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; ordinances, none of your neighbors could attend your funeral but your body was at least put into the communal plague pits, instead of being left out to rot.
-&lt;&lt;/if&gt;&gt;
-&lt;br&gt;&lt;br&gt;
-&lt;&lt;if $religion is &quot;Catholic&quot;&gt;&gt;As a God-fearing Catholic, you know you are destined to spend time in purgatory before you can ascend to heaven but you hope that will not take too long&lt;&lt;if $reputation lte 0&gt;&gt;, despite your poor reputation on earth.&lt;&lt;/if&gt;&gt;&lt;&lt;else&gt;&gt;As a good Protestant, you know that Christ the Redeemer has died for you and your admittance to heaven is guaranteed.&lt;&lt;/if&gt;&gt;
-&lt;br&gt;&lt;br&gt;
-[[At least you didn&#39;t die of the plague-&gt;stats]].
+&lt;br&gt;&lt;br&gt;Unfortunately you have suffered from a fatal accident &lt;&lt;if $socio is &quot;day labourers&quot;&gt;&gt;while out on a job&lt;&lt;/if&gt;&gt;. &lt;&lt;set $death to random(1,5)&gt;&gt;&lt;&lt;if $death is 1&gt;&gt;You drowned in &lt;&lt;if $socio is &quot;day labourers&quot;&gt;&gt;a brewer&#39;s mash&lt;&lt;else&gt;&gt;a well&lt;&lt;/if&gt;&gt;. &lt;&lt;elseif $death is 2&gt;&gt;You were bitten by a dog. &lt;&lt;elseif $death is 3&gt;&gt;You fell from &lt;&lt;if $socio is &quot;day labourers&quot;&gt;&gt;scaffolding&lt;&lt;else&gt;&gt;a window&lt;&lt;/if&gt;&gt;. &lt;&lt;elseif $death is 4&gt;&gt;You were run over by a cart. &lt;&lt;else&gt;&gt;You fell down a flight of stairs.&lt;&lt;/if&gt;&gt;&lt;br&gt;&lt;br&gt;At least you didn&#39;t die of the plague.&lt;br&gt;&lt;br&gt;
+&lt;&lt;death-announcement&gt;&gt;
 &lt;&lt;else&gt;&gt;
 You have suffered an accident while&lt;&lt;if $socio is &quot;day labourers&quot;&gt;&gt;out on a job&lt;&lt;else&gt;&gt;running errands&lt;&lt;/if&gt;&gt;, but thanks to God you are still alive. &lt;&lt;set $accident to random (1,5)&gt;&gt;&lt;&lt;if $accident is 1&gt;&gt;You fell from a window. &lt;&lt;elseif $accident is 2&gt;&gt;You were kicked by a horse. &lt;&lt;elseif $accident is 3&gt;&gt;You broke your arm. &lt;&lt;elseif $accident is 4&gt;&gt;You were hit by a wagon wheel. &lt;&lt;else&gt;&gt;You fell in the Thames and a cut on your arm was infected. &lt;&lt;/if&gt;&gt; Fortunately, this is something you can recover from with rest and care. &lt;&lt;if $reputation lte 0&gt;&gt;Unfortunately your reputation is too low for anyone to offer you assistance so you must recover on your own and &lt;&lt;else&gt;&gt;Your &lt;&lt;if $NPCs.length gt 0&gt;&gt;family&lt;&lt;else&gt;&gt;neighbors&lt;&lt;/if&gt;&gt; take good care of you, but &lt;&lt;/if&gt;&gt;you lose money every day you aren&#39;t working.&lt;&lt;set $money -=3&gt;&gt;&lt;br&gt;&lt;br&gt;Soon you are ready to rejoin &lt;&lt;if $socio is &quot;day labourers&quot;&gt;&gt;the other &lt;&lt;defDayLabourer &quot;day labourers&quot;&gt;&gt; in their search for work. &lt;&lt;storyline-return&gt;&gt;&lt;&lt;else&gt;&gt;your &lt;&lt;print $masterTitle || &quot;master&quot;&gt;&gt;&#39;s household. &lt;&lt;storyline-return&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
@@ -5285,27 +5271,8 @@ You have suffered an accident while&lt;&lt;if $socio is &quot;day labourers&quot
 Send not to know for whom the church bells toll. They toll for you. Unfortunately your old age has caught up with you. You have managed not to die of a wide range of diseases and other ailments, but at long last you have died of natural causes. 
 &lt;br&gt;&lt;br&gt;
 
-&lt;&lt;if hasVisited(&quot;May 1666&quot;)&gt;&gt;
-&lt;&lt;if $reputation lte 0&gt;&gt;You died with such a poor reputation that most of your neighbors didn&#39;t care. The rest of them probably cursed your name and hoped you were suffering in hell. Luckily, 
-&lt;&lt;else&gt;&gt;You died with a good enough reputation that your neighbors say prayers for your soul. Because of the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; ordinances, none of your neighbors could attend your funeral but 
-&lt;&lt;if $socio is &quot;nobles&quot;&gt;&gt;as a member of the nobility, you were interred in a position of honor in a vault within your family&#39;s private chapel.
-&lt;&lt;elseif $socio is &quot;merchants&quot;&gt;&gt;you were rich enough to be buried within the walls of your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; churchyard. Your heirs, of course, paid extremely well for that privilege.
-&lt;&lt;elseif $socio is &quot;artisans&quot;&gt;&gt;your body was at least carefully wrapped in a burial shroud before being put into the communal plague pits, late at night with no one to witness your burial.
-&lt;&lt;else&gt;&gt;your body was at least put into the communal plague pits, instead of being left out to rot.&lt;&lt;/if&gt;&gt;
-&lt;&lt;/if&gt;&gt;
-&lt;&lt;else&gt;&gt;
-&lt;&lt;if $reputation gte 0&gt;&gt;
-You died with a good enough reputation that your neighbors say prayers for your soul. 
-&lt;&lt;if $socio is &quot;nobles&quot;&gt;&gt;As a member of the nobility, you were interred in a position of honor in a vault within your family&#39;s private chapel.
-&lt;&lt;elseif $socio is &quot;merchants&quot;&gt;&gt;You were rich enough to be buried within the walls of your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; churchyard. Your heirs, of course, paid extremely well for that privilege.
-&lt;&lt;elseif $socio is &quot;artisans&quot;&gt;&gt;Your body was carefully wrapped in a burial shroud and buried on the ground of your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; churchyard. 
-&lt;&lt;else&gt;&gt;Your body was buried in your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; churchyard. 
-&lt;&lt;/if&gt;&gt;
-&lt;&lt;/if&gt;&gt;
-&lt;&lt;/if&gt;&gt;
-&lt;br&gt;&lt;br&gt;
-&lt;&lt;if $religion is &quot;Catholic&quot;&gt;&gt;As a God-fearing Catholic, you know you are destined to spend time in purgatory before you can ascend to heaven but you hope that will not take too long&lt;&lt;if $reputation lte 0&gt;&gt;, despite your poor reputation on earth.&lt;&lt;/if&gt;&gt;&lt;&lt;else&gt;&gt;As a good Protestant, you know that Christ the Redeemer has died for you and your admittance to heaven is guaranteed.&lt;&lt;/if&gt;&gt;&lt;br&gt;&lt;br&gt;
-[[At least you didn&#39;t die of plague-&gt;stats]]
+At least you didn&#39;t die of plague.&lt;br&gt;&lt;br&gt;
+&lt;&lt;death-announcement&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;
 
 &lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="101" name="runover" tags="widget" position="2150,275" size="100,100">&lt;&lt;widget &quot;runover&quot;&gt;&gt;
@@ -5326,20 +5293,8 @@ You died with a good enough reputation that your neighbors say prayers for your 
     &lt;&lt;else&gt;&gt;
     Unfortunately, begging in the street comes with risks in a bustling city like London, and you have been run over by a cart, an accident from which you will not recover.
     &lt;&lt;/if&gt;&gt;
-    &lt;&lt;if hasVisited(&quot;May 1666&quot;)&gt;&gt;
-        &lt;&lt;if $reputation lte 0&gt;&gt;You died with such a poor reputation that most of your neighbors didn&#39;t care. The rest of them probably cursed your name and hoped you were suffering in hell. 
-        &lt;&lt;else&gt;&gt;You died with a good enough reputation that your neighbors say prayers for your soul. Because of the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; ordinances, none of your neighbors could attend your funeral but your body was at least put into the communal plague pits, instead of being left out to rot.
-        &lt;&lt;/if&gt;&gt;
-    &lt;&lt;else&gt;&gt;
-        &lt;&lt;if $reputation gte 0&gt;&gt;
-            You died with a good enough reputation that your neighbors say prayers for your soul. Your body was buried in your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; churchyard. 
-        &lt;&lt;else&gt;&gt;You died with such a poor reputation that most of your neighbors didn&#39;t care. The rest of them probably cursed your name and hoped you were suffering in hell. 
-        &lt;&lt;/if&gt;&gt;
-        &lt;br&gt;&lt;br&gt;
-        &lt;&lt;if $religion is &quot;Catholic&quot;&gt;&gt;As a God-fearing Catholic, you know you are destined to spend time in purgatory before you can ascend to heaven but you hope that will not take too long&lt;&lt;if $reputation lte 0&gt;&gt;, despite your poor reputation on earth.&lt;&lt;/if&gt;&gt;&lt;&lt;else&gt;&gt;As a good Protestant, you know that Christ the Redeemer has died for you and your admittance to heaven is guaranteed.
-        &lt;&lt;/if&gt;&gt;
-    &lt;&lt;/if&gt;&gt;&lt;br&gt;&lt;br&gt;
-[[At least you didn&#39;t die of plague-&gt;stats]].
+&lt;br&gt;&lt;br&gt;At least you didn&#39;t die of plague.&lt;br&gt;&lt;br&gt;
+&lt;&lt;death-announcement&gt;&gt;
 &lt;&lt;else&gt;&gt;
     &lt;&lt;if passage() is &quot;September 1666&quot;&gt;&gt;
         &lt;&lt;if $location is &quot;inside the City walls&quot;&gt;&gt;Early one Sunday morning, you wake to the frantic ringing of church bells. This isn&#39;t the ordinary &lt;&lt;defCallToService &quot;call to service&quot;&gt;&gt;—&lt;&lt;if $religion is &quot;member of the Church of England&quot;&gt;&gt;something you were looking forward to attending after you slept in&lt;&lt;else&gt;&gt;as if you&#39;d ever attend a service in the Church of England!&lt;&lt;/if&gt;&gt;—but rather a call to arms. 
@@ -5359,28 +5314,8 @@ You died with a good enough reputation that your neighbors say prayers for your 
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="102" name="fever" tags="widget" position="2675,375" size="100,100">&lt;&lt;widget &quot;fever&quot;&gt;&gt;
 &lt;&lt;nobr&gt;&gt;
-&lt;&lt;if random(0,10) is 1&gt;&gt;&lt;&lt;set _eventCausedDeath to true&gt;&gt;Send not to know for whom the church bells toll. They toll for you. You have come down with a mysterious fever. &lt;&lt;if $reputation gt 0&gt;&gt;Despite the care of your friends and family,&lt;&lt;else&gt;&gt;Your reputation is so low that no one will lend you aid in your sickness and&lt;&lt;/if&gt;&gt; you die.
-&lt;&lt;if hasVisited(&quot;May 1666&quot;)&gt;&gt;
-&lt;&lt;if $reputation lt 0&gt;&gt; You died with such a poor reputation that most of your neighbors didn&#39;t care. The rest of them probably cursed your name and hoped you were suffering in hell. Luckily, 
-&lt;&lt;else&gt;&gt; You died with a good enough reputation that your neighbors say prayers for your soul. Because of the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; ordinances, none of your neighbors could attend your funeral but 
-&lt;&lt;if $socio is &quot;nobles&quot;&gt;&gt;as a member of the nobility, you were interred in a position of honor in a vault within your family&#39;s private chapel.
-&lt;&lt;elseif $socio is &quot;merchants&quot;&gt;&gt;you were rich enough to be buried within the walls of your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; churchyard. Your heirs, of course, paid extremely well for that privilege.
-&lt;&lt;elseif $socio is &quot;artisans&quot;&gt;&gt;your body was at least carefully wrapped in a burial shroud before being put into the communal plague pits, late at night with no one to witness your burial.
-&lt;&lt;else&gt;&gt;your body was at least put into the communal plague pits, instead of being left out to rot.&lt;&lt;/if&gt;&gt;
-&lt;&lt;/if&gt;&gt;
-&lt;&lt;else&gt;&gt;
-&lt;&lt;if $reputation gt 0&gt;&gt;
-You died with a good enough reputation that your neighbors say prayers for your soul. 
-&lt;&lt;if $socio is &quot;nobles&quot;&gt;&gt;As a member of the nobility, you were interred in a position of honor in a vault within your family&#39;s private chapel.
-&lt;&lt;elseif $socio is &quot;merchants&quot;&gt;&gt;You were rich enough to be buried within the walls of your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; churchyard. Your heirs, of course, paid extremely well for that privilege.
-&lt;&lt;elseif $socio is &quot;artisans&quot;&gt;&gt;Your body was carefully wrapped in a burial shroud and buried on the ground of your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; churchyard. 
-&lt;&lt;else&gt;&gt;Your body was buried in your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; churchyard. 
-&lt;&lt;/if&gt;&gt;
-&lt;&lt;/if&gt;&gt;
-&lt;&lt;/if&gt;&gt;
-&lt;br&gt;&lt;br&gt;
-&lt;&lt;if $religion is &quot;Catholic&quot;&gt;&gt;As a God-fearing Catholic, you know you are destined to spend time in purgatory before you can ascend to heaven but you hope that will not take too long&lt;&lt;if $reputation lte 0&gt;&gt;, despite your poor reputation on earth.&lt;&lt;/if&gt;&gt;&lt;&lt;else&gt;&gt;As a good Protestant, you know that Christ the Redeemer has died for you and your admittance to heaven is guaranteed.&lt;&lt;/if&gt;&gt;&lt;br&gt;&lt;br&gt;
-[[At least you didn&#39;t die of plague-&gt;stats]]
+&lt;&lt;if random(0,10) is 1&gt;&gt;&lt;&lt;set _eventCausedDeath to true&gt;&gt;Send not to know for whom the church bells toll. They toll for you. You have come down with a mysterious fever. &lt;&lt;if $reputation gt 0&gt;&gt;Despite the care of your friends and family,&lt;&lt;else&gt;&gt;Your reputation is so low that no one will lend you aid in your sickness and&lt;&lt;/if&gt;&gt; you die.&lt;br&gt;&lt;br&gt;At least you didn&#39;t die of plague.&lt;br&gt;&lt;br&gt;
+&lt;&lt;death-announcement&gt;&gt;
 &lt;&lt;else&gt;&gt;
 &lt;&lt;set $money -=2&gt;&gt;Alack! You have come down with a mysterious fever.&lt;&lt;if $reputation gt 0&gt;&gt; Your reputation is high enough that your friends and family take diligent care of you in your sickness and&lt;&lt;else&gt;&gt; Your reputation is so low that no one lends you aid in your sickness but&lt;&lt;/if&gt;&gt; you slowly recover.
 &lt;br&gt;&lt;br&gt;
@@ -5753,16 +5688,8 @@ You have realized you are pregnant! You look forward to adding a new member to t
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="112" name="birth" tags="widget" position="2750,500" size="100,100">&lt;&lt;widget &quot;birth&quot;&gt;&gt;
 &lt;&lt;nobr&gt;&gt;
-&lt;&lt;if random(1,30) is 1&gt;&gt;&lt;&lt;set _eventCausedDeath to true&gt;&gt;Send not to know for whom the church bells toll. They toll for you. You died in childbirth.
-&lt;&lt;if $reputation lt 0&gt;&gt; You died with such a poor reputation that most of your neighbors didn&#39;t care. The rest of them probably cursed your name and hoped you were suffering in hell. Luckily, 
-&lt;&lt;else&gt;&gt; You died with a good enough reputation that your neighbors say prayers for your soul. Because of the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; ordinances, none of your neighbors could attend your funeral but 
-&lt;&lt;if $socio is &quot;nobles&quot;&gt;&gt;as a member of the nobility, you were interred in a position of honor in a vault within your family&#39;s private chapel.
-&lt;&lt;elseif $socio is &quot;merchants&quot;&gt;&gt;you were rich enough to be buried within the walls of your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; churchyard. Your heirs, of course, paid extremely well for that privilege.
-&lt;&lt;elseif $socio is &quot;artisans&quot;&gt;&gt;your body was at least carefully wrapped in a burial shroud before being put into the communal plague pits, late at night with no one to witness your burial.
-&lt;&lt;else&gt;&gt;your body was at least put into the communal plague pits, instead of being left out to rot.&lt;&lt;/if&gt;&gt;
-&lt;&lt;/if&gt;&gt;
-&lt;&lt;if $religion is &quot;Catholic&quot;&gt;&gt;As a God-fearing Catholic, you know you are destined to spend time in purgatory before you can ascend to heaven but you hope that will not take too long&lt;&lt;if $reputation lte 0&gt;&gt;, despite your poor reputation on earth.&lt;&lt;/if&gt;&gt;&lt;&lt;else&gt;&gt;As a good Protestant, you know that Christ the Redeemer has died for you and your admittance to heaven is guaranteed.&lt;&lt;/if&gt;&gt;&lt;br&gt;&lt;br&gt;
-[[At least you didn&#39;t die of plague-&gt;stats]]
+&lt;&lt;if random(1,30) is 1&gt;&gt;&lt;&lt;set _eventCausedDeath to true&gt;&gt;Send not to know for whom the church bells toll. They toll for you. You died in childbirth.&lt;br&gt;&lt;br&gt;At least you didn&#39;t die of plague.&lt;br&gt;&lt;br&gt;
+&lt;&lt;death-announcement&gt;&gt;
 &lt;&lt;else&gt;&gt;
 &lt;&lt;if random(1,4) is 1&gt;&gt;After a long, hard labor you are devastated to find your baby was stillborn. You bury &lt;&lt;= either(&quot;him&quot;, &quot;her&quot;)&gt;&gt;&lt;&lt;set $money -=9&gt;&gt; and attempt to move on.
 &lt;&lt;else&gt;&gt;
@@ -5923,7 +5850,32 @@ Unfortunately, you have suffered a miscarriage and are no longer pregnant.
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="115" name="Claude-widgets" tags="widget" position="675,1175" size="100,100">/* all widgets generated via Claude  or other AI should be temporarily placed here then manually moved to new locations as needed */
 
-
+&lt;&lt;widget &quot;death-announcement&quot;&gt;&gt;
+&lt;&lt;nobr&gt;&gt;
+&lt;&lt;if hasVisited(&quot;May 1666&quot;)&gt;&gt;
+&lt;&lt;if $reputation lte 0&gt;&gt;You died with such a poor reputation that most of your neighbors didn&#39;t care. The rest of them probably cursed your name and hoped you were suffering in hell. Luckily, 
+&lt;&lt;else&gt;&gt;You died with a good enough reputation that your neighbors say prayers for your soul. Because of the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; ordinances, none of your neighbors could attend your funeral but 
+&lt;&lt;if $socio is &quot;nobles&quot;&gt;&gt;as a member of the nobility, you were interred in a position of honor in a vault within your family&#39;s private chapel.
+&lt;&lt;elseif $socio is &quot;merchants&quot;&gt;&gt;you were rich enough to be buried within the walls of your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; churchyard. Your heirs, of course, paid extremely well for that privilege.
+&lt;&lt;elseif $socio is &quot;artisans&quot;&gt;&gt;your body was at least carefully wrapped in a burial shroud before being put into the communal plague pits, late at night with no one to witness your burial.
+&lt;&lt;else&gt;&gt;your body was at least put into the communal plague pits, instead of being left out to rot.&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;else&gt;&gt;
+&lt;&lt;if $reputation gte 0&gt;&gt;
+You died with a good enough reputation that your neighbors say prayers for your soul. 
+&lt;&lt;if $socio is &quot;nobles&quot;&gt;&gt;As a member of the nobility, you were interred in a position of honor in a vault within your family&#39;s private chapel.
+&lt;&lt;elseif $socio is &quot;merchants&quot;&gt;&gt;You were rich enough to be buried within the walls of your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; churchyard. Your heirs, of course, paid extremely well for that privilege.
+&lt;&lt;elseif $socio is &quot;artisans&quot;&gt;&gt;Your body was carefully wrapped in a burial shroud and buried on the ground of your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; churchyard. 
+&lt;&lt;else&gt;&gt;Your body was buried in your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; churchyard. 
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;else&gt;&gt;You died with such a poor reputation that most of your neighbors didn&#39;t care. The rest of them probably cursed your name and hoped you were suffering in hell.
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;br&gt;&lt;br&gt;
+&lt;&lt;if $religion is &quot;Catholic&quot;&gt;&gt;As a God-fearing Catholic, you know you are destined to spend time in purgatory before you can ascend to heaven but you hope that will not take too long&lt;&lt;if $reputation lte 0&gt;&gt;, despite your poor reputation on earth.&lt;&lt;/if&gt;&gt;&lt;&lt;else&gt;&gt;As a good Protestant, you know that Christ the Redeemer has died for you and your admittance to heaven is guaranteed.&lt;&lt;/if&gt;&gt;&lt;br&gt;&lt;br&gt;
+[[How typical was your experience of the Great Plague of London? Let&#39;s find out!-&gt;stats]]
+&lt;&lt;/nobr&gt;&gt;
+&lt;&lt;/widget&gt;&gt;
 </tw-passagedata><tw-passagedata pid="116" name="june-1665-helper-widget" tags="widget" position="1450,350" size="100,100">&lt;&lt;widget &quot;june-1665-helper&quot;&gt;&gt;
 &lt;&lt;nobr&gt;&gt;
 The &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; grows worse and the streets are soon filled with coaches and wagons full of people fleeing with their goods to the countryside. The &lt;&lt;defQueenMother &quot;Queen Mother&quot;&gt;&gt; &lt;&lt;defHenriettaMaria &quot;Henrietta Maria&quot;&gt;&gt; moves back to France&lt;&lt;if $religion is &quot;Catholic&quot;&gt;&gt;, much to your dismay, and that of your fellow Catholics who flock to her chapel each week&lt;&lt;else&gt;&gt;, much to your relief, and that of all your fellow God-fearing &lt;&lt;defProtestants &quot;Protestants&quot;&gt;&gt;&lt;&lt;/if&gt;&gt;. On June 29th, the King packs up his entire &lt;&lt;defHousehold &quot;household&quot;&gt;&gt; in 148 carriages and moves 12 miles away, to his palace at &lt;&lt;defHamptonCourt &quot;Hampton Court&quot;&gt;&gt;.


### PR DESCRIPTION
…s — bump to v2.12

Create a reusable <<death-announcement>> widget in the Claude-widgets passage (pid 115) that handles burial description (by reputation, socio class, and plague era), religious reflection, and the stats link. Update 7 death passages (pids 5, 55, 98, 100, 101, 102, 112) to call the widget instead of inlining duplicated logic. The navy-volunteer passage (pid 103) is excluded per requirements since it has unique naval burial text.

https://claude.ai/code/session_01JDQbrb1wr35fm1MQMxB1D6