### PR TITLE
Fix $hoh edge cases: mistress succession, orphan guardians, fled-fami…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.47" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.48" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -2915,7 +2915,7 @@ There aren&#39;t as many rumors as there might have been, given how many people 
 &lt;&lt;set _authoritySick to false&gt;&gt;
 &lt;&lt;if $hoh is 0 or $hoh is 2&gt;&gt;
     &lt;&lt;for _npc range $NPCs&gt;&gt;
-        &lt;&lt;if _npc.health is &quot;infected&quot; and ($gender is &quot;male&quot; and (_npc.relationship is &quot;father&quot; or _npc.relationship is &quot;step-father&quot;) or $gender isnot &quot;male&quot; and (_npc.relationship is &quot;father&quot; or _npc.relationship is &quot;step-father&quot; or _npc.relationship is &quot;mother&quot; or _npc.relationship is &quot;step-mother&quot;))&gt;&gt;
+        &lt;&lt;if _npc.health is &quot;infected&quot; and ($gender is &quot;male&quot; and (_npc.relationship is &quot;father&quot; or _npc.relationship is &quot;step-father&quot;) or $gender isnot &quot;male&quot; and (_npc.relationship is &quot;father&quot; or _npc.relationship is &quot;step-father&quot; or _npc.relationship is &quot;mother&quot; or _npc.relationship is &quot;step-mother&quot;) or _npc.relationship is &quot;uncle&quot; or _npc.relationship is &quot;aunt&quot; or _npc.relationship is &quot;widowed aunt&quot; or _npc.relationship is &quot;guardian&quot; or _npc.relationship is &quot;guardian&#39;s wife&quot; or _npc.relationship is &quot;cousin&quot; or _npc.relationship is &quot;cousin&#39;s wife&quot;)&gt;&gt;
             &lt;&lt;set _authoritySick to true&gt;&gt;
         &lt;&lt;/if&gt;&gt;
     &lt;&lt;/for&gt;&gt;
@@ -2933,7 +2933,7 @@ There aren&#39;t as many rumors as there might have been, given how many people 
     &lt;&lt;/for&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/silently&gt;&gt;
-It is a difficult decision, but &lt;&lt;if $hoh is 0&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;with your &lt;&lt;if $gender is &quot;male&quot;&gt;&gt;father&lt;&lt;else&gt;&gt;parent&lt;&lt;/if&gt;&gt; among the sick, you decide&lt;&lt;else&gt;&gt;your family decide&lt;&lt;/if&gt;&gt;&lt;&lt;elseif $hoh is 2&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;with your &lt;&lt;if $gender is &quot;male&quot;&gt;&gt;father&lt;&lt;else&gt;&gt;parent&lt;&lt;/if&gt;&gt; among the sick, you decide&lt;&lt;else&gt;&gt;your family decide&lt;&lt;/if&gt;&gt;&lt;&lt;elseif $hoh is 3&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;with your $masterTitle among the sick, you decide&lt;&lt;else&gt;&gt;your $masterTitle decides&lt;&lt;/if&gt;&gt;&lt;&lt;elseif $hoh is 4&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;with your husband among the sick, you decide&lt;&lt;else&gt;&gt;your family decide&lt;&lt;/if&gt;&gt;&lt;&lt;else&gt;&gt;you decide&lt;&lt;/if&gt;&gt; it&#39;s for the best to send your sick to the &lt;&lt;defPesthouse &quot;pesthouse&quot;&gt;&gt;.
+It is a difficult decision, but &lt;&lt;if $hoh is 0&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;with your &lt;&lt;set-caretaker&gt;&gt;&lt;&lt;print _caretakerLabel&gt;&gt; among the sick, you decide&lt;&lt;else&gt;&gt;your family decide&lt;&lt;/if&gt;&gt;&lt;&lt;elseif $hoh is 2&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;with your &lt;&lt;if $gender is &quot;male&quot;&gt;&gt;father&lt;&lt;else&gt;&gt;parent&lt;&lt;/if&gt;&gt; among the sick, you decide&lt;&lt;else&gt;&gt;your family decide&lt;&lt;/if&gt;&gt;&lt;&lt;elseif $hoh is 3&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;with your $masterTitle among the sick, you decide&lt;&lt;else&gt;&gt;your $masterTitle decides&lt;&lt;/if&gt;&gt;&lt;&lt;elseif $hoh is 4&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;with your husband among the sick, you decide&lt;&lt;else&gt;&gt;your family decide&lt;&lt;/if&gt;&gt;&lt;&lt;else&gt;&gt;you decide&lt;&lt;/if&gt;&gt; it&#39;s for the best to send your sick to the &lt;&lt;defPesthouse &quot;pesthouse&quot;&gt;&gt;.
 &lt;br&gt;&lt;br&gt;
 &lt;&lt;if $reputation lte 2&gt;&gt;To your horror, rumors swirl that your family have actually murdered a member of your household and hidden the body! &lt;&lt;if $murder gte 1&gt;&gt; Remembering the rumors of murder that circulated last time  your family sent someone to the household, you &lt;&lt;/if&gt;&gt;&lt;&lt;if $murder lte 1&gt;&gt;You&lt;&lt;/if&gt;&gt; send to the master of the pesthouse to produce a certificate for you that proves the rumor is a lie.
 &lt;&lt;set $reputation to Math.clamp($reputation - 2, 0, 10)&gt;&gt;&lt;&lt;set $murder =1&gt;&gt;
@@ -3015,7 +3015,7 @@ As morning dawns, a terrible realization settles over your &lt;&lt;defHousehold 
         &lt;&lt;set _authoritySick to false&gt;&gt;
         &lt;&lt;if $hoh is 0 or $hoh is 2&gt;&gt;
             &lt;&lt;for _idx range _infectedFamily&gt;&gt;
-                &lt;&lt;if $NPCs[_idx].relationship is &quot;father&quot; or $NPCs[_idx].relationship is &quot;step-father&quot; or $NPCs[_idx].relationship is &quot;mother&quot; or $NPCs[_idx].relationship is &quot;step-mother&quot;&gt;&gt;
+                &lt;&lt;if $NPCs[_idx].relationship is &quot;father&quot; or $NPCs[_idx].relationship is &quot;step-father&quot; or $NPCs[_idx].relationship is &quot;mother&quot; or $NPCs[_idx].relationship is &quot;step-mother&quot; or $NPCs[_idx].relationship is &quot;uncle&quot; or $NPCs[_idx].relationship is &quot;aunt&quot; or $NPCs[_idx].relationship is &quot;widowed aunt&quot; or $NPCs[_idx].relationship is &quot;guardian&quot; or $NPCs[_idx].relationship is &quot;guardian&#39;s wife&quot; or $NPCs[_idx].relationship is &quot;cousin&quot; or $NPCs[_idx].relationship is &quot;cousin&#39;s wife&quot;&gt;&gt;
                     &lt;&lt;set _authoritySick to true&gt;&gt;
                 &lt;&lt;/if&gt;&gt;
             &lt;&lt;/for&gt;&gt;
@@ -3051,7 +3051,7 @@ As morning dawns, a terrible realization settles over your &lt;&lt;defHousehold 
         &lt;&lt;/if&gt;&gt;
         &lt;&lt;/for&gt;&gt;
     &lt;br&gt;
-    As a good Christian, it is your duty to look after the poor, sick, and needy. But as a good Christian, you also know it is a sin to needlessly risk your life. &lt;&lt;if $hoh is 0&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;With your &lt;&lt;if $gender is &quot;male&quot;&gt;&gt;father&lt;&lt;else&gt;&gt;parent&lt;&lt;/if&gt;&gt; too ill to make decisions, the responsibility falls to you. Do you&lt;&lt;else&gt;&gt;Do you convince your household to&lt;&lt;/if&gt;&gt;&lt;&lt;elseif $hoh is 2&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;With your &lt;&lt;if $gender is &quot;male&quot;&gt;&gt;father&lt;&lt;else&gt;&gt;parent&lt;&lt;/if&gt;&gt; too ill to make decisions, the responsibility falls to you. Do you&lt;&lt;else&gt;&gt;Do you convince your family to&lt;&lt;/if&gt;&gt;&lt;&lt;elseif $hoh is 3&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;With your $masterTitle too ill to give orders, the decision falls to you. Do you&lt;&lt;else&gt;&gt;Do you convince your $masterTitle to&lt;&lt;/if&gt;&gt;&lt;&lt;elseif $hoh is 4&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;With your husband too ill to make decisions, you must decide for yourself. Do you&lt;&lt;else&gt;&gt;Do you convince your husband to&lt;&lt;/if&gt;&gt;&lt;&lt;else&gt;&gt;Do you&lt;&lt;/if&gt;&gt;:&lt;ul&gt;
+    As a good Christian, it is your duty to look after the poor, sick, and needy. But as a good Christian, you also know it is a sin to needlessly risk your life. &lt;&lt;if $hoh is 0&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;&lt;&lt;set-caretaker&gt;&gt;With your &lt;&lt;print _caretakerLabel&gt;&gt; too ill to make decisions, the responsibility falls to you. Do you&lt;&lt;else&gt;&gt;Do you convince your household to&lt;&lt;/if&gt;&gt;&lt;&lt;elseif $hoh is 2&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;With your &lt;&lt;if $gender is &quot;male&quot;&gt;&gt;father&lt;&lt;else&gt;&gt;parent&lt;&lt;/if&gt;&gt; too ill to make decisions, the responsibility falls to you. Do you&lt;&lt;else&gt;&gt;Do you convince your family to&lt;&lt;/if&gt;&gt;&lt;&lt;elseif $hoh is 3&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;With your $masterTitle too ill to give orders, the decision falls to you. Do you&lt;&lt;else&gt;&gt;Do you convince your $masterTitle to&lt;&lt;/if&gt;&gt;&lt;&lt;elseif $hoh is 4&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;With your husband too ill to make decisions, you must decide for yourself. Do you&lt;&lt;else&gt;&gt;Do you convince your husband to&lt;&lt;/if&gt;&gt;&lt;&lt;else&gt;&gt;Do you&lt;&lt;/if&gt;&gt;:&lt;ul&gt;
 &lt;li&gt;[[Quarantine with your household-&gt;Quarantine, Week 1][$reputation to Math.clamp($reputation + 3, 0, 10)]]&lt;/li&gt;
     &lt;li&gt;[[Send the sick to the pesthouse-&gt;FamPesthouse][$reputation to Math.clamp($reputation - 5, 0, 10)]]&lt;/li&gt;
     &lt;/ul&gt;
@@ -3097,7 +3097,15 @@ As morning dawns, a terrible realization settles over your &lt;&lt;defHousehold 
             &lt;&lt;/if&gt;&gt;
         &lt;&lt;/for&gt;&gt;
     &lt;&lt;/if&gt;&gt;
-    /* Priority 3: master or mistress */
+    /* Priority 3: uncle, aunt, or guardian */
+    &lt;&lt;if _stayIdx is -1&gt;&gt;
+        &lt;&lt;for _fi = 0; _fi &lt; $NPCs.length; _fi++&gt;&gt;
+            &lt;&lt;if _stayIdx is -1 and ($NPCs[_fi].relationship is &quot;uncle&quot; or $NPCs[_fi].relationship is &quot;aunt&quot; or $NPCs[_fi].relationship is &quot;widowed aunt&quot; or $NPCs[_fi].relationship is &quot;guardian&quot; or $NPCs[_fi].relationship is &quot;guardian&#39;s wife&quot; or $NPCs[_fi].relationship is &quot;cousin&quot; or $NPCs[_fi].relationship is &quot;cousin&#39;s wife&quot;)&gt;&gt;
+                &lt;&lt;set _stayIdx to _fi&gt;&gt;
+            &lt;&lt;/if&gt;&gt;
+        &lt;&lt;/for&gt;&gt;
+    &lt;&lt;/if&gt;&gt;
+    /* Priority 4: master or mistress */
     &lt;&lt;if _stayIdx is -1&gt;&gt;
         &lt;&lt;for _fi = 0; _fi &lt; $NPCs.length; _fi++&gt;&gt;
             &lt;&lt;if $NPCs[_fi].relationship is &quot;master&quot; or $NPCs[_fi].relationship is &quot;mistress&quot;&gt;&gt;
@@ -3105,7 +3113,7 @@ As morning dawns, a terrible realization settles over your &lt;&lt;defHousehold 
             &lt;&lt;/if&gt;&gt;
         &lt;&lt;/for&gt;&gt;
     &lt;&lt;/if&gt;&gt;
-    /* Priority 4: oldest adult by agenum */
+    /* Priority 5: oldest adult by agenum */
     &lt;&lt;if _stayIdx is -1&gt;&gt;
         &lt;&lt;set _bestAge to -1&gt;&gt;
         &lt;&lt;for _fi = 0; _fi &lt; $NPCs.length; _fi++&gt;&gt;
@@ -3172,6 +3180,7 @@ As morning dawns, a terrible realization settles over your &lt;&lt;defHousehold 
     &lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;check-widowed&gt;&gt;
+&lt;&lt;set-hoh&gt;&gt;
 &lt;&lt;/silently&gt;&gt;&lt;&lt;/if&gt;&gt;/* end fled-family infection guard */
 &lt;&lt;/widget&gt;&gt;
 
@@ -3248,9 +3257,9 @@ As morning dawns, a terrible realization settles over your &lt;&lt;defHousehold 
         &lt;&lt;/if&gt;&gt;
     &lt;&lt;/for&gt;&gt;
 &lt;&lt;elseif $hoh is 0 or $hoh is 2&gt;&gt;
-    /* For children/those living with parents, check if the parent in $NPCs is currently infected */
+    /* For children/those living with parents, check if the parent or guardian in $NPCs is currently infected */
     &lt;&lt;for _npc range $NPCs&gt;&gt;
-        &lt;&lt;if _npc.health is &quot;infected&quot; and ($gender is &quot;male&quot; and (_npc.relationship is &quot;father&quot; or _npc.relationship is &quot;step-father&quot;) or $gender isnot &quot;male&quot; and (_npc.relationship is &quot;father&quot; or _npc.relationship is &quot;step-father&quot; or _npc.relationship is &quot;mother&quot; or _npc.relationship is &quot;step-mother&quot;))&gt;&gt;
+        &lt;&lt;if _npc.health is &quot;infected&quot; and ($gender is &quot;male&quot; and (_npc.relationship is &quot;father&quot; or _npc.relationship is &quot;step-father&quot;) or $gender isnot &quot;male&quot; and (_npc.relationship is &quot;father&quot; or _npc.relationship is &quot;step-father&quot; or _npc.relationship is &quot;mother&quot; or _npc.relationship is &quot;step-mother&quot;) or _npc.relationship is &quot;uncle&quot; or _npc.relationship is &quot;aunt&quot; or _npc.relationship is &quot;widowed aunt&quot; or _npc.relationship is &quot;guardian&quot; or _npc.relationship is &quot;guardian&#39;s wife&quot; or _npc.relationship is &quot;cousin&quot; or _npc.relationship is &quot;cousin&#39;s wife&quot;)&gt;&gt;
             &lt;&lt;set _authoritySick to true&gt;&gt;
         &lt;&lt;/if&gt;&gt;
     &lt;&lt;/for&gt;&gt;
@@ -3281,7 +3290,7 @@ As morning dawns, a terrible realization settles over your &lt;&lt;defHousehold 
     &lt;&lt;/for&gt;&gt;
 &lt;&lt;/if&gt;&gt;
     &lt;br&gt;
-    As a good Christian, it is your duty to look after the poor, sick, and needy. But as a good Christian, you also know it is a sin to needlessly risk your life. &lt;&lt;if $hoh is 0&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;With your &lt;&lt;if $gender is &quot;male&quot;&gt;&gt;father&lt;&lt;else&gt;&gt;parent&lt;&lt;/if&gt;&gt; too ill to make decisions, the responsibility falls to you. Do you&lt;&lt;else&gt;&gt;Do you convince your household to&lt;&lt;/if&gt;&gt;&lt;&lt;elseif $hoh is 2&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;With your &lt;&lt;if $gender is &quot;male&quot;&gt;&gt;father&lt;&lt;else&gt;&gt;parent&lt;&lt;/if&gt;&gt; too ill to make decisions, the responsibility falls to you. Do you&lt;&lt;else&gt;&gt;Do you convince your family to&lt;&lt;/if&gt;&gt;&lt;&lt;elseif $hoh is 3&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;With your $masterTitle too ill to give orders, the decision falls to you. Do you&lt;&lt;else&gt;&gt;Do you convince your $masterTitle to&lt;&lt;/if&gt;&gt;&lt;&lt;elseif $hoh is 4&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;With your husband too ill to make decisions, you must decide for yourself. Do you&lt;&lt;else&gt;&gt;Do you convince your husband to&lt;&lt;/if&gt;&gt;&lt;&lt;else&gt;&gt;Do you&lt;&lt;/if&gt;&gt;:&lt;ul&gt;
+    As a good Christian, it is your duty to look after the poor, sick, and needy. But as a good Christian, you also know it is a sin to needlessly risk your life. &lt;&lt;if $hoh is 0&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;&lt;&lt;set-caretaker&gt;&gt;With your &lt;&lt;print _caretakerLabel&gt;&gt; too ill to make decisions, the responsibility falls to you. Do you&lt;&lt;else&gt;&gt;Do you convince your household to&lt;&lt;/if&gt;&gt;&lt;&lt;elseif $hoh is 2&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;With your &lt;&lt;if $gender is &quot;male&quot;&gt;&gt;father&lt;&lt;else&gt;&gt;parent&lt;&lt;/if&gt;&gt; too ill to make decisions, the responsibility falls to you. Do you&lt;&lt;else&gt;&gt;Do you convince your family to&lt;&lt;/if&gt;&gt;&lt;&lt;elseif $hoh is 3&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;With your $masterTitle too ill to give orders, the decision falls to you. Do you&lt;&lt;else&gt;&gt;Do you convince your $masterTitle to&lt;&lt;/if&gt;&gt;&lt;&lt;elseif $hoh is 4&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;With your husband too ill to make decisions, you must decide for yourself. Do you&lt;&lt;else&gt;&gt;Do you convince your husband to&lt;&lt;/if&gt;&gt;&lt;&lt;else&gt;&gt;Do you&lt;&lt;/if&gt;&gt;:&lt;ul&gt;
 &lt;li&gt;&lt;&lt;link &quot;Quarantine with the sick&quot; &quot;Quarantine, Week 1&quot;&gt;&gt;&lt;&lt;swap-to-other-hh&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation + 3, 0, 10)&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
     &lt;li&gt;&lt;&lt;link &quot;Remain in your own household&quot;&gt;&gt;&lt;&lt;silently&gt;&gt;&lt;&lt;set _deadOther to []&gt;&gt;&lt;&lt;set _recovOther to []&gt;&gt;&lt;&lt;for _mi = 0; _mi &lt; $NPCsMaster.length; _mi++&gt;&gt;&lt;&lt;if $NPCsMaster[_mi].health is &quot;infected&quot;&gt;&gt;&lt;&lt;if random(1,2) eq 1&gt;&gt;&lt;&lt;set $NPCsMaster[_mi].health to &quot;deceased&quot;&gt;&gt;&lt;&lt;set _deadOther.push($NPCsMaster[_mi].relationship + &quot; &quot; + $NPCsMaster[_mi].name)&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $NPCsMaster[_mi].health to &quot;recovered&quot;&gt;&gt;&lt;&lt;set _recovOther.push($NPCsMaster[_mi].relationship + &quot; &quot; + $NPCsMaster[_mi].name)&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;for _ei = 0; _ei &lt; $NPCsExtended.length; _ei++&gt;&gt;&lt;&lt;if $NPCsExtended[_ei].health is &quot;infected&quot;&gt;&gt;&lt;&lt;if random(1,2) eq 1&gt;&gt;&lt;&lt;set $NPCsExtended[_ei].health to &quot;deceased&quot;&gt;&gt;&lt;&lt;set _deadOther.push($NPCsExtended[_ei].relationship + &quot; &quot; + $NPCsExtended[_ei].name)&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $NPCsExtended[_ei].health to &quot;recovered&quot;&gt;&gt;&lt;&lt;set _recovOther.push($NPCsExtended[_ei].relationship + &quot; &quot; + $NPCsExtended[_ei].name)&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;check-widowed&gt;&gt;&lt;&lt;/silently&gt;&gt;&lt;&lt;replace &quot;#other-hh-choice&quot;&gt;&gt;You decide to remain in your own household and pray for the sick.&lt;&lt;if _deadOther.length gt 0&gt;&gt; Despite your prayers, &lt;&lt;for _n, _name range _deadOther&gt;&gt;&lt;&lt;if _deadOther.length eq 1&gt;&gt;your _name has&lt;&lt;elseif _n &lt; _deadOther.length - 1&gt;&gt;your _name, &lt;&lt;else&gt;&gt;and your _name have&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt; died.&lt;&lt;/if&gt;&gt;&lt;&lt;if _recovOther.length gt 0&gt;&gt; Thankfully, &lt;&lt;for _n, _name range _recovOther&gt;&gt;&lt;&lt;if _recovOther.length eq 1&gt;&gt;your _name has&lt;&lt;elseif _n &lt; _recovOther.length - 1&gt;&gt;your _name, &lt;&lt;else&gt;&gt;and your _name have&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt; survived.&lt;&lt;/if&gt;&gt;&lt;&lt;storyline-return&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
     &lt;/ul&gt;&lt;/span&gt;
@@ -3663,10 +3672,10 @@ Your $masterTitle learns of your debts and is furious. &lt;&lt;set $socio to &qu
       &lt;&lt;/if&gt;&gt;
     &lt;&lt;/for&gt;&gt;
   &lt;&lt;/if&gt;&gt;
-  /* Priority 3: uncle or aunt */
+  /* Priority 3: uncle, aunt, or guardian */
   &lt;&lt;if _hohNPCName is &quot;&quot;&gt;&gt;
     &lt;&lt;for _pi to 0; _pi lt $NPCs.length; _pi++&gt;&gt;
-      &lt;&lt;if _hohNPCName is &quot;&quot; and ($NPCs[_pi].relationship is &quot;uncle&quot; or $NPCs[_pi].relationship is &quot;aunt&quot;) and $NPCs[_pi].health isnot &quot;deceased&quot;&gt;&gt;
+      &lt;&lt;if _hohNPCName is &quot;&quot; and ($NPCs[_pi].relationship is &quot;uncle&quot; or $NPCs[_pi].relationship is &quot;aunt&quot; or $NPCs[_pi].relationship is &quot;widowed aunt&quot; or $NPCs[_pi].relationship is &quot;guardian&quot; or $NPCs[_pi].relationship is &quot;guardian&#39;s wife&quot; or $NPCs[_pi].relationship is &quot;cousin&quot; or $NPCs[_pi].relationship is &quot;cousin&#39;s wife&quot;) and $NPCs[_pi].health isnot &quot;deceased&quot;&gt;&gt;
         &lt;&lt;set _hohNPCName to $NPCs[_pi].name&gt;&gt;
         &lt;&lt;set _hohNPCRel to $NPCs[_pi].relationship&gt;&gt;
       &lt;&lt;/if&gt;&gt;
@@ -5916,7 +5925,7 @@ You are in debt and can no longer afford your recurring expenses.&lt;&lt;if _deb
   &lt;&lt;/if&gt;&gt;
   /* Check for servant living with master (hoh 3) */
   &lt;&lt;for _shi to 0; _shi lt $NPCs.length; _shi++&gt;&gt;
-    &lt;&lt;if $NPCs[_shi].relationship is &quot;master&quot; and $NPCs[_shi].health isnot &quot;deceased&quot;&gt;&gt;
+    &lt;&lt;if ($NPCs[_shi].relationship is &quot;master&quot; or $NPCs[_shi].relationship is &quot;mistress&quot;) and $NPCs[_shi].health isnot &quot;deceased&quot;&gt;&gt;
       &lt;&lt;set $hoh to 3&gt;&gt;
     &lt;&lt;/if&gt;&gt;
   &lt;&lt;/for&gt;&gt;
@@ -5949,7 +5958,15 @@ You are in debt and can no longer afford your recurring expenses.&lt;&lt;if _deb
       &lt;&lt;/if&gt;&gt;
     &lt;&lt;/for&gt;&gt;
   &lt;&lt;/if&gt;&gt;
-  /* Priority 3: master or mistress */
+  /* Priority 3: uncle, aunt, or guardian */
+  &lt;&lt;if _caretakerLabel is &quot;&quot;&gt;&gt;
+    &lt;&lt;for _ci to 0; _ci lt $NPCs.length; _ci++&gt;&gt;
+      &lt;&lt;if _caretakerLabel is &quot;&quot; and ($NPCs[_ci].relationship is &quot;uncle&quot; or $NPCs[_ci].relationship is &quot;aunt&quot; or $NPCs[_ci].relationship is &quot;widowed aunt&quot; or $NPCs[_ci].relationship is &quot;guardian&quot; or $NPCs[_ci].relationship is &quot;guardian&#39;s wife&quot; or $NPCs[_ci].relationship is &quot;cousin&quot; or $NPCs[_ci].relationship is &quot;cousin&#39;s wife&quot;) and $NPCs[_ci].health isnot &quot;deceased&quot;&gt;&gt;
+        &lt;&lt;set _caretakerLabel to $NPCs[_ci].relationship&gt;&gt;
+      &lt;&lt;/if&gt;&gt;
+    &lt;&lt;/for&gt;&gt;
+  &lt;&lt;/if&gt;&gt;
+  /* Priority 4: master or mistress */
   &lt;&lt;if _caretakerLabel is &quot;&quot;&gt;&gt;
     &lt;&lt;for _ci to 0; _ci lt $NPCs.length; _ci++&gt;&gt;
       &lt;&lt;if _caretakerLabel is &quot;&quot; and ($NPCs[_ci].relationship is &quot;master&quot; or $NPCs[_ci].relationship is &quot;mistress&quot;) and $NPCs[_ci].health isnot &quot;deceased&quot;&gt;&gt;


### PR DESCRIPTION
…ly reclassification — bump to v2.48

- set-hoh now checks for "mistress" relationship so servants get $hoh=3 after master-death succession to the master's mother
- set-caretaker, FamPesthouse, sickFam, sickOtherHH, and fled-family stay-behind logic now recognize uncle/aunt/widowed aunt/guardian/cousin relationships for orphaned children
- fled-family now calls <<set-hoh>> after moving NPCs so $hoh is properly reclassified (e.g. $hoh=2 → $hoh=1 when parents flee)
- debtor-widgets prison priority expanded to include all guardian relationship types

https://claude.ai/code/session_01Pyg6M888bFFxt9j95VJPdL