### PR TITLE
Add church office eligibility system for artisans/merchants — bump to…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.23" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.24" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -2117,6 +2117,7 @@ But those are worries for the future! For now, it is time to eat, drink, and pla
 &lt;&lt;nobr&gt;&gt;
       &lt;&lt;set $NPCs.push({ name: weightedEither($mNames), agenum: random(10,15), age: &quot;adolescent&quot;, relationship: &quot;apprentice&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
 &lt;&lt;set $apprentice to 2&gt;&gt;
+&lt;&lt;set $office to &quot;&quot;&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;
 
@@ -3735,6 +3736,13 @@ You died with a good enough reputation that your neighbors say prayers for your 
 
 &lt;&lt;set $fledFromIndex to $monthIndex&gt;&gt;
 
+&lt;&lt;if $office isnot &quot;&quot;&gt;&gt;
+You have abandoned your parish and been removed from your position as $office.
+&lt;&lt;set $office to &quot;&quot;&gt;&gt;
+&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;
+&lt;br&gt;&lt;br&gt;
+&lt;&lt;/if&gt;&gt;
+
 &lt;&lt;if $socio is &quot;nobles&quot;&gt;&gt;You&lt;&lt;if $agenum lte 15&gt;&gt; convince your family to&lt;&lt;else&gt;&gt; have decided to&lt;&lt;/if&gt;&gt; &#39;&#39;flee to your country estate&#39;&#39;.
 &lt;&lt;elseif $socio is &quot;servants&quot;&gt;&gt;
 Your $masterTitle flees London with you and the rest of &lt;&lt;if $masterGender is &quot;female&quot;&gt;&gt;her&lt;&lt;else&gt;&gt;his&lt;&lt;/if&gt;&gt; &lt;&lt;defHousehold &quot;household&quot;&gt;&gt;. You have only a little time to prepare and say goodbye to your friends before you leave.&lt;br&gt;
@@ -4076,6 +4084,7 @@ Luckily, there are no &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; cases in your
 &lt;ul&gt;&lt;li&gt;Name: $name&lt;/li&gt;
 &lt;li&gt;Age: $age&lt;/li&gt;
 &lt;li&gt;Social class: $socio&lt;/li&gt;
+&lt;&lt;if $office isnot &quot;&quot;&gt;&gt;&lt;li&gt;Office: $office&lt;/li&gt;&lt;&lt;/if&gt;&gt;
 &lt;li&gt;Location: $location&lt;/li&gt;
 &lt;li&gt;Current plague status: $playerPlagueStatus&lt;/li&gt;
 &lt;/ul&gt;
@@ -5488,6 +5497,8 @@ Unfortunately, you have suffered a miscarriage and are no longer pregnant.
 				&lt;&lt;if not _npcDeathOccurred&gt;&gt;&lt;&lt;set _randomEventFired to false&gt;&gt;&lt;&lt;/if&gt;&gt;
 			&lt;&lt;/if&gt;&gt;
 	&lt;&lt;elseif $socio is &quot;merchants&quot; or $socio is &quot;artisans&quot;&gt;&gt;
+		&lt;&lt;hold-office&gt;&gt;
+		&lt;&lt;if not _officeEventFired&gt;&gt;
 		&lt;&lt;if $apprentice isnot 0&gt;&gt;
 			&lt;&lt;set $apprentice to random(1,10)&gt;&gt;
 			&lt;&lt;if $apprentice is 1 and hasVisited(&quot;March 1666&quot;)&gt;&gt;
@@ -5497,6 +5508,7 @@ Unfortunately, you have suffered a miscarriage and are no longer pregnant.
 			&lt;&lt;/if&gt;&gt;
 		&lt;&lt;else&gt;&gt;
 			&lt;&lt;if not _npcDeathOccurred&gt;&gt;&lt;&lt;set _randomEventFired to false&gt;&gt;&lt;&lt;/if&gt;&gt;
+		&lt;&lt;/if&gt;&gt;
 		&lt;&lt;/if&gt;&gt;
 	&lt;&lt;else&gt;&gt; /* it should not be possible to reach this point but putting in as safeguard */
 		&lt;&lt;if not _npcDeathOccurred&gt;&gt;&lt;&lt;set _randomEventFired to false&gt;&gt;&lt;&lt;/if&gt;&gt;
@@ -5561,6 +5573,35 @@ You tended to the sick in your parish this month and were paid &lt;&lt;print _cw
 &lt;&lt;set _partyCost to 6&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;set $money -= _partyCost&gt;&gt;
+&lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;
+
+&lt;&lt;widget &quot;hold-office&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
+&lt;&lt;set _officeEventFired to false&gt;&gt;
+/* Check for office removal due to low reputation */
+&lt;&lt;if $office isnot &quot;&quot; and $reputation lte 4&gt;&gt;
+Because of your poor reputation, the vestry of $parish has removed you from your position as $office.
+&lt;&lt;set $office to &quot;&quot;&gt;&gt;
+&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;
+&lt;br&gt;&lt;br&gt;
+&lt;&lt;/if&gt;&gt;
+/* Check eligibility for church office: CoE male, age 30+, artisan/merchant, rep 8+, no current office */
+&lt;&lt;if $office is &quot;&quot; and $religion is &quot;member of the Church of England&quot; and $gender is &quot;male&quot; and $agenum gte 30 and $reputation gte 8&gt;&gt;
+&lt;&lt;set _officeRoll to random(1,4)&gt;&gt;
+&lt;&lt;if _officeRoll is 1&gt;&gt;
+&lt;&lt;set _officeEventFired to true&gt;&gt;
+&lt;&lt;set _officeType to either(&quot;Churchwarden&quot;, &quot;Overseer of the Poor&quot;)&gt;&gt;
+&lt;span id=&quot;officeChoice&quot;&gt;The vestry of $parish has taken note of your good reputation and asks if you would be willing to serve as &lt;&lt;print _officeType&gt;&gt;. Will you accept?&lt;br&gt;&lt;br&gt;
+&lt;&lt;link &quot;Yes, I will serve&quot;&gt;&gt;&lt;&lt;replace &quot;#officeChoice&quot;&gt;&gt;
+&lt;&lt;set $office to _officeType&gt;&gt;
+&lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;
+You accept the position of &lt;&lt;print _officeType&gt;&gt; in $parish. Your neighbors are pleased by your willingness to serve, and your reputation improves.&lt;br&gt;&lt;br&gt;
+&lt;&lt;storyline-return&gt;&gt;
+&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No, I must decline&quot;&gt;&gt;&lt;&lt;replace &quot;#officeChoice&quot;&gt;&gt;
+You politely decline the position. The vestry thanks you for your consideration.&lt;br&gt;&lt;br&gt;
+&lt;&lt;storyline-return&gt;&gt;
+&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="115" name="june-1665-helper-widget" tags="widget" position="1475,325" size="100,100">&lt;&lt;widget &quot;june-1665-helper&quot;&gt;&gt;
 &lt;&lt;nobr&gt;&gt;
 The &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; grows worse and the streets are soon filled with coaches and wagons full of people fleeing with their goods to the countryside. The &lt;&lt;defQueenMother &quot;Queen Mother&quot;&gt;&gt; &lt;&lt;defHenriettaMaria &quot;Henrietta Maria&quot;&gt;&gt; moves back to France&lt;&lt;if $religion is &quot;Catholic&quot;&gt;&gt;, much to your dismay, and that of your fellow Catholics who flock to her chapel each week&lt;&lt;else&gt;&gt;, much to your relief, and that of all your fellow God-fearing &lt;&lt;defProtestants &quot;Protestants&quot;&gt;&gt;&lt;&lt;/if&gt;&gt;. On June 29th, the King packs up his entire &lt;&lt;defHousehold &quot;household&quot;&gt;&gt; in 148 carriages and moves 12 miles away, to his palace at &lt;&lt;defHamptonCourt &quot;Hampton Court&quot;&gt;&gt;.

--- a/variables.md
+++ b/variables.md
@@ -588,7 +588,17 @@ This document lists all global (story) variables used in **Gaming the Great Plag
   - `"merchants"`: `8`
   - `"nobles"`: `10`
 - **Modified by:** Various increments/decrements (`+= 1`, `-= 1`, `+= 2`, `-= 2`, `+= 3`, `-= 3`, or set to `0` for contract-breaking). Always clamped to 0--10.
-- **Used for:** Affects flee success (artisans with reputation <= 5 may fail to flee), available choices, and narrative outcomes
+- **Used for:** Affects flee success (artisans with reputation <= 5 may fail to flee), available choices, narrative outcomes, and church office eligibility
+
+### `$office`
+- **Type:** String
+- **Possible values:** `""` (no office), `"Churchwarden"`, `"Overseer of the Poor"`
+- **Initial value:** `""` (set in `char-gen-widgets`, pid 14)
+- **Set by:** The `hold-office` widget (pid 114) when an eligible player accepts a church office position.
+- **Eligibility:** `$socio` is `"artisans"` or `"merchants"`, `$religion` is `"member of the Church of England"`, `$gender` is `"male"`, `$agenum gte 30`, `$reputation gte 8`, and `$office` is `""`. If eligible, there is a 25% chance per month of being offered an office, with equal odds of Churchwarden or Overseer of the Poor.
+- **Removal conditions:** Removed (reset to `""`) with &minus;1 reputation if `$reputation lte 4`, or if the player flees (enters the Fled passage, pid 63).
+- **Displayed in:** Household Status (pid 74) as "Office: $office" beneath "Social class" when not empty.
+- **Dependencies:** Interacts with `$reputation` (eligibility threshold, removal threshold, +1 on acceptance, &minus;1 on removal).
 
 ### `$skipServices`
 - **Type:** Integer


### PR DESCRIPTION
… v2.24

Implement hold-office widget allowing eligible players (male, Church of England, age 30+, artisan/merchant, reputation >= 8) a 25% monthly chance to be offered Churchwarden or Overseer of the Poor in their parish.

- New $office variable initialized in char-gen, displayed in Household Status
- Office removed with -1 reputation if reputation drops to 4 or below
- Office removed with -1 reputation and notification if player flees
- Widget called in random-events before the apprentice event
- variables.md updated with $office documentation

https://claude.ai/code/session_01422kr6SbyJfAKqHKECuWRW