### PR TITLE
Add warder role for male Church of England plague workers — bump to v…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.27" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.28" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -1477,6 +1477,8 @@ The graveyards are beginning to overflow and corpses are being flung into the op
 &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/7/7a/Wilson_%22The_plague...%22%3B_a_corpses_bearer_Wellcome_L0016624.jpg&quot; width=&quot;100%&quot;&gt;
 //Printed by R. Price, A corpse bearer; reproduction of an engraving from a series of London Cries, 1655. Wellcome Images//
 
+    &lt;&lt;elseif $role is &quot;warder&quot;&gt;&gt;You stand watch outside quarantined houses, listening to the cries and pleas of those locked inside. Some beg you to let them out, swearing they are not sick, but you must hold your post.
+
     &lt;&lt;elseif $role is &quot;searcher&quot;&gt;&gt;People attempt to bribe you to say that their loved ones died of something other than &lt;&lt;defPlague &quot;plague&quot;&gt;&gt;. 
     &lt;br&gt;
     &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/6/67/Plague_in_1665_%28BM_1875%2C0508.1513%29.jpg&quot; width=&quot;100%&quot;&gt;
@@ -2305,11 +2307,11 @@ You
 &lt;&lt;corpse-work&gt;&gt;
  /* Beggar &amp; Day Labourer choices */
 /* nts: need text if day labourers don&#39;t have a job */
-    &lt;&lt;if $role is &quot;corpsebearer&quot; or $role is &quot;searcher&quot; or $role is &quot;nurse&quot;&gt;&gt;
+    &lt;&lt;if $role is &quot;corpsebearer&quot; or $role is &quot;searcher&quot; or $role is &quot;nurse&quot; or $role is &quot;warder&quot;&gt;&gt;
         &lt;&lt;if ndef $textGroup&gt;&gt;&lt;&lt;set $textGroup = 1&gt;&gt;&lt;&lt;/if&gt;&gt;
         &lt;&lt;switch $textGroup&gt;&gt;
             People are dying so fast now that burials have to happen night and day to keep corpses from piling up throughout the city.&lt;br&gt;&lt;br&gt;
-            &lt;&lt;case 1&gt;&gt;&lt;&lt;if $role is &quot;corpsebearer&quot;&gt;&gt;As you take the dead to the graveyards&lt;&lt;elseif $role is &quot;searcher&quot;&gt;&gt;Almost all the bodies you inspect are of &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; victims and&lt;&lt;else&gt;&gt;Your patients die almost as fast as you are assigned to care for them and&lt;&lt;/if&gt;&gt; you marvel at how much money is being wasted through the clothing that is buried with them. It’s illegal to take goods off the dead, and you know it’s dangerous as well. 
+            &lt;&lt;case 1&gt;&gt;&lt;&lt;if $role is &quot;corpsebearer&quot;&gt;&gt;As you take the dead to the graveyards&lt;&lt;elseif $role is &quot;searcher&quot;&gt;&gt;Almost all the bodies you inspect are of &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; victims and&lt;&lt;elseif $role is &quot;warder&quot;&gt;&gt;As you stand guard outside quarantined houses, you see the dead being carried out in ever greater numbers and&lt;&lt;else&gt;&gt;Your patients die almost as fast as you are assigned to care for them and&lt;&lt;/if&gt;&gt; you marvel at how much money is being wasted through the clothing that is buried with them. It’s illegal to take goods off the dead, and you know it’s dangerous as well. 
             &lt;br&gt;&lt;br&gt;
             You decide to:
             &lt;ul&gt;
@@ -2345,6 +2347,7 @@ So many people are sick and shut up in their houses that the city has imposed a 
 The deaths continue in such great numbers that you can hardly believe it.&lt;br&gt;&lt;br&gt;
 &lt;&lt;if $role is &quot;corpsebearer&quot;&gt;&gt;You are shocked to see that some bold people have begun attending &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; funerals, as if it were a child’s game or dare. &lt;br&gt;&lt;br&gt;
 &lt;&lt;sep-1665-helper&gt;&gt; 
+    &lt;&lt;elseif $role is &quot;warder&quot;&gt;&gt;Some of those locked in their houses have grown desperate and you have had to physically restrain people trying to break out of quarantine.&lt;br&gt;&lt;br&gt;&lt;&lt;sep-1665-helper&gt;&gt; 
     &lt;&lt;elseif $role is &quot;nurse&quot;&gt;&gt;Some of your patients, furious at being locked in, have been trying to lean out windows to breathe and spit upon the healthy people walking past.&lt;br&gt;&lt;br&gt;&lt;&lt;sep-1665-helper&gt;&gt; 
     &lt;&lt;else&gt;&gt;
     &lt;span id=&quot;gossip&quot;&gt;Do you continue to go out in the city? &lt;&lt;link &quot;No, better say inside for now&quot;&gt;&gt;&lt;&lt;replace &quot;#gossip&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Sep 1665: Stayed indoors&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;You stay indoors. 
@@ -2838,11 +2841,13 @@ Do you:
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;elseif $socio is &quot;day labourers&quot;&gt;&gt;&lt;&lt;set $socio to &quot;beggars&quot;&gt;&gt;&lt;&lt;set $money to 0&gt;&gt;Because you are no longer working, you quickly run out of money and have to throw yourself on the mercy of your &lt;&lt;defParish &quot;parish&#39;s&quot;&gt;&gt; &lt;&lt;defOverseersOfThePoor &quot;Overseers of the Poor&quot;&gt;&gt;.&lt;br&gt;&lt;br&gt;
 &lt;&lt;if $religion is &quot;member of the Church of England&quot;&gt;&gt;They have decided it will be your job to 
-&lt;&lt;if $gender is &quot;male&quot; or $gender is &quot;nonbinary&quot;&gt;&gt;&lt;&lt;set $role to &quot;corpsebearer&quot;&gt;&gt;remove the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; corpses of anyone who dies.
+&lt;&lt;if $gender is &quot;male&quot; or $gender is &quot;nonbinary&quot;&gt;&gt;&lt;&lt;set _offeredRole to either(&quot;corpsebearer&quot;, &quot;warder&quot;)&gt;&gt;&lt;&lt;set $role to _offeredRole&gt;&gt;&lt;&lt;if _offeredRole is &quot;warder&quot;&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if _offeredRole is &quot;corpsebearer&quot;&gt;&gt;remove the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; corpses of anyone who dies.
 &lt;br&gt;
 &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/7/7a/Wilson_%22The_plague...%22%3B_a_corpses_bearer_Wellcome_L0016624.jpg&quot; width=&quot;100%&quot;&gt;
 &lt;br&gt;
 //Printed by R. Price, A corpse bearer; reproduction of an engraving from a series of London Cries, 1655. Wellcome Images//
+&lt;&lt;else&gt;&gt;stand guard outside quarantined houses to prevent anyone from escaping.
+&lt;&lt;/if&gt;&gt;
 &lt;br&gt;&lt;br&gt;
 &lt;&lt;elseif $gender is &quot;female&quot; and $reputation gt 5&gt;&gt;&lt;&lt;set $role to &quot;searcher&quot;&gt;&gt;look at the corpses and determine if they died of &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; or some other cause of death
 &lt;br&gt;
@@ -3448,10 +3453,12 @@ One of your neighbors &lt;&lt;if $reputation gte 6&gt;&gt;provides you with left
 &lt;&lt;storyline-return&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="54" name="beggar-roles" tags="widget" position="1450,25" size="100,100">&lt;&lt;widget &quot;beggar-roles&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
     &lt;&lt;if $disability is 0 and $religion is &quot;member of the Church of England&quot;&gt;&gt; and the &lt;&lt;defOverseersOfThePoor &quot;Overseers of the Poor&quot;&gt;&gt; have decided it will be your job to
-        &lt;&lt;if $gender is &quot;male&quot; or $gender is &quot;nonbinary&quot;&gt;&gt;&lt;&lt;set $role to &quot;corpsebearer&quot;&gt;&gt;remove the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; corpses if anyone dies
+        &lt;&lt;if $gender is &quot;male&quot; or $gender is &quot;nonbinary&quot;&gt;&gt;&lt;&lt;set _offeredRole to either(&quot;corpsebearer&quot;, &quot;warder&quot;)&gt;&gt;&lt;&lt;set $role to _offeredRole&gt;&gt;&lt;&lt;if _offeredRole is &quot;warder&quot;&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if _offeredRole is &quot;corpsebearer&quot;&gt;&gt;remove the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; corpses if anyone dies
         &lt;br&gt;
 &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/7/7a/Wilson_%22The_plague...%22%3B_a_corpses_bearer_Wellcome_L0016624.jpg&quot; width=&quot;100%&quot;&gt;
 //Printed by R. Price, A corpse bearer; reproduction of an engraving from a series of London Cries, 1655. Wellcome Images//
+        &lt;&lt;else&gt;&gt;stand guard outside quarantined houses to prevent anyone from escaping
+        &lt;&lt;/if&gt;&gt;
         
         &lt;&lt;elseif $gender is &quot;female&quot; and $reputation gt 5&gt;&gt;&lt;&lt;set $role to &quot;searcher&quot;&gt;&gt;look at the corpses and determine if they died of &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; or some other cause of death
         &lt;br&gt;
@@ -3815,11 +3822,11 @@ In fact, you&lt;&lt;if $agenum lte 15&gt;&gt; and your family&lt;&lt;/if&gt;&gt;
 &lt;&lt;if $socio is &quot;day labourers&quot;&gt;&gt;
 &lt;&lt;if _ctx is &quot;initial&quot;&gt;&gt;
 &lt;&lt;if $origin isnot &quot;London&quot;&gt;&gt; You still have family back home in $origin and have to consider whether or not to abandon your home and whatever possessions you cannot carry to take refuge with your family.&lt;&lt;/if&gt;&gt;&lt;br&gt;&lt;br&gt;
-    &lt;&lt;if $religion is &quot;member of the Church of England&quot;&gt;&gt;You hear that the local parish officials want to hire you to &lt;&lt;if $gender is &quot;male&quot; and $agenum gte 16&gt;&gt;remove the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; corpses if anyone dies&lt;&lt;elseif $gender is &quot;female&quot; and $agenum gte 16 and $reputation gte 5&gt;&gt;look at plague corpses and determine if they died of plague or some other cause of death&lt;&lt;else&gt;&gt;nurse the sick and dying, despite the risk to your own life&lt;&lt;/if&gt;&gt;.&lt;br&gt;&lt;br&gt;
+    &lt;&lt;if $religion is &quot;member of the Church of England&quot;&gt;&gt;&lt;&lt;set _offeredRole to either(&quot;corpsebearer&quot;, &quot;warder&quot;)&gt;&gt;You hear that the local parish officials want to hire you to &lt;&lt;if $gender is &quot;male&quot; and $agenum gte 16 and _offeredRole is &quot;corpsebearer&quot;&gt;&gt;remove the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; corpses if anyone dies&lt;&lt;elseif $gender is &quot;male&quot; and $agenum gte 16 and _offeredRole is &quot;warder&quot;&gt;&gt;stand guard outside quarantined houses to prevent anyone from escaping&lt;&lt;elseif $gender is &quot;female&quot; and $agenum gte 16 and $reputation gte 5&gt;&gt;look at plague corpses and determine if they died of plague or some other cause of death&lt;&lt;else&gt;&gt;nurse the sick and dying, despite the risk to your own life&lt;&lt;/if&gt;&gt;.&lt;br&gt;&lt;br&gt;
 &lt;&lt;else&gt;&gt;As you are not a member of the Church of England, the parish cannot offer you plague work.&lt;br&gt;&lt;br&gt;
 &lt;&lt;/if&gt;&gt;    You decide to:
     &lt;ul&gt;
-        &lt;&lt;if $religion is &quot;member of the Church of England&quot;&gt;&gt;&lt;li&gt;&lt;&lt;link &quot;accept the job&quot; &quot;Stay&quot;&gt;&gt;&lt;&lt;set $fled to 4&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Accepted a plague work job&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;if $gender is &quot;female&quot; and $agenum gte 16 and $reputation gte 5&gt;&gt;&lt;&lt;set $role to &quot;searcher&quot;&gt;&gt;&lt;&lt;elseif $agenum lte 15&gt;&gt;&lt;&lt;set $role to &quot;nurse&quot;&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $role to &quot;corpsebearer&quot;&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
+        &lt;&lt;if $religion is &quot;member of the Church of England&quot;&gt;&gt;&lt;li&gt;&lt;&lt;link &quot;accept the job&quot; &quot;Stay&quot;&gt;&gt;&lt;&lt;set $fled to 4&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Accepted a plague work job&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;if $gender is &quot;female&quot; and $agenum gte 16 and $reputation gte 5&gt;&gt;&lt;&lt;set $role to &quot;searcher&quot;&gt;&gt;&lt;&lt;elseif $agenum lte 15&gt;&gt;&lt;&lt;set $role to &quot;nurse&quot;&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $role to _offeredRole&gt;&gt;&lt;&lt;if _offeredRole is &quot;warder&quot;&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
         &lt;li&gt;[[not accept the job-&gt;Stay][_repBefore to $reputation; $reputation to Math.clamp($reputation - 1, 0, 10); $fled to 4; $role to &quot;unemployed&quot;; $decisions.push({text: &quot;Refused the plague work job&quot;, money: 0, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: null})]]&lt;/li&gt;
         &lt;&lt;else&gt;&gt;&lt;li&gt;[[Remain in the city-&gt;Stay][$fled to 4; $decisions.push({text: &quot;Remained in the city&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})]]&lt;/li&gt;
         &lt;&lt;/if&gt;&gt;
@@ -4059,6 +4066,8 @@ Luckily, there are no &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; cases in your
     //Nathaniel Parr, published by Thomas Astley, Plague in 1665, 1747.//
      
      &lt;&lt;elseif $role is &quot;nurse&quot;&gt;&gt;The &lt;&lt;defOverseersOfThePoor &quot;Overseers of the Poor&quot;&gt;&gt; assign you to your first &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; patient to nurse.
+
+     &lt;&lt;elseif $role is &quot;warder&quot;&gt;&gt;As a warder, you stand guard outside the locked up houses of your &lt;&lt;defParish &quot;parish&quot;&gt;&gt;, making sure no one escapes their quarantine. You pray to God that the sickness does not reach you.
      &lt;&lt;/if&gt;&gt;
 
 &lt;&lt;elseif $socio is &quot;servants&quot;&gt;&gt; /* NTS: work text here */
@@ -4075,6 +4084,8 @@ Luckily, there are no &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; cases in your
     //Nathaniel Parr, published by Thomas Astley, Plague in 1665, 1747.//
    
    &lt;&lt;elseif $role is &quot;nurse&quot;&gt;&gt;&lt;&lt;defParish &quot;Parish&quot;&gt;&gt; officials tell you there is a patient for you to nurse.
+
+	&lt;&lt;elseif $role is &quot;warder&quot;&gt;&gt;You stand guard outside the locked up houses of your &lt;&lt;defParish &quot;parish&quot;&gt;&gt;, making sure no one escapes their quarantine. You pray to God that the sickness does not reach you.
 	&lt;&lt;/if&gt;&gt;
     
 &lt;&lt;elseif $socio is &quot;artisans&quot;&gt;&gt; /* NTS: work text here */
@@ -4842,7 +4853,7 @@ While you&lt;&lt;if $agenum lte 15&gt;&gt; and your family&lt;&lt;/if&gt;&gt; co
 
     /* Day Labourers */
     &lt;&lt;if $socio is &quot;day labourers&quot;&gt;&gt;
-    &lt;&lt;if $role is &quot;searcher&quot; or $role is &quot;nurse&quot; or $role is &quot;corpsebearer&quot;&gt;&gt;You accept the job from the &lt;&lt;defParish &quot;parish&quot;&gt;&gt; officials, which at least provides you with a little income while other work has dwindled.&lt;&lt;else&gt;&gt;You decide not to accept the job from &lt;&lt;defParish &quot;parish&quot;&gt;&gt; officials. Unfortunately, without any steady work, it may soon be difficult to survive as other work around the city dwindles.&lt;&lt;/if&gt;&gt;
+    &lt;&lt;if $role is &quot;searcher&quot; or $role is &quot;nurse&quot; or $role is &quot;corpsebearer&quot; or $role is &quot;warder&quot;&gt;&gt;You accept the job from the &lt;&lt;defParish &quot;parish&quot;&gt;&gt; officials, which at least provides you with a little income while other work has dwindled.&lt;&lt;else&gt;&gt;You decide not to accept the job from &lt;&lt;defParish &quot;parish&quot;&gt;&gt; officials. Unfortunately, without any steady work, it may soon be difficult to survive as other work around the city dwindles.&lt;&lt;/if&gt;&gt;
     &lt;&lt;/if&gt;&gt;
 
     /* Servants Stay*/
@@ -5539,7 +5550,7 @@ Unfortunately, you have suffered a miscarriage and are no longer pregnant.
 &lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="114" name="Claude-widgets" tags="widget" position="500,1225" size="100,100">/* all widgets generated via Claude  or other AI should be temporarily placed here then manually moved to new locations as needed */
 
 &lt;&lt;widget &quot;corpse-work&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
-&lt;&lt;if ($role is &quot;corpsebearer&quot; or $role is &quot;searcher&quot; or $role is &quot;nurse&quot;) and $corpseBuried and $corpseBuried[$parish]&gt;&gt;
+&lt;&lt;if ($role is &quot;corpsebearer&quot; or $role is &quot;searcher&quot; or $role is &quot;nurse&quot; or $role is &quot;warder&quot;) and $corpseBuried and $corpseBuried[$parish]&gt;&gt;
 &lt;&lt;set _cwBuried to $corpseBuried[$parish][$monthIndex]&gt;&gt;
 &lt;&lt;set _cwPlague to $corpsePlague[$parish][$monthIndex]&gt;&gt;
 &lt;&lt;if _cwBuried gt 0&gt;&gt;
@@ -5573,6 +5584,19 @@ You tended to the sick in your parish this month and were paid &lt;&lt;print _cw
 &lt;&lt;set $plagueInfection to 1&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Nursed plague patients&quot;, money: _cwPay, repDelta: 0, repBefore: $reputation, infectPct: _cwPlague})&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;elseif $role is &quot;warder&quot;&gt;&gt;
+&lt;&lt;set _cwWarderPay to 48&gt;&gt;
+&lt;&lt;set $money to Math.clamp($money - _cwPay + _cwWarderPay, 0, Infinity)&gt;&gt;
+You stood guard outside quarantined houses this month and were paid &lt;&lt;print _cwWarderPay&gt;&gt;d. by the churchwardens for your service to the parish.
+&lt;&lt;if _cwPlague gt 0&gt;&gt; &lt;&lt;print _cwPlague&gt;&gt; of the shut-up houses had plague, may the Lord have mercy on their souls and protect you from sickness.&lt;&lt;/if&gt;&gt;
+&lt;&lt;if $playerPlagueStatus is &quot;healthy&quot; and _cwPlague gt 0&gt;&gt;
+&lt;&lt;set _cwWarderRisk to Math.min(_cwPlague * 2, 100)&gt;&gt;
+&lt;&lt;set _cwRoll to random(1, 100)&gt;&gt;
+&lt;&lt;if _cwRoll lte _cwWarderRisk&gt;&gt;
+&lt;&lt;set $plagueInfection to 1&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Guarded quarantined houses&quot;, money: _cwWarderPay, repDelta: 0, repBefore: $reputation, infectPct: _cwWarderRisk})&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;br&gt;&lt;br&gt;
@@ -5649,7 +5673,7 @@ The &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; grows worse and the streets are
 /* If location is western suburbs */
     &lt;&lt;if $location is &quot;in another part of the western suburbs&quot;&gt;&gt;
         &lt;&lt;if $socio is &quot;beggars&quot;&gt;&gt;
-            &lt;&lt;if $role is &quot;corpsebearer&quot; or $role is &quot;searcher&quot; or $role is &quot;nurse&quot;&gt;&gt;
+            &lt;&lt;if $role is &quot;corpsebearer&quot; or $role is &quot;searcher&quot; or $role is &quot;nurse&quot; or $role is &quot;warder&quot;&gt;&gt;
                 &lt;&lt;plague-work&gt;&gt;
                 &lt;br&gt;&lt;br&gt;Do you:
                 &lt;ul&gt;&lt;li&gt;
@@ -5663,7 +5687,7 @@ The &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; grows worse and the streets are
 			&lt;&lt;else&gt;&gt;No one has any charity right now for a healthy &lt;&lt;defBeggars &quot;beggar&quot;&gt;&gt;, but somehow you manage to scrape together enough food to last you to [[July 1665]].
             &lt;&lt;/if&gt;&gt;
         &lt;&lt;elseif $socio is &quot;day labourers&quot;&gt;&gt;
-            &lt;&lt;if $role is &quot;corpsebearer&quot; or $role is &quot;searcher&quot; or $role is &quot;nurse&quot;&gt;&gt;
+            &lt;&lt;if $role is &quot;corpsebearer&quot; or $role is &quot;searcher&quot; or $role is &quot;nurse&quot; or $role is &quot;warder&quot;&gt;&gt;
                 &lt;&lt;plague-work&gt;&gt;
                 &lt;br&gt;&lt;br&gt;Do you:
                 &lt;ul&gt;&lt;li&gt;

--- a/variables.md
+++ b/variables.md
@@ -92,9 +92,10 @@ This document lists all global (story) variables used in **Gaming the Great Plag
 
 ### `$role`
 - **Type:** String
-- **Possible values:** `"0"` (none/default), `"searcher"`, `"nurse"`, `"corpsebearer"`, `"unemployed"`
-- **Set by:** Initially `"0"`. Changes to a plague worker role when the player takes a plague job, or `"unemployed"` when a servant breaks their contract.
+- **Possible values:** `"0"` (none/default), `"searcher"`, `"nurse"`, `"corpsebearer"`, `"warder"`, `"unemployed"`
+- **Set by:** Initially `"0"`. Changes to a plague worker role when the player takes a plague job, or `"unemployed"` when a servant breaks their contract. Male/nonbinary Church of England members have a 50/50 chance of being assigned `"corpsebearer"` or `"warder"`.
 - **Dependency:** `$socio` determines which roles are available. `$role` affects income and narrative options.
+- **Notes on warder role:** Warders stand guard outside quarantined houses to prevent escape. They earn a flat 48d. per month (not per-corpse), their monthly plague risk is doubled compared to other plague workers, and they take a −1 reputation hit upon accepting the job.
 
 ### `$hoh`
 - **Type:** Integer (boolean-like)


### PR DESCRIPTION
…2.28

Male/nonbinary Church of England members now have a 50/50 chance of being assigned as a corpsebearer or a warder. Warders stand guard outside quarantined houses to prevent anyone from escaping. Mechanics:
- Reputation takes a -1 hit upon accepting the warder role
- Monthly plague risk is doubled compared to other plague workers
- Fixed pay of 48d. per month (not per-corpse)

Updated passages: 7, 18, 19, 37, 54, 64, 68, 89, 114, 115.

https://claude.ai/code/session_01GpHabmyRUzkwn8E5vu7frL