### PR TITLE
Add plague risk parameter to storyline-return widget — bump to v2.31

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.30" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.31" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -3221,6 +3221,9 @@ As morning dawns, a terrible realization settles over your &lt;&lt;defHousehold 
 	/* Argument 3: Reputation to add/subtract (Defaults to 0) */
     &lt;&lt;set _reputationOffset to _args[3] || 0&gt;&gt;
     
+	/* Argument 4: Increased plague risk as a percentage (Defaults to 0, e.g. 5 = 5% increased risk) */
+    &lt;&lt;set _plagueRisk to _args[4] || 0&gt;&gt;
+    
     /* Calculate the next passage index */
     &lt;&lt;set _nextIndex to $monthIndex + _timeOffset&gt;&gt;
     
@@ -3236,6 +3239,11 @@ As morning dawns, a terrible realization settles over your &lt;&lt;defHousehold 
 		&lt;&lt;if $reputation gte 10&gt;&gt;
         	&lt;&lt;set $reputation to 10&gt;&gt;
         &lt;&lt;/if&gt;&gt; /* using math clamp elsewhere, revisit this bit of code and check minimums as well */
+	&lt;&lt;if _plagueRisk gt 0&gt;&gt;
+		&lt;&lt;if random(1, 100) lte _plagueRisk&gt;&gt;
+			&lt;&lt;set $plagueInfection to 1&gt;&gt;
+		&lt;&lt;/if&gt;&gt;
+	&lt;&lt;/if&gt;&gt;
     &lt;&lt;/link&gt;&gt;
     &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="42" name="Hide" tags="infection-rates" position="500,500" size="100,100">&lt;&lt;nobr&gt;&gt;&lt;&lt;silently&gt;&gt;&lt;&lt;set $plagueInfection to 2&gt;&gt;&lt;&lt;/silently&gt;&gt;
@@ -3440,8 +3448,8 @@ Do you:
 &lt;ul&gt;
 &lt;li&gt;&lt;&lt;if random(1,3) == 1&gt;&gt;[[beg on the highways, even though you know it&#39;s illegal|impressed][$impressed += 1]]&lt;&lt;else&gt;&gt;[[beg on the highways, even though you know it&#39;s illegal-&gt;begging-success][$reputation to Math.clamp($reputation - 1, 0, 10)]]&lt;&lt;/if&gt;&gt;&lt;/li&gt;
 &lt;&lt;if $gender is &quot;female&quot;&gt;&gt;&lt;li&gt;[[put your trust in the charity of your neighbors-&gt;good-neighbors][$reputation to Math.clamp($reputation + 1, 0, 10)]]&lt;/li&gt;
-&lt;li&gt;&lt;&lt;storyline-return &quot;take in extra laundry from your neighbors&quot; 1 48&gt;&gt;&lt;/li&gt;&lt;&lt;/if&gt;&gt;
-&lt;&lt;if $religion is &quot;member of the Church of England&quot;&gt;&gt;&lt;li&gt;&lt;&lt;storyline-return &quot;offer to wash the church linens and sweep clean your church&quot; 1 32&gt;&gt;&lt;/li&gt;&lt;&lt;/if&gt;&gt;
+&lt;li&gt;&lt;&lt;storyline-return &quot;take in extra laundry from your neighbors&quot; 1 48 0 10&gt;&gt;&lt;/li&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if $religion is &quot;member of the Church of England&quot;&gt;&gt;&lt;li&gt;&lt;&lt;storyline-return &quot;offer to wash the church linens and sweep clean your church&quot; 1 32 0 5&gt;&gt;&lt;/li&gt;&lt;&lt;/if&gt;&gt;
 &lt;li&gt;&lt;&lt;storyline-return &quot;hope that you can survive on the resources you have&quot;&gt;&gt;&lt;/li&gt;
 &lt;/ul&gt;
 &lt;&lt;/nobr&gt;&gt;


### PR DESCRIPTION
The storyline-return widget now accepts a 5th argument (index 4) for increased plague risk as a percentage (e.g. 5 = 5% chance). When the player clicks the link, if a risk value was provided, the game rolls random(1,100) and sets $plagueInfection to 1 if the roll is within the risk threshold.

Updated beggar-choice widget calls:
- "take in extra laundry from your neighbors": 10% plague risk
- "offer to wash the church linens and sweep clean your church": 5% plague risk

https://claude.ai/code/session_01NaScLj4oFA87DxjKKSXovP