### PR TITLE
Add SessionStart hook to set CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (web) environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Set max output tokens for all sessions
+echo 'export CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000' >> "$CLAUDE_ENV_FILE"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds a session-start hook that ensures all remote Claude Code sessions have a 64K output token limit, preventing sessions from hitting the default limit prematurely.

https://claude.ai/code/session_01NGrvHhfSng9wVExP2gdvLH