### PR TITLE
Add infection guards to prevent fleeing/sending away infected househo…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.15" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.16" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -2917,6 +2917,13 @@ As morning dawns, a terrible realization settles over your &lt;&lt;defHousehold 
 
 /* if sending household away or back to place of origin, change their location for status updates */
 &lt;&lt;widget &quot;fled-family&quot;&gt;&gt;&lt;&lt;silently&gt;&gt;
+/* Guard: block sending household away if any NPC or servant is infected */
+&lt;&lt;set _famFleeBlocked to false&gt;&gt;
+&lt;&lt;for _npc range $NPCs&gt;&gt;&lt;&lt;if _npc.health is &quot;infected&quot;&gt;&gt;&lt;&lt;set _famFleeBlocked to true&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
+&lt;&lt;for _sv range $NPCsServants&gt;&gt;&lt;&lt;if _sv.health is &quot;infected&quot;&gt;&gt;&lt;&lt;set _famFleeBlocked to true&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
+&lt;&lt;/silently&gt;&gt;&lt;&lt;if _famFleeBlocked&gt;&gt;&lt;&lt;set $fled to 4&gt;&gt;You prepare your household to flee the city. It takes some time to sort out the travel logistics, but finally everything is in order. They will leave tomorrow.&lt;br&gt;&lt;br&gt;
+&lt;&lt;sickFam&gt;&gt;
+&lt;&lt;else&gt;&gt;&lt;&lt;silently&gt;&gt;
 &lt;&lt;if $origin isnot &quot;London&quot;&gt;&gt;&lt;&lt;set $hhlocation to $origin&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $hhlocation to &quot;in the countryside&quot;&gt;&gt;&lt;&lt;/if&gt;&gt;
 /* If the player is a child or adolescent, one adult NPC stays behind */
 &lt;&lt;if $agenum lte 15&gt;&gt;
@@ -2956,7 +2963,6 @@ As morning dawns, a terrible realization settles over your &lt;&lt;defHousehold 
     /* Move everyone except the staying adult to FledFamily */
     &lt;&lt;for _fi = 0; _fi &lt; $NPCs.length; _fi++&gt;&gt;
         &lt;&lt;if _fi isnot _stayIdx&gt;&gt;
-            &lt;&lt;if $NPCs[_fi].health is &quot;infected&quot;&gt;&gt;&lt;&lt;if random(1,2) eq 1&gt;&gt;&lt;&lt;set $NPCs[_fi].health to &quot;deceased&quot;&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $NPCs[_fi].health to &quot;recovered&quot;&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;
             &lt;&lt;set $FledFamily.push($NPCs[_fi])&gt;&gt;
         &lt;&lt;/if&gt;&gt;
     &lt;&lt;/for&gt;&gt;
@@ -2968,14 +2974,12 @@ As morning dawns, a terrible realization settles over your &lt;&lt;defHousehold 
     /* If the child has servants, keep the oldest one */
     &lt;&lt;if $NPCsServants.length gt 0&gt;&gt;
         &lt;&lt;for _fs = 1; _fs &lt; $NPCsServants.length; _fs++&gt;&gt;
-            &lt;&lt;if $NPCsServants[_fs].health is &quot;infected&quot;&gt;&gt;&lt;&lt;if random(1,2) eq 1&gt;&gt;&lt;&lt;set $NPCsServants[_fs].health to &quot;deceased&quot;&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $NPCsServants[_fs].health to &quot;recovered&quot;&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;
             &lt;&lt;set $FledServants.push($NPCsServants[_fs])&gt;&gt;
         &lt;&lt;/for&gt;&gt;
         &lt;&lt;set $NPCsServants to $NPCsServants.slice(0, 1)&gt;&gt;
     &lt;&lt;/if&gt;&gt;
 &lt;&lt;else&gt;&gt;
     &lt;&lt;for _f range $NPCs&gt;&gt;
-            &lt;&lt;if _f.health is &quot;infected&quot;&gt;&gt;&lt;&lt;if random(1,2) eq 1&gt;&gt;&lt;&lt;set _f.health to &quot;deceased&quot;&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set _f.health to &quot;recovered&quot;&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;
             &lt;&lt;set $FledFamily.push(_f)&gt;&gt;
     &lt;&lt;/for&gt;&gt;
     &lt;&lt;set $NPCs to []&gt;&gt;
@@ -2985,14 +2989,13 @@ As morning dawns, a terrible realization settles over your &lt;&lt;defHousehold 
         &lt;&lt;if _keepCount gt $NPCsServants.length&gt;&gt;&lt;&lt;set _keepCount to $NPCsServants.length&gt;&gt;&lt;&lt;/if&gt;&gt;
         &lt;&lt;set _totalServants to $NPCsServants.length&gt;&gt;
         &lt;&lt;for _fs to _keepCount; _fs lt _totalServants; _fs++&gt;&gt;
-            &lt;&lt;if $NPCsServants[_fs].health is &quot;infected&quot;&gt;&gt;&lt;&lt;if random(1,2) eq 1&gt;&gt;&lt;&lt;set $NPCsServants[_fs].health to &quot;deceased&quot;&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $NPCsServants[_fs].health to &quot;recovered&quot;&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;
             &lt;&lt;set $FledServants.push($NPCsServants[_fs])&gt;&gt;
         &lt;&lt;/for&gt;&gt;
         &lt;&lt;set $NPCsServants to $NPCsServants.slice(0, _keepCount)&gt;&gt;
     &lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;check-widowed&gt;&gt;
-&lt;&lt;/silently&gt;&gt;
+&lt;&lt;/silently&gt;&gt;&lt;&lt;/if&gt;&gt;/* end fled-family infection guard */
 &lt;&lt;/widget&gt;&gt;
 
 &lt;&lt;widget &quot;health-update&quot;&gt;&gt;
@@ -3669,6 +3672,19 @@ In fact, you&lt;&lt;if $agenum lte 15&gt;&gt; and your family&lt;&lt;/if&gt;&gt;
 &lt;&lt;widget &quot;flee-choice&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
 &lt;&lt;set _ctx to $args[0]&gt;&gt;
 
+/* Infection guard: block flight if PC or household NPCs are infected */
+&lt;&lt;set _fleeInfected to false&gt;&gt;
+&lt;&lt;if $plagueInfection eq 1&gt;&gt;&lt;&lt;set _fleeInfected to true&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;silently&gt;&gt;
+&lt;&lt;set _hasInfectedNPC to false&gt;&gt;
+&lt;&lt;for _npc range $NPCs&gt;&gt;&lt;&lt;if _npc.health is &quot;infected&quot;&gt;&gt;&lt;&lt;set _hasInfectedNPC to true&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
+&lt;&lt;for _sv range $NPCsServants&gt;&gt;&lt;&lt;if _sv.health is &quot;infected&quot;&gt;&gt;&lt;&lt;set _hasInfectedNPC to true&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
+&lt;&lt;/silently&gt;&gt;
+&lt;&lt;if _fleeInfected&gt;&gt;You begin to make preparations to leave the city, but as you do you notice a strange lump forming on your body. God&#39;s wounds &amp;mdash; you have caught the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt;! There will be no fleeing now.
+&lt;&lt;sickPC&gt;&gt;
+&lt;&lt;elseif _hasInfectedNPC&gt;&gt;You prepare your household to flee the city. It takes some time to sort out the travel logistics, but finally everything is in order. They will leave tomorrow.&lt;br&gt;&lt;br&gt;
+&lt;&lt;sickFam&gt;&gt;
+&lt;&lt;else&gt;&gt;
 /* Day Labourers */
 &lt;&lt;if $socio is &quot;day labourers&quot;&gt;&gt;
 &lt;&lt;if _ctx is &quot;initial&quot;&gt;&gt;
@@ -3801,6 +3817,7 @@ You decide to:
 It&#39;s also not too late to &lt;&lt;if $hoh is 0 and $NPCs.length gt 0&gt;&gt;try and convince your family to &lt;&lt;/if&gt;&gt;[[flee to the countryside with your household-&gt;Fled][_repBefore to $reputation; $fled to 6; $money -= 10000; $reputation to Math.clamp($reputation - 1, 0, 10); $decisions.push({text: &quot;Fled the city with household&quot;, money: -10000, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: null})]]
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;/* end infection guard */
 &lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="65" name="Household-Fled" tags="fled" position="775,1300" size="100,100">
 You help your &lt;&lt;defHousehold &quot;household&quot;&gt;&gt; to pack up and leave the city for safety.  You promise to meet them should the situation grow worse.
 
@@ -3952,7 +3969,7 @@ Luckily, there are no &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; cases in your
 &lt;li&gt;&lt;&lt;link &quot;Household Status&quot;&gt;&gt;
     &lt;&lt;run Dialog.setup(&quot;Household&quot;, &quot;household&quot;); Dialog.wiki(Story.get(&quot;Household Status&quot;).text); Dialog.open()&gt;&gt;
 &lt;&lt;/link&gt;&gt;&lt;/li&gt;
-&lt;&lt;if visited(&quot;May 1665&quot;) and $fled isnot 6 and $fled isnot 1 and $fled isnot 2&gt;&gt;&lt;li&gt;&lt;&lt;link &quot;Flight&quot;&gt;&gt;
+&lt;&lt;if visited(&quot;May 1665&quot;) and $fled isnot 6 and $fled isnot 1 and $fled isnot 2 and passage() isnot &quot;FamPesthouse&quot; and passage() isnot &quot;Quarantine, Week 1&quot; and passage() isnot &quot;Quarantine Continues&quot; and passage() isnot &quot;sickPC&quot; and passage() isnot &quot;Hide&quot; and passage() isnot &quot;YouPesthouse&quot; and passage() isnot &quot;death&quot;&gt;&gt;&lt;li&gt;&lt;&lt;link &quot;Flight&quot;&gt;&gt;
     &lt;&lt;run Dialog.setup(&quot;Flight&quot;, &quot;flight&quot;); Dialog.wiki(Story.get(&quot;Flight&quot;).text); Dialog.open()&gt;&gt;
 &lt;&lt;/link&gt;&gt;&lt;/li&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="73" name="empty" tags="" position="150,1300" size="100,100">/* use as needed */</tw-passagedata><tw-passagedata pid="74" name="Household Status" tags="" position="650,25" size="100,100">Player stats:


### PR DESCRIPTION
…ld — bump to v2.16

Three guards added to close all escape paths for infected players and NPCs:

1. Hide Flight sidebar button during quarantine, sickness, pesthouse, and death passages (FamPesthouse, Quarantine Week 1, Quarantine Continues, sickPC, Hide, YouPesthouse, death)

2. Block all flee options in the flee-choice widget when the player character ($plagueInfection eq 1) or any household NPC/servant is infected, routing to <<sickPC>> or <<sickFam>> respectively

3. Replace 50/50 coin-flip cleanup in fled-family widget with a proper guard that blocks sending infected NPCs away, reverting $fled to 4 and calling <<sickFam>> instead

https://claude.ai/code/session_01XwS7QtxB9zNN2JCjkqprpT