### PR TITLE
Restrict searcher, corpsebearer, and nurse roles to Church of England…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.26" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.27" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -2837,7 +2837,7 @@ Do you:
 [[stand firm in your refusal to risk your life-&gt;deported][$decisions.push({text: &quot;Stood firm and was deported&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})]]
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;elseif $socio is &quot;day labourers&quot;&gt;&gt;&lt;&lt;set $socio to &quot;beggars&quot;&gt;&gt;&lt;&lt;set $money to 0&gt;&gt;Because you are no longer working, you quickly run out of money and have to throw yourself on the mercy of your &lt;&lt;defParish &quot;parish&#39;s&quot;&gt;&gt; &lt;&lt;defOverseersOfThePoor &quot;Overseers of the Poor&quot;&gt;&gt;.&lt;br&gt;&lt;br&gt;
-They have decided it will be your job to 
+&lt;&lt;if $religion is &quot;member of the Church of England&quot;&gt;&gt;They have decided it will be your job to 
 &lt;&lt;if $gender is &quot;male&quot; or $gender is &quot;nonbinary&quot;&gt;&gt;&lt;&lt;set $role to &quot;corpsebearer&quot;&gt;&gt;remove the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; corpses of anyone who dies.
 &lt;br&gt;
 &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/7/7a/Wilson_%22The_plague...%22%3B_a_corpses_bearer_Wellcome_L0016624.jpg&quot; width=&quot;100%&quot;&gt;
@@ -2852,6 +2852,8 @@ They have decided it will be your job to
 &lt;&lt;else&gt;&gt;&lt;&lt;set $role to &quot;nurse&quot;&gt;&gt;nurse the sick and dying, despite the risk to your own life.
 &lt;&lt;/if&gt;&gt;
 You have no choice but to &lt;&lt;storyline-return &quot;accept your new role&quot;&gt;&gt;.
+&lt;&lt;else&gt;&gt;As you are not a member of the Church of England, the parish cannot assign you to plague work. You have no choice but to &lt;&lt;storyline-return &quot;accept your new situation&quot;&gt;&gt;.
+&lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="38" name="July 1665" tags="storyline 1665" position="1450,475" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
@@ -3445,7 +3447,7 @@ While this is enough for a little extra bread, you are painfully aware that this
 One of your neighbors &lt;&lt;if $reputation gte 6&gt;&gt;provides you with leftovers from a feast&lt;&lt;else&gt;&gt;&lt;&lt;if _charity is 1&gt;&gt;gives you some moldy bread&lt;&lt;else&gt;&gt;lets you have an old dress, which you sell for a bit of extra bread&lt;&lt;set $plagueInfection to random(1,100)&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;. Because you didn&#39;t have to spend as much money on food, you manage to save an extra $beggarsluck pence.&lt;&lt;unset $beggarsluck&gt;&gt;
 &lt;&lt;storyline-return&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="54" name="beggar-roles" tags="widget" position="1450,25" size="100,100">&lt;&lt;widget &quot;beggar-roles&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
-    &lt;&lt;if $disability is 0&gt;&gt; and the &lt;&lt;defOverseersOfThePoor &quot;Overseers of the Poor&quot;&gt;&gt; have decided it will be your job to
+    &lt;&lt;if $disability is 0 and $religion is &quot;member of the Church of England&quot;&gt;&gt; and the &lt;&lt;defOverseersOfThePoor &quot;Overseers of the Poor&quot;&gt;&gt; have decided it will be your job to
         &lt;&lt;if $gender is &quot;male&quot; or $gender is &quot;nonbinary&quot;&gt;&gt;&lt;&lt;set $role to &quot;corpsebearer&quot;&gt;&gt;remove the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; corpses if anyone dies
         &lt;br&gt;
 &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/7/7a/Wilson_%22The_plague...%22%3B_a_corpses_bearer_Wellcome_L0016624.jpg&quot; width=&quot;100%&quot;&gt;
@@ -3458,6 +3460,7 @@ One of your neighbors &lt;&lt;if $reputation gte 6&gt;&gt;provides you with left
         
         &lt;&lt;else&gt;&gt;&lt;&lt;set $role to &quot;nurse&quot;&gt;&gt;nurse the sick and dying, despite the risk to your own life
         &lt;&lt;/if&gt;&gt;
+    &lt;&lt;elseif $disability is 0&gt;&gt;, but the &lt;&lt;defOverseersOfThePoor &quot;Overseers of the Poor&quot;&gt;&gt; have refused to hire you for plague work, as only members of the Church of England may serve in such parish offices
     &lt;&lt;/if&gt;&gt;.
     &lt;&lt;if $disability gte 1&gt;&gt;Many of your neighbors begin to flee the city and those who remain curse at you to leave when you try begging at their doors.&lt;&lt;/if&gt;&gt;
 &lt;br&gt;&lt;br&gt;You decide to:
@@ -3812,11 +3815,14 @@ In fact, you&lt;&lt;if $agenum lte 15&gt;&gt; and your family&lt;&lt;/if&gt;&gt;
 &lt;&lt;if $socio is &quot;day labourers&quot;&gt;&gt;
 &lt;&lt;if _ctx is &quot;initial&quot;&gt;&gt;
 &lt;&lt;if $origin isnot &quot;London&quot;&gt;&gt; You still have family back home in $origin and have to consider whether or not to abandon your home and whatever possessions you cannot carry to take refuge with your family.&lt;&lt;/if&gt;&gt;&lt;br&gt;&lt;br&gt;
-    You hear that the local parish officials want to hire you to &lt;&lt;if $gender is &quot;male&quot; and $agenum gte 16&gt;&gt;remove the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; corpses if anyone dies&lt;&lt;elseif $gender is &quot;female&quot; and $agenum gte 16 and $reputation gte 5&gt;&gt;look at plague corpses and determine if they died of plague or some other cause of death&lt;&lt;else&gt;&gt;nurse the sick and dying, despite the risk to your own life&lt;&lt;/if&gt;&gt;.&lt;br&gt;&lt;br&gt;
-    You decide to:
+    &lt;&lt;if $religion is &quot;member of the Church of England&quot;&gt;&gt;You hear that the local parish officials want to hire you to &lt;&lt;if $gender is &quot;male&quot; and $agenum gte 16&gt;&gt;remove the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; corpses if anyone dies&lt;&lt;elseif $gender is &quot;female&quot; and $agenum gte 16 and $reputation gte 5&gt;&gt;look at plague corpses and determine if they died of plague or some other cause of death&lt;&lt;else&gt;&gt;nurse the sick and dying, despite the risk to your own life&lt;&lt;/if&gt;&gt;.&lt;br&gt;&lt;br&gt;
+&lt;&lt;else&gt;&gt;As you are not a member of the Church of England, the parish cannot offer you plague work.&lt;br&gt;&lt;br&gt;
+&lt;&lt;/if&gt;&gt;    You decide to:
     &lt;ul&gt;
-        &lt;li&gt;&lt;&lt;link &quot;accept the job&quot; &quot;Stay&quot;&gt;&gt;&lt;&lt;set $fled to 4&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Accepted a plague work job&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;if $gender is &quot;female&quot; and $agenum gte 16 and $reputation gte 5&gt;&gt;&lt;&lt;set $role to &quot;searcher&quot;&gt;&gt;&lt;&lt;elseif $agenum lte 15&gt;&gt;&lt;&lt;set $role to &quot;nurse&quot;&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $role to &quot;corpsebearer&quot;&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
+        &lt;&lt;if $religion is &quot;member of the Church of England&quot;&gt;&gt;&lt;li&gt;&lt;&lt;link &quot;accept the job&quot; &quot;Stay&quot;&gt;&gt;&lt;&lt;set $fled to 4&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Accepted a plague work job&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;if $gender is &quot;female&quot; and $agenum gte 16 and $reputation gte 5&gt;&gt;&lt;&lt;set $role to &quot;searcher&quot;&gt;&gt;&lt;&lt;elseif $agenum lte 15&gt;&gt;&lt;&lt;set $role to &quot;nurse&quot;&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $role to &quot;corpsebearer&quot;&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
         &lt;li&gt;[[not accept the job-&gt;Stay][_repBefore to $reputation; $reputation to Math.clamp($reputation - 1, 0, 10); $fled to 4; $role to &quot;unemployed&quot;; $decisions.push({text: &quot;Refused the plague work job&quot;, money: 0, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: null})]]&lt;/li&gt;
+        &lt;&lt;else&gt;&gt;&lt;li&gt;[[Remain in the city-&gt;Stay][$fled to 4; $decisions.push({text: &quot;Remained in the city&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})]]&lt;/li&gt;
+        &lt;&lt;/if&gt;&gt;
         &lt;&lt;if $origin isnot &quot;London&quot;&gt;&gt;
             &lt;&lt;if $hoh is 1&gt;&gt;&lt;li&gt;[[flee the city and return to your place of origin-&gt;Fled][$fled to 6; $decisions.push({text: &quot;Fled back to place of origin&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})]]&lt;/li&gt;
                 &lt;&lt;if $NPCs.length gt 0&gt;&gt;&lt;li&gt;[[remain in the city yourself, but send your family back to your place of origin-&gt;Stay][$fled to 5; $decisions.push({text: &quot;Sent family home but stayed&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: 0}); $plagueInfection to 0; _infectedFamily to 0]]&lt;/li&gt;&lt;&lt;/if&gt;&gt;


### PR DESCRIPTION
… members — bump to v2.27

Non-conformists (Presbyterian, Baptist, Quaker) and Catholics are now ineligible for plague work roles assigned by the parish Overseers of the Poor, reflecting the historically accurate restriction that these official parish positions were limited to members of the Church of England.

Changes to three role-assignment locations:
- pid 54 (beggar-roles widget): roles only offered when $religion is "member of the Church of England"; non-members see a refusal message instead.
- pid 37 (work-refusal): day labourers who become beggars only get a plague role if Church of England; others receive an explanation and continue without a role.
- pid 64 (flee-choice widget): day labourers are only offered the job acceptance option if Church of England; others see a "parish cannot offer you plague work" message and a plain "Remain in the city" option.

https://claude.ai/code/session_01PSb671v5Vj3rxzdYbxWdfa