### PR TITLE
Split searcher/corpsebearer income among crew — bump to v2.34

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.33" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.34" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -4067,13 +4067,14 @@ Luckily, there are no &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; cases in your
   &lt;/div&gt;
 &lt;/div&gt;</tw-passagedata><tw-passagedata pid="68" name="plague-work" tags="widget" position="1325,25" size="100,100">&lt;&lt;widget &quot;plague-work&quot;&gt;&gt;
 &lt;&lt;nobr&gt;&gt;
+&lt;&lt;if $location is &quot;inside the City walls&quot;&gt;&gt;&lt;&lt;set _cwCrew to 2&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set _cwCrew to random(4, 6)&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;if $socio is &quot;beggars&quot;&gt;&gt;
-	&lt;&lt;if $role is &quot;corpsebearer&quot;&gt;&gt;As a corpsebearer, every night, you must go round to the locked up houses of your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; and call for them to bring out their dead, while praying to God that you remain safe.
+	&lt;&lt;if $role is &quot;corpsebearer&quot;&gt;&gt;As a corpsebearer, every night, you and your fellow corpsebearer&lt;&lt;if _cwCrew gt 2&gt;&gt;s&lt;&lt;/if&gt;&gt; must go round to the locked up houses of your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; and call for them to bring out their dead, while praying to God that you remain safe.
 &lt;br&gt;
 &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/7/7a/Wilson_%22The_plague...%22%3B_a_corpses_bearer_Wellcome_L0016624.jpg&quot; width=&quot;100%&quot;&gt;
 //Printed by R. Price, A corpse bearer; reproduction of an engraving from a series of London Cries, 1655. Wellcome Images//
 
-     &lt;&lt;elseif $role is &quot;searcher&quot;&gt;&gt;As a searcher, every time you are called to someone&#39;s house to determine a cause of death, you pray to God to protect you. You are starting to have nightmares about seeing &lt;&lt;defBuboes &quot;buboes&quot;&gt;&gt; and the tokens of &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; on your neighbors.
+     &lt;&lt;elseif $role is &quot;searcher&quot;&gt;&gt;As a searcher, every time you and your fellow searcher&lt;&lt;if _cwCrew gt 2&gt;&gt;s&lt;&lt;/if&gt;&gt; are called to someone&#39;s house to determine a cause of death, you pray to God to protect you. You are starting to have nightmares about seeing &lt;&lt;defBuboes &quot;buboes&quot;&gt;&gt; and the tokens of &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; on your neighbors.
     &lt;br&gt;
     &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/6/67/Plague_in_1665_%28BM_1875%2C0508.1513%29.jpg&quot; width=&quot;100%&quot;&gt;
     //Nathaniel Parr, published by Thomas Astley, Plague in 1665, 1747.//
@@ -4086,12 +4087,12 @@ Luckily, there are no &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; cases in your
 &lt;&lt;elseif $socio is &quot;servants&quot;&gt;&gt; /* NTS: work text here */
 
 &lt;&lt;elseif $socio is &quot;day labourers&quot;&gt;&gt;
-	&lt;&lt;if $role is &quot;corpsebearer&quot;&gt;&gt;Every night, you go round to the locked up houses of your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; and call for them to bring out their dead, while praying to God that you remain safe.
+	&lt;&lt;if $role is &quot;corpsebearer&quot;&gt;&gt;Every night, you and your fellow corpsebearer&lt;&lt;if _cwCrew gt 2&gt;&gt;s&lt;&lt;/if&gt;&gt; go round to the locked up houses of your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; and call for them to bring out their dead, while praying to God that you remain safe.
         &lt;br&gt;
 &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/7/7a/Wilson_%22The_plague...%22%3B_a_corpses_bearer_Wellcome_L0016624.jpg&quot; width=&quot;100%&quot;&gt;
 //Printed by R. Price, A corpse bearer; reproduction of an engraving from a series of London Cries, 1655. Wellcome Images//
     
-    &lt;&lt;elseif $role is &quot;searcher&quot;&gt;&gt;Every time you are called to someone&#39;s house to determine a cause of death, you pray to God to protect you. You are starting to have nightmares about seeing &lt;&lt;defBuboes &quot;buboes&quot;&gt;&gt; and the tokens of &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; on your neighbors.
+    &lt;&lt;elseif $role is &quot;searcher&quot;&gt;&gt;Every time you and your fellow searcher&lt;&lt;if _cwCrew gt 2&gt;&gt;s&lt;&lt;/if&gt;&gt; are called to someone&#39;s house to determine a cause of death, you pray to God to protect you. You are starting to have nightmares about seeing &lt;&lt;defBuboes &quot;buboes&quot;&gt;&gt; and the tokens of &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; on your neighbors.
     &lt;br&gt;
     &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/6/67/Plague_in_1665_%28BM_1875%2C0508.1513%29.jpg&quot; width=&quot;100%&quot;&gt;
     //Nathaniel Parr, published by Thomas Astley, Plague in 1665, 1747.//
@@ -5572,9 +5573,11 @@ Unfortunately, you have suffered a miscarriage and are no longer pregnant.
 &lt;&lt;set _cwPlague to $corpsePlague[$parish][$monthIndex]&gt;&gt;
 &lt;&lt;if _cwBuried gt 0&gt;&gt;
 &lt;&lt;set _cwPay to _cwBuried * 4&gt;&gt;
+&lt;&lt;if $role is &quot;corpsebearer&quot; or $role is &quot;searcher&quot;&gt;&gt;&lt;&lt;if $location is &quot;inside the City walls&quot;&gt;&gt;&lt;&lt;set _cwCrew to 2&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set _cwCrew to random(4, 6)&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;set _cwPay to Math.trunc(_cwPay / _cwCrew)&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;set $money to Math.clamp($money + _cwPay, 0, Infinity)&gt;&gt;
 &lt;&lt;if $role is &quot;corpsebearer&quot;&gt;&gt;
-You transported &lt;&lt;print _cwBuried&gt;&gt; corpses this month and were paid &lt;&lt;print _cwPay&gt;&gt;d. by the churchwardens for your service to the parish.
+You and your fellow corpsebearer&lt;&lt;if _cwCrew gt 2&gt;&gt;s&lt;&lt;/if&gt;&gt; transported &lt;&lt;print _cwBuried&gt;&gt; corpses this month and you were paid &lt;&lt;print _cwPay&gt;&gt;d. by the churchwardens for your service to the parish.
 &lt;&lt;if _cwPlague gt 0&gt;&gt; &lt;&lt;print _cwPlague&gt;&gt; of the dead had plague, may the Lord have mercy on their souls and protect you from sickness.&lt;&lt;/if&gt;&gt;
 &lt;&lt;if $playerPlagueStatus is &quot;healthy&quot; and _cwPlague gt 0&gt;&gt;
 &lt;&lt;set _cwRoll to random(1, 100)&gt;&gt;
@@ -5584,7 +5587,7 @@ You transported &lt;&lt;print _cwBuried&gt;&gt; corpses this month and were paid
 &lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Transported plague corpses&quot;, money: _cwPay, repDelta: 0, repBefore: $reputation, infectPct: _cwPlague})&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;elseif $role is &quot;searcher&quot;&gt;&gt;
-You examined &lt;&lt;print _cwBuried&gt;&gt; corpses this month and were paid &lt;&lt;print _cwPay&gt;&gt;d. by the churchwardens for your service to the parish.
+You and your fellow searcher&lt;&lt;if _cwCrew gt 2&gt;&gt;s&lt;&lt;/if&gt;&gt; examined &lt;&lt;print _cwBuried&gt;&gt; corpses this month and you were paid &lt;&lt;print _cwPay&gt;&gt;d. by the churchwardens for your service to the parish.
  You determined &lt;&lt;print _cwPlague&gt;&gt; of the dead had plague, may the Lord have mercy on their souls and protect you from sickness.
 &lt;&lt;if $playerPlagueStatus is &quot;healthy&quot; and _cwPlague gt 0&gt;&gt;
 &lt;&lt;set _cwRoll to random(1, 100)&gt;&gt;


### PR DESCRIPTION
Searchers and corpsebearers now share income with fellow workers:
- Inside city walls: divide pay by 2 (crew of 2)
- Outside city walls: divide pay by random 4-6 (larger crew)

Updated flavor text in both corpse-work and plague-work widgets to reference "you and your fellow searcher(s)/corpsebearer(s)".

https://claude.ai/code/session_01RkYdXHse7DcdBuLKfwdAZM