### PR TITLE
Resolve "somewhere else" origin to specific locations in bio passage …

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.28" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.29" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -1137,11 +1137,13 @@ $(document).on(':passagestart', function (ev) {
 /* initialize savings*/&lt;&lt;income&gt;&gt;&lt;&lt;expenses&gt;&gt;&lt;&lt;if $socio is &quot;servants&quot;&gt;&gt;&lt;&lt;disposable&gt;&gt;&lt;&lt;elseif $socio is &quot;artisans&quot;&gt;&gt;&lt;&lt;disposable&gt;&gt;&lt;&lt;disposable&gt;&gt;&lt;&lt;elseif $socio is &quot;merchants&quot;&gt;&gt;&lt;&lt;disposable&gt;&gt;&lt;&lt;disposable&gt;&gt;&lt;&lt;disposable&gt;&gt;&lt;&lt;set $role to either($trades)&gt;&gt;&lt;&lt;elseif $socio is &quot;nobles&quot;&gt;&gt;&lt;&lt;disposable&gt;&gt;&lt;&lt;disposable&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;if $religion is &quot;member of a dissident Protestant church&quot;&gt;&gt;
 &lt;&lt;set $religion to either(&quot;Presbyterian&quot;, &quot;Baptist&quot;, &quot;Quaker&quot;)&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if $origin is &quot;somewhere else&quot;&gt;&gt;
+&lt;&lt;set $origin to either(&quot;the Holy Roman Empire&quot;, &quot;Italy&quot;, &quot;Spain&quot;, &quot;the Americas&quot;)&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;/silently&gt;&gt;
 
 &lt;&lt;if $gender is &quot;nonbinary&quot;&gt;&gt;&lt;&lt;set _x to random(1,4)&gt;&gt;&lt;&lt;if _x is 1&gt;&gt;Your friends and family call you &lt;&lt;set _name = [&quot;Charles&quot;, &quot;Charlotte&quot;]&gt;&gt;&lt;&lt;listbox &quot;$name&quot;&gt;&gt;&lt;&lt;optionsfrom _name&gt;&gt;&lt;&lt;/listbox&gt;&gt;&lt;&lt;elseif _x is 2&gt;&gt;Your friends and family call you &lt;&lt;set _name = [&quot;Phillip&quot;, &quot;Phillippa&quot;]&gt;&gt;&lt;&lt;listbox &quot;$name&quot;&gt;&gt;&lt;&lt;optionsfrom _name&gt;&gt;&lt;&lt;/listbox&gt;&gt;&lt;&lt;elseif _x is 3&gt;&gt;Your friends and family call you &lt;&lt;set _name = [&quot;John&quot;, &quot;Joan&quot;]&gt;&gt;&lt;&lt;listbox &quot;$name&quot;&gt;&gt;&lt;&lt;optionsfrom _name&gt;&gt;&lt;&lt;/listbox&gt;&gt;&lt;&lt;else&gt;&gt;Your friends and family call you &lt;&lt;set _name = [&quot;Thomas&quot;, &quot;Thomasina&quot;]&gt;&gt;&lt;&lt;listbox &quot;$name&quot;&gt;&gt;&lt;&lt;optionsfrom _name&gt;&gt;&lt;&lt;/listbox&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;else&gt;&gt;Your name is $name&lt;&lt;/if&gt;&gt;, and you are $agenum years old. You are proud to be a &lt;&lt;defVarReligion $religion&gt;&gt;, &lt;&lt;if $religion is &quot;member of the Church of England&quot;&gt;&gt;the only true and legal faith&lt;&lt;else&gt;&gt;despite the fact that it is illegal in England.&lt;&lt;/if&gt;&gt;
 &lt;br&gt;&lt;br&gt;
-You were born and raised in &lt;&lt;if $origin is &quot;London&quot;&gt;&gt;London&lt;&lt;elseif $origin is &quot;somewhere else&quot;&gt;&gt;a faraway land, though you now make your home in London&lt;&lt;else&gt;&gt;$origin, though you now make your home in London&lt;&lt;/if&gt;&gt;. You currently live in the &lt;&lt;defParish &quot;parish&quot;&gt;&gt; of $parish, which is $location. It is a good place for &lt;&lt;defVarSocio $socio&gt;&gt; like you.&lt;br&gt;&lt;br&gt; /*NTS update with roles for merchants and artisans*/
+You were born and raised in &lt;&lt;if $origin is &quot;London&quot;&gt;&gt;London&lt;&lt;else&gt;&gt;$origin, though you now make your home in London&lt;&lt;/if&gt;&gt;. You currently live in the &lt;&lt;defParish &quot;parish&quot;&gt;&gt; of $parish, which is $location. It is a good place for &lt;&lt;defVarSocio $socio&gt;&gt; like you.&lt;br&gt;&lt;br&gt; /*NTS update with roles for merchants and artisans*/
 
 &lt;&lt;silently&gt;&gt;
 /* add family for young children */
@@ -2219,7 +2221,7 @@ You&#39;ve been taken by a press gang&lt;&lt;if $impressed gte 2&gt;&gt; again&l
 &lt;&lt;else&gt;&gt;
 	You have been &lt;&lt;defImpressed &quot;impressed&quot;&gt;&gt; into His Majesty&#39;s Navy!
     &lt;br&gt;&lt;br&gt;
-&lt;&lt;if $origin is &quot;France&quot; or $origin is &quot;somewhere else&quot; or $origin is &quot;the Dutch Republic&quot;&gt;&gt;Luckily for you, you are not a subject of the British monarch and should not have been impressed. You bribe a literate crewmate to write a letter to the Naval Board on your behalf, protesting your impressment.&lt;br&gt;&lt;br&gt;
+&lt;&lt;if $origin is &quot;France&quot; or $origin is &quot;the Holy Roman Empire&quot; or $origin is &quot;Italy&quot; or $origin is &quot;Spain&quot; or $origin is &quot;the Americas&quot; or $origin is &quot;the Dutch Republic&quot;&gt;&gt;Luckily for you, you are not a subject of the British monarch and should not have been impressed. You bribe a literate crewmate to write a letter to the Naval Board on your behalf, protesting your impressment.&lt;br&gt;&lt;br&gt;
         Your captain, on hearing about the letter, sends you back to London&lt;&lt;if $origin is &quot;the Dutch Republic&quot;&gt;&gt;. While you successfully argue your case in front of the Naval Board, they are not pleased to hear they had a Dutchman on their ships. They imprison you as a spy and only release you at the end of the war in 1667.
         &lt;br&gt;&lt;br&gt;
         [[How typical was your experience of the Great Plague of London? Let&#39;s find out!-&gt;stats]]&lt;&lt;else&gt;&gt; where you successfully argue your case and are &lt;&lt;storyline-return &quot;set at liberty&quot;&gt;&gt;.&lt;br&gt;&lt;br&gt;
@@ -3307,7 +3309,7 @@ Do you:
 &lt;&lt;/if&gt;&gt;</tw-passagedata><tw-passagedata pid="47" name="go quietly" tags="" position="1925,775" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;if $origin is &quot;London&quot;&gt;&gt;There&#39;s no &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; in the New World, so you decide to take a chance and move to the colonies. It&#39;s a rough journey and difficult to start over again somewhere so different. You will always miss London.
 &lt;&lt;else&gt;&gt;
-You return to &lt;&lt;if $origin isnot &quot;somewhere else&quot;&gt;&gt;$origin&lt;&lt;else&gt;&gt;your homeland&lt;&lt;/if&gt;&gt; and never see London again.&lt;&lt;/if&gt;&gt;
+You return to $origin and never see London again.&lt;&lt;/if&gt;&gt;
 &lt;br&gt;&lt;br&gt;
 But at least you didn&#39;t die of plague!
 &lt;br&gt;&lt;br&gt;
@@ -3473,7 +3475,7 @@ One of your neighbors &lt;&lt;if $reputation gte 6&gt;&gt;provides you with left
 &lt;br&gt;&lt;br&gt;You decide to:
 &lt;ul&gt;
 &lt;li&gt;[[Remain in the city-&gt;Stay][$fled to 4; $decisions.push({text: &quot;Remained in the city&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})]]&lt;/li&gt;
-&lt;&lt;if $origin isnot &quot;London&quot; and $origin isnot &quot;somewhere else&quot;&gt;&gt;&lt;li&gt;[[Flee the city and return to $origin-&gt;Fled][$fled to 6; $decisions.push({text: &quot;Fled back to place of origin&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})]]&lt;/li&gt;&lt;&lt;elseif $origin is &quot;somewhere else&quot;&gt;&gt;&lt;li&gt;[[Flee the city and return to your homeland-&gt;Fled][$fled to 6; $decisions.push({text: &quot;Fled back to homeland&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})]]&lt;/li&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if $origin isnot &quot;London&quot;&gt;&gt;&lt;li&gt;[[Flee the city and return to $origin-&gt;Fled][$fled to 6; $decisions.push({text: &quot;Fled back to place of origin&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})]]&lt;/li&gt;&lt;&lt;/if&gt;&gt;
 &lt;/ul&gt;
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="55" name="freeze" tags="" position="1825,1100" size="100,100">&lt;&lt;nobr&gt;&gt;You quietly freeze to death, but at least it was a painless way to go.&lt;br&gt;&lt;br&gt;
@@ -3772,7 +3774,7 @@ You have abandoned your parish and been removed from your position as $office.
 &lt;&lt;elseif $socio is &quot;servants&quot;&gt;&gt;
 Your $masterTitle flees London with you and the rest of &lt;&lt;if $masterGender is &quot;female&quot;&gt;&gt;her&lt;&lt;else&gt;&gt;his&lt;&lt;/if&gt;&gt; &lt;&lt;defHousehold &quot;household&quot;&gt;&gt;. You have only a little time to prepare and say goodbye to your friends before you leave.&lt;br&gt;
     &lt;&lt;elseif $socio is &quot;beggars&quot; and $fled is 2&gt;&gt;You&lt;&lt;if $agenum lte 15&gt;&gt; convince your family &lt;&lt;else&gt;&gt; decide &lt;&lt;/if&gt;&gt;to flee the city to save yourself. Unfortunately, with no money and no reputation to speak of anymore, you only have the option of illegally begging along the road to survive./*note this conditional includes servants who flee their masters*/
-    &lt;&lt;else&gt;&gt;You decide to flee the city&lt;&lt;if $origin isnot &quot;London&quot; and $origin isnot &quot;somewhere else&quot;&gt;&gt; and return to $origin&lt;&lt;elseif $origin is &quot;somewhere else&quot;&gt;&gt;and return to your homeland&lt;&lt;/if&gt;&gt;.&lt;br&gt;&lt;br&gt;&lt;&lt;/if&gt;&gt;
+    &lt;&lt;else&gt;&gt;You decide to flee the city&lt;&lt;if $origin isnot &quot;London&quot;&gt;&gt; and return to $origin&lt;&lt;/if&gt;&gt;.&lt;br&gt;&lt;br&gt;&lt;&lt;/if&gt;&gt;
 
 Despite being safely out of harm&#39;s way, you closely follow the news of London&#39;s &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; outbreak. As the death toll rises, you worry about the people you know back in the city but are relieved that you are out of harm&#39;s way.&lt;br&gt;&lt;br&gt;
 


### PR DESCRIPTION
…— bump to v2.29

When a player chooses $origin as "somewhere else", the bio passage now randomizes it to one of: "the Holy Roman Empire", "Italy", "Spain", or "the Americas" — paralleling how $religion resolves "member of a dissident Protestant church" to a specific denomination.

Updated the impressed passage foreign-origin check to include the four new values, and removed now-unreachable "somewhere else" display branches in bio, go quietly, beggar-roles, and Fled passages.

https://claude.ai/code/session_011SQATNY4eHBVeifZZk2Y7F