### PR TITLE
Cancel recurring costs when player enters debt — bump to v2.35

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.34" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.35" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -1641,6 +1641,8 @@ When you go to church on Easter Sunday, you are reminded of how lucky you are as
 &lt;&lt;set $hoh to 0&gt;&gt;
 &lt;&lt;set $role to &quot;0&quot;&gt;&gt;
 &lt;&lt;set $billSubscribed to 0&gt;&gt;
+&lt;&lt;set $debtWarned to 0&gt;&gt;
+&lt;&lt;set $debtForcedAttend to 0&gt;&gt;
 &lt;&lt;set $disability to 0&gt;&gt;
 &lt;&lt;set $reputation to 6&gt;&gt;
 &lt;&lt;set $plagueInfection to 0&gt;&gt;
@@ -1705,6 +1707,7 @@ John: 1500, Thomas: 1300, William: 1300, Richard: 620, Robert: 600, Henry: 500, 
 &lt;&lt;/silently&gt;&gt;
 &lt;&lt;if tags().includes(&quot;storyline&quot;)&gt;&gt;&lt;h2&gt;&lt;&lt;print passage()&gt;&gt;, $location&lt;/h2&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;if tags().includes(&quot;quarantine&quot;)&gt;&gt;&lt;h2&gt;&lt;&lt;print passage()&gt;&gt;&lt;/h2&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if tags().includes(&quot;storyline&quot;) and visited() lte 1&gt;&gt;&lt;&lt;debt-check&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;silently&gt;&gt;
 &lt;&lt;if $location is &quot;inside the City walls&quot; and hasVisited(&quot;June 1665&quot;)&gt;&gt;&lt;&lt;set $apothecary to 1&gt;&gt; /*this is OBE since currently apothecary set to always show*/
 	&lt;&lt;elseif $location isnot &quot;in another part of the western suburbs&quot;&gt;&gt;
@@ -5704,6 +5707,23 @@ You don&#39;t want the hassle of holding office in your parish and pay a fine to
 &lt;span id=&quot;billOffer&quot;&gt;You hear that you can subscribe to the weekly Bills of Mortality, printed broadsides that record every death in every parish in London and whether the cause of death was plague. A subscription costs 4d. per month. Do you wish to subscribe?&lt;br&gt;&lt;br&gt;
 &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#billOffer&quot;&gt;&gt;&lt;&lt;set $billSubscribed to 1&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;May 1665: Subscribed to the Bills of Mortality&quot;, money: -4, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;You subscribe to the Bills of Mortality. Each month, you will receive a report on the deaths in your parish.&lt;br&gt;&lt;br&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#billOffer&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;May 1665: Declined Bills of Mortality subscription&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;You decide not to subscribe to the Bills of Mortality.&lt;br&gt;&lt;br&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 &lt;&lt;/if&gt;&gt;
+&lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;
+
+&lt;&lt;widget &quot;debt-check&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
+&lt;&lt;if $money lt 0 and $debtWarned is 0&gt;&gt;
+&lt;&lt;set $debtWarned to 1&gt;&gt;
+&lt;&lt;set _debtCancelled to []&gt;&gt;
+&lt;&lt;if $billSubscribed is 1&gt;&gt;
+&lt;&lt;set $billSubscribed to 0&gt;&gt;
+&lt;&lt;set _debtCancelled.push(&quot;your subscription to the Bills of Mortality&quot;)&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;if $skipServices is 1&gt;&gt;
+&lt;&lt;set $skipServices to 0&gt;&gt;
+&lt;&lt;set $debtForcedAttend to 1&gt;&gt;
+&lt;&lt;set _debtCancelled.push(&quot;your commitment to always skip Church of England services&quot;)&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+You are in debt and can no longer afford your recurring expenses.&lt;&lt;if _debtCancelled.length gt 0&gt;&gt; The following have been cancelled: &lt;&lt;print _debtCancelled.join(&quot; and &quot;)&gt;&gt;.&lt;&lt;/if&gt;&gt;&lt;br&gt;&lt;br&gt;
+&lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="115" name="june-1665-helper-widget" tags="widget" position="1475,325" size="100,100">&lt;&lt;widget &quot;june-1665-helper&quot;&gt;&gt;
 &lt;&lt;nobr&gt;&gt;
 The &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; grows worse and the streets are soon filled with coaches and wagons full of people fleeing with their goods to the countryside. The &lt;&lt;defQueenMother &quot;Queen Mother&quot;&gt;&gt; &lt;&lt;defHenriettaMaria &quot;Henrietta Maria&quot;&gt;&gt; moves back to France&lt;&lt;if $religion is &quot;Catholic&quot;&gt;&gt;, much to your dismay, and that of your fellow Catholics who flock to her chapel each week&lt;&lt;else&gt;&gt;, much to your relief, and that of all your fellow God-fearing &lt;&lt;defProtestants &quot;Protestants&quot;&gt;&gt;&lt;&lt;/if&gt;&gt;. On June 29th, the King packs up his entire &lt;&lt;defHousehold &quot;household&quot;&gt;&gt; in 148 carriages and moves 12 miles away, to his palace at &lt;&lt;defHamptonCourt &quot;Hampton Court&quot;&gt;&gt;.
@@ -5824,6 +5844,11 @@ The &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; grows worse and the streets are
 &lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Skipped Church of England services (fined 48d.)&quot;, money: -48, repDelta: -1, repBefore: $reputation, infectPct: null})&gt;&gt;
 &lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;
 &lt;&lt;set $money to Math.clamp($money - 48, -Infinity, Infinity)&gt;&gt;
+/* Forced to attend due to debt - 2% plague risk */
+&lt;&lt;elseif $debtForcedAttend is 1 and $money lt 0&gt;&gt;
+&lt;&lt;set $plagueInfection to random(1,50)&gt;&gt;
+&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Attended parish church services (debt)&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: 2})&gt;&gt;
+You return to the Church of England services this month. You cannot afford to pay the fine for skipping while in debt. Your previous commitment to always skip services no longer applies, but once you are no longer in debt, you can re-commit to always skipping Church of England services.&lt;br&gt;&lt;br&gt;
 /* Offer choice if not in debt */
 &lt;&lt;elseif $money gte 0&gt;&gt;
 &lt;span id=&quot;churchChoice&quot;&gt;As a $religion, do you want to attend services at your parish Church of England this month?&lt;br&gt;&lt;br&gt;

--- a/variables.md
+++ b/variables.md
@@ -608,7 +608,7 @@ This document lists all global (story) variables used in **Gaming the Great Plag
 - **Initial value:** `0`
 - **Set by:** `random-character` widget (pid 14) initializes to `0`. Set to `1` when the player chooses "Always avoid Church of England services" in the `church-services` widget.
 - **Used for:** Controls whether non-Church of England characters skip weekly parish church services. When `1`, the 48d. fine and &minus;1 reputation penalty are applied automatically each month without prompting the player. Only available to characters not in debt (`$money gte 0`). Does not apply in April 1666 (Easter has its own service code).
-- **Dependency:** Only meaningful when `$religion isnot "member of the Church of England"`. Interacts with `$money` (fine) and `$reputation` (penalty).
+- **Dependency:** Only meaningful when `$religion isnot "member of the Church of England"`. Interacts with `$money` (fine) and `$reputation` (penalty). Reset to `0` by the `debt-check` widget when the player enters debt, which also sets `$debtForcedAttend` to `1`.
 
 ### `$billSubscribed`
 - **Type:** Integer (boolean-like)
@@ -617,7 +617,23 @@ This document lists all global (story) variables used in **Gaming the Great Plag
 - **Set by:** The `bill-subscribe` widget (pid 114) when the player accepts the subscription offer in May 1665. Set to `1` on acceptance.
 - **Used for:** Controls whether the player receives monthly Bills of Mortality reports showing total burials and plague deaths in their parish. When `1`, the `corpse-work` widget (pid 114) deducts 4d. per month and displays a burial report at the top of each month passage.
 - **Suppression:** Reports are suppressed when `$role is "searcher"` or `$role is "corpsebearer"`, since those roles already receive equivalent information through their plague work duties.
-- **Dependencies:** Interacts with `$money` (4d. monthly charge), `$corpseBuried` and `$corpsePlague` (data source), `$parish` and `$monthIndex` (data lookup), `$role` (suppression logic).
+- **Dependencies:** Interacts with `$money` (4d. monthly charge), `$corpseBuried` and `$corpsePlague` (data source), `$parish` and `$monthIndex` (data lookup), `$role` (suppression logic). Reset to `0` by the `debt-check` widget when the player enters debt.
+
+### `$debtWarned`
+- **Type:** Integer (boolean-like)
+- **Possible values:** `0` (not yet warned), `1` (debt warning has fired)
+- **Initial value:** `0` (set in `StoryInit`, pid 10)
+- **Set by:** The `debt-check` widget (pid 114) sets this to `1` the first time `$money` falls below 0 after a monthly disposable-income calculation. Once set to `1`, it is never reset.
+- **Used for:** Prevents the debt warning message and recurring-cost cancellation logic from firing more than once. When the player first enters debt, the `debt-check` widget cancels `$billSubscribed` and `$skipServices` (if active) and displays a one-time notification.
+- **Dependencies:** Checked alongside `$money` in the `debt-check` widget. Interacts with `$billSubscribed`, `$skipServices`, and `$debtForcedAttend`.
+
+### `$debtForcedAttend`
+- **Type:** Integer (boolean-like)
+- **Possible values:** `0` (not applicable), `1` (player was forced back to attending Church of England services due to debt)
+- **Initial value:** `0` (set in `StoryInit`, pid 10)
+- **Set by:** The `debt-check` widget (pid 114) sets this to `1` when `$skipServices` is reset from `1` to `0` due to the player entering debt.
+- **Used for:** In the `church-services` widget (pid 115), when `$debtForcedAttend is 1` and `$money lt 0`, the player is automatically enrolled in Church of England services (2% plague infection risk) with a message explaining they cannot afford the fine for non-attendance. Once `$money` recovers to &ge; 0, the normal three-way choice (always skip / skip this month / attend) is presented again.
+- **Dependencies:** Interacts with `$skipServices`, `$money`, `$religion`, and `$plagueInfection`.
 
 ### `$timeline`
 - **Type:** Array of strings


### PR DESCRIPTION
Add debt-check widget that fires once when $money falls below 0 after monthly disposable-income calculation. On first debt:
- Cancels Bills of Mortality subscription ($billSubscribed → 0)
- Cancels church-skip commitment ($skipServices → 0)
- Displays one-time notification listing cancelled expenses

Modify church-services widget so non-CoE players forced out of their skip commitment attend services with 2% plague risk and see a message explaining they can re-commit to skipping once out of debt.

New variables: $debtWarned (tracks one-time warning), $debtForcedAttend (tracks forced church attendance due to debt).

https://claude.ai/code/session_01ER8VQa2ekuh99VYKc6XkBY