### PR TITLE
Restrict plague job assignments by age, religion, and reputation — bu…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.37" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.38" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -2849,24 +2849,25 @@ Do you:
 [[stand firm in your refusal to risk your life-&gt;deported][$decisions.push({text: &quot;Stood firm and was deported&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})]]
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;elseif $socio is &quot;day labourers&quot;&gt;&gt;&lt;&lt;set $socio to &quot;beggars&quot;&gt;&gt;&lt;&lt;set $money to 0&gt;&gt;Because you are no longer working, you quickly run out of money and have to throw yourself on the mercy of your &lt;&lt;defParish &quot;parish&#39;s&quot;&gt;&gt; &lt;&lt;defOverseersOfThePoor &quot;Overseers of the Poor&quot;&gt;&gt;.&lt;br&gt;&lt;br&gt;
-&lt;&lt;if $religion is &quot;member of the Church of England&quot;&gt;&gt;They have decided it will be your job to 
-&lt;&lt;if $gender is &quot;male&quot; or $gender is &quot;nonbinary&quot;&gt;&gt;&lt;&lt;set _offeredRole to either(&quot;corpsebearer&quot;, &quot;warder&quot;)&gt;&gt;&lt;&lt;set $role to _offeredRole&gt;&gt;&lt;&lt;if _offeredRole is &quot;warder&quot;&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if _offeredRole is &quot;corpsebearer&quot;&gt;&gt;remove the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; corpses of anyone who dies.
-&lt;br&gt;
-&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/7/7a/Wilson_%22The_plague...%22%3B_a_corpses_bearer_Wellcome_L0016624.jpg&quot; width=&quot;100%&quot;&gt;
-&lt;br&gt;
-//Printed by R. Price, A corpse bearer; reproduction of an engraving from a series of London Cries, 1655. Wellcome Images//
-&lt;&lt;else&gt;&gt;stand guard outside quarantined houses to prevent anyone from escaping.
-&lt;&lt;/if&gt;&gt;
-&lt;br&gt;&lt;br&gt;
-&lt;&lt;elseif $gender is &quot;female&quot; and $reputation gt 5&gt;&gt;&lt;&lt;set $role to &quot;searcher&quot;&gt;&gt;look at the corpses and determine if they died of &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; or some other cause of death
+&lt;&lt;if $religion is &quot;member of the Church of England&quot; and $agenum gt 16&gt;&gt;They have decided it will be your job to 
+&lt;&lt;if $reputation gte 6&gt;&gt;&lt;&lt;if $gender is &quot;female&quot;&gt;&gt;&lt;&lt;set $role to &quot;searcher&quot;&gt;&gt;look at the corpses and determine if they died of &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; or some other cause of death
 &lt;br&gt;
     &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/6/67/Plague_in_1665_%28BM_1875%2C0508.1513%29.jpg&quot; width=&quot;100%&quot;&gt;
     &lt;br&gt;
     //Nathaniel Parr, published by Thomas Astley, Plague in 1665, 1747//
-&lt;&lt;else&gt;&gt;&lt;&lt;set $role to &quot;nurse&quot;&gt;&gt;nurse the sick and dying, despite the risk to your own life.
+&lt;&lt;else&gt;&gt;&lt;&lt;set $role to &quot;warder&quot;&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;stand guard outside quarantined houses to prevent anyone from escaping.
 &lt;&lt;/if&gt;&gt;
+&lt;&lt;else&gt;&gt;&lt;&lt;if $gender is &quot;female&quot;&gt;&gt;&lt;&lt;set $role to &quot;nurse&quot;&gt;&gt;nurse the sick and dying, despite the risk to your own life.
+&lt;&lt;else&gt;&gt;&lt;&lt;set $role to &quot;corpsebearer&quot;&gt;&gt;remove the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; corpses of anyone who dies.
+&lt;br&gt;
+&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/7/7a/Wilson_%22The_plague...%22%3B_a_corpses_bearer_Wellcome_L0016624.jpg&quot; width=&quot;100%&quot;&gt;
+&lt;br&gt;
+//Printed by R. Price, A corpse bearer; reproduction of an engraving from a series of London Cries, 1655. Wellcome Images//
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;br&gt;&lt;br&gt;
 You have no choice but to &lt;&lt;storyline-return &quot;accept your new role&quot;&gt;&gt;.
-&lt;&lt;else&gt;&gt;As you are not a member of the Church of England, the parish cannot assign you to plague work. You have no choice but to &lt;&lt;storyline-return &quot;accept your new situation&quot;&gt;&gt;.
+&lt;&lt;else&gt;&gt;&lt;&lt;if $religion isnot &quot;member of the Church of England&quot;&gt;&gt;As you are not a member of the Church of England, the parish cannot assign you to plague work.&lt;&lt;else&gt;&gt;The parish does not consider you old enough for plague work.&lt;&lt;/if&gt;&gt; You have no choice but to &lt;&lt;storyline-return &quot;accept your new situation&quot;&gt;&gt;.
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="38" name="July 1665" tags="storyline 1665" position="1450,475" size="100,100">&lt;&lt;nobr&gt;&gt;
@@ -3469,22 +3470,21 @@ While this is enough for a little extra bread, you are painfully aware that this
 One of your neighbors &lt;&lt;if $reputation gte 6&gt;&gt;provides you with leftovers from a feast&lt;&lt;else&gt;&gt;&lt;&lt;if _charity is 1&gt;&gt;gives you some moldy bread&lt;&lt;else&gt;&gt;lets you have an old dress, which you sell for a bit of extra bread&lt;&lt;set $plagueInfection to random(1,100)&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;. Because you didn&#39;t have to spend as much money on food, you manage to save an extra $beggarsluck pence.&lt;&lt;unset $beggarsluck&gt;&gt;
 &lt;&lt;storyline-return&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="54" name="beggar-roles" tags="widget" position="1450,25" size="100,100">&lt;&lt;widget &quot;beggar-roles&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
-    &lt;&lt;if $disability is 0 and $religion is &quot;member of the Church of England&quot;&gt;&gt; and the &lt;&lt;defOverseersOfThePoor &quot;Overseers of the Poor&quot;&gt;&gt; have decided it will be your job to
-        &lt;&lt;if $gender is &quot;male&quot; or $gender is &quot;nonbinary&quot;&gt;&gt;&lt;&lt;set _offeredRole to either(&quot;corpsebearer&quot;, &quot;warder&quot;)&gt;&gt;&lt;&lt;set $role to _offeredRole&gt;&gt;&lt;&lt;if _offeredRole is &quot;warder&quot;&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if _offeredRole is &quot;corpsebearer&quot;&gt;&gt;remove the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; corpses if anyone dies
-        &lt;br&gt;
-&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/7/7a/Wilson_%22The_plague...%22%3B_a_corpses_bearer_Wellcome_L0016624.jpg&quot; width=&quot;100%&quot;&gt;
-//Printed by R. Price, A corpse bearer; reproduction of an engraving from a series of London Cries, 1655. Wellcome Images//
-        &lt;&lt;else&gt;&gt;stand guard outside quarantined houses to prevent anyone from escaping
-        &lt;&lt;/if&gt;&gt;
-        
-        &lt;&lt;elseif $gender is &quot;female&quot; and $reputation gt 5&gt;&gt;&lt;&lt;set $role to &quot;searcher&quot;&gt;&gt;look at the corpses and determine if they died of &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; or some other cause of death
+    &lt;&lt;if $disability is 0 and $religion is &quot;member of the Church of England&quot; and $agenum gt 16&gt;&gt; and the &lt;&lt;defOverseersOfThePoor &quot;Overseers of the Poor&quot;&gt;&gt; have decided it will be your job to
+        &lt;&lt;if $reputation gte 6&gt;&gt;&lt;&lt;if $gender is &quot;female&quot;&gt;&gt;&lt;&lt;set $role to &quot;searcher&quot;&gt;&gt;look at the corpses and determine if they died of &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; or some other cause of death
         &lt;br&gt;
     &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/6/67/Plague_in_1665_%28BM_1875%2C0508.1513%29.jpg&quot; width=&quot;100%&quot;&gt;
     //Nathaniel Parr, published by Thomas Astley, Plague in 1665, 1747.//
-        
-        &lt;&lt;else&gt;&gt;&lt;&lt;set $role to &quot;nurse&quot;&gt;&gt;nurse the sick and dying, despite the risk to your own life
+        &lt;&lt;else&gt;&gt;&lt;&lt;set $role to &quot;warder&quot;&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;stand guard outside quarantined houses to prevent anyone from escaping
         &lt;&lt;/if&gt;&gt;
-    &lt;&lt;elseif $disability is 0&gt;&gt;, but the &lt;&lt;defOverseersOfThePoor &quot;Overseers of the Poor&quot;&gt;&gt; have refused to hire you for plague work, as only members of the Church of England may serve in such parish offices
+        &lt;&lt;else&gt;&gt;&lt;&lt;if $gender is &quot;female&quot;&gt;&gt;&lt;&lt;set $role to &quot;nurse&quot;&gt;&gt;nurse the sick and dying, despite the risk to your own life
+        &lt;&lt;else&gt;&gt;&lt;&lt;set $role to &quot;corpsebearer&quot;&gt;&gt;remove the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; corpses if anyone dies
+        &lt;br&gt;
+&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/7/7a/Wilson_%22The_plague...%22%3B_a_corpses_bearer_Wellcome_L0016624.jpg&quot; width=&quot;100%&quot;&gt;
+//Printed by R. Price, A corpse bearer; reproduction of an engraving from a series of London Cries, 1655. Wellcome Images//
+        &lt;&lt;/if&gt;&gt;
+        &lt;&lt;/if&gt;&gt;
+    &lt;&lt;elseif $disability is 0&gt;&gt;, but the &lt;&lt;defOverseersOfThePoor &quot;Overseers of the Poor&quot;&gt;&gt; have refused to hire you for plague work&lt;&lt;if $religion isnot &quot;member of the Church of England&quot;&gt;&gt;, as only members of the Church of England may serve in such parish offices&lt;&lt;else&gt;&gt;, as you are not old enough for such work&lt;&lt;/if&gt;&gt;
     &lt;&lt;/if&gt;&gt;.
     &lt;&lt;if $disability gte 1&gt;&gt;Many of your neighbors begin to flee the city and those who remain curse at you to leave when you try begging at their doors.&lt;&lt;/if&gt;&gt;
 &lt;br&gt;&lt;br&gt;You decide to:
@@ -3839,11 +3839,11 @@ In fact, you&lt;&lt;if $agenum lte 15&gt;&gt; and your family&lt;&lt;/if&gt;&gt;
 &lt;&lt;if $socio is &quot;day labourers&quot;&gt;&gt;
 &lt;&lt;if _ctx is &quot;initial&quot;&gt;&gt;
 &lt;&lt;if $origin isnot &quot;London&quot;&gt;&gt; You still have family back home in $origin and have to consider whether or not to abandon your home and whatever possessions you cannot carry to take refuge with your family.&lt;&lt;/if&gt;&gt;&lt;br&gt;&lt;br&gt;
-    &lt;&lt;if $religion is &quot;member of the Church of England&quot;&gt;&gt;&lt;&lt;set _offeredRole to either(&quot;corpsebearer&quot;, &quot;warder&quot;)&gt;&gt;You hear that the local parish officials want to hire you to &lt;&lt;if $gender is &quot;male&quot; and $agenum gte 16 and _offeredRole is &quot;corpsebearer&quot;&gt;&gt;remove the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; corpses if anyone dies&lt;&lt;elseif $gender is &quot;male&quot; and $agenum gte 16 and _offeredRole is &quot;warder&quot;&gt;&gt;stand guard outside quarantined houses to prevent anyone from escaping&lt;&lt;elseif $gender is &quot;female&quot; and $agenum gte 16 and $reputation gte 3&gt;&gt;look at plague corpses and determine if they died of plague or some other cause of death&lt;&lt;else&gt;&gt;nurse the sick and dying, despite the risk to your own life&lt;&lt;/if&gt;&gt;.&lt;br&gt;&lt;br&gt;
-&lt;&lt;else&gt;&gt;As you are not a member of the Church of England, the parish cannot offer you plague work.&lt;br&gt;&lt;br&gt;
+    &lt;&lt;if $religion is &quot;member of the Church of England&quot; and $agenum gt 16&gt;&gt;You hear that the local parish officials want to hire you to &lt;&lt;if $reputation gte 6&gt;&gt;&lt;&lt;if $gender is &quot;female&quot;&gt;&gt;look at plague corpses and determine if they died of plague or some other cause of death&lt;&lt;else&gt;&gt;stand guard outside quarantined houses to prevent anyone from escaping&lt;&lt;/if&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;if $gender is &quot;female&quot;&gt;&gt;nurse the sick and dying, despite the risk to your own life&lt;&lt;else&gt;&gt;remove the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; corpses if anyone dies&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;.&lt;br&gt;&lt;br&gt;
+&lt;&lt;else&gt;&gt;&lt;&lt;if $religion isnot &quot;member of the Church of England&quot;&gt;&gt;As you are not a member of the Church of England, the parish cannot offer you plague work.&lt;&lt;else&gt;&gt;The parish does not consider you old enough for plague work.&lt;&lt;/if&gt;&gt;&lt;br&gt;&lt;br&gt;
 &lt;&lt;/if&gt;&gt;    You decide to:
     &lt;ul&gt;
-        &lt;&lt;if $religion is &quot;member of the Church of England&quot;&gt;&gt;&lt;li&gt;&lt;&lt;link &quot;accept the job&quot; &quot;Stay&quot;&gt;&gt;&lt;&lt;set $fled to 4&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Accepted a plague work job&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;if $gender is &quot;female&quot; and $agenum gte 16 and $reputation gte 3&gt;&gt;&lt;&lt;set $role to &quot;searcher&quot;&gt;&gt;&lt;&lt;elseif $agenum lte 15&gt;&gt;&lt;&lt;set $role to &quot;nurse&quot;&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $role to _offeredRole&gt;&gt;&lt;&lt;if _offeredRole is &quot;warder&quot;&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
+        &lt;&lt;if $religion is &quot;member of the Church of England&quot; and $agenum gt 16&gt;&gt;&lt;li&gt;&lt;&lt;link &quot;accept the job&quot; &quot;Stay&quot;&gt;&gt;&lt;&lt;set $fled to 4&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Accepted a plague work job&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;if $reputation gte 6&gt;&gt;&lt;&lt;if $gender is &quot;female&quot;&gt;&gt;&lt;&lt;set $role to &quot;searcher&quot;&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $role to &quot;warder&quot;&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;if $gender is &quot;female&quot;&gt;&gt;&lt;&lt;set $role to &quot;nurse&quot;&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $role to &quot;corpsebearer&quot;&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
         &lt;li&gt;[[not accept the job-&gt;Stay][_repBefore to $reputation; $reputation to Math.clamp($reputation - 1, 0, 10); $fled to 4; $role to &quot;unemployed&quot;; $decisions.push({text: &quot;Refused the plague work job&quot;, money: 0, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: null})]]&lt;/li&gt;
         &lt;&lt;else&gt;&gt;&lt;li&gt;[[Remain in the city-&gt;Stay][$fled to 4; $decisions.push({text: &quot;Remained in the city&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})]]&lt;/li&gt;
         &lt;&lt;/if&gt;&gt;


### PR DESCRIPTION
…mp to v2.38

Jobs (corpsebearer, warder, searcher, nurse) now require characters to be over 16 and Church of England. Assignment is reputation-based rather than random: rep >= 6 gives searcher (female) or warder (others); rep <= 5 gives nurse (female) or corpsebearer (others). Updated pid 64 (flight-choice), pid 54 (beggar-roles), and pid 37 (work-refusal).

https://claude.ai/code/session_01RHaz6kCJVMwyN65G53CTkb