### PR TITLE
Fix flight menu, $office init, church rep penalty, bio text — bump to…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.48" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.49" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -1144,7 +1144,7 @@ $(document).on(':passagestart', function (ev) {
 
 &lt;&lt;if $gender is &quot;nonbinary&quot;&gt;&gt;&lt;&lt;set _x to random(1,4)&gt;&gt;&lt;&lt;if _x is 1&gt;&gt;Your friends and family call you &lt;&lt;set _name = [&quot;Charles&quot;, &quot;Charlotte&quot;]&gt;&gt;&lt;&lt;listbox &quot;$name&quot;&gt;&gt;&lt;&lt;optionsfrom _name&gt;&gt;&lt;&lt;/listbox&gt;&gt;&lt;&lt;elseif _x is 2&gt;&gt;Your friends and family call you &lt;&lt;set _name = [&quot;Phillip&quot;, &quot;Phillippa&quot;]&gt;&gt;&lt;&lt;listbox &quot;$name&quot;&gt;&gt;&lt;&lt;optionsfrom _name&gt;&gt;&lt;&lt;/listbox&gt;&gt;&lt;&lt;elseif _x is 3&gt;&gt;Your friends and family call you &lt;&lt;set _name = [&quot;John&quot;, &quot;Joan&quot;]&gt;&gt;&lt;&lt;listbox &quot;$name&quot;&gt;&gt;&lt;&lt;optionsfrom _name&gt;&gt;&lt;&lt;/listbox&gt;&gt;&lt;&lt;else&gt;&gt;Your friends and family call you &lt;&lt;set _name = [&quot;Thomas&quot;, &quot;Thomasina&quot;]&gt;&gt;&lt;&lt;listbox &quot;$name&quot;&gt;&gt;&lt;&lt;optionsfrom _name&gt;&gt;&lt;&lt;/listbox&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;else&gt;&gt;Your name is $name&lt;&lt;/if&gt;&gt;, and you are $agenum years old. You are proud to be a &lt;&lt;defVarReligion $religion&gt;&gt;, &lt;&lt;if $religion is &quot;member of the Church of England&quot;&gt;&gt;the only true and legal faith&lt;&lt;else&gt;&gt;despite the fact that it is illegal in England.&lt;&lt;/if&gt;&gt;
 &lt;br&gt;&lt;br&gt;
-You were born and raised in &lt;&lt;if $origin is &quot;London&quot;&gt;&gt;London&lt;&lt;else&gt;&gt;$origin, though you now make your home in London&lt;&lt;/if&gt;&gt;. You currently live in the &lt;&lt;defParish &quot;parish&quot;&gt;&gt; of $parish, which is $location. It is a good place for &lt;&lt;defVarSocio $socio&gt;&gt; like you.&lt;br&gt;&lt;br&gt; /*NTS update with roles for merchants and artisans*/
+You were &lt;&lt;if $agenum lte 15&gt;&gt;born&lt;&lt;else&gt;&gt;born and raised&lt;&lt;/if&gt;&gt; in &lt;&lt;if $origin is &quot;London&quot;&gt;&gt;London&lt;&lt;else&gt;&gt;$origin, though you now make your home in London&lt;&lt;/if&gt;&gt;. You currently live in the &lt;&lt;defParish &quot;parish&quot;&gt;&gt; of $parish, which is $location. It is a good place for &lt;&lt;defVarSocio $socio&gt;&gt; like you.&lt;br&gt;&lt;br&gt; /*NTS update with roles for merchants and artisans*/
 
 &lt;&lt;silently&gt;&gt;
 /* add family for young children */
@@ -1646,6 +1646,8 @@ When you go to church on Easter Sunday, you are reminded of how lucky you are as
 &lt;&lt;set $debtForcedAttend to 0&gt;&gt;
 &lt;&lt;set $disability to 0&gt;&gt;
 &lt;&lt;set $reputation to 6&gt;&gt;
+&lt;&lt;set $office to &quot;&quot;&gt;&gt;
+&lt;&lt;set $churchSkipRepPenalty to 0&gt;&gt;
 &lt;&lt;set $plagueInfection to 0&gt;&gt;
 &lt;&lt;set $playerPlagueStatus to &quot;healthy&quot;&gt;&gt;
 &lt;&lt;set $location to 0&gt;&gt;
@@ -4287,7 +4289,7 @@ Luckily, there are no &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; cases in your
 &lt;li&gt;&lt;&lt;link &quot;Household Status&quot;&gt;&gt;
     &lt;&lt;run Dialog.setup(&quot;Household&quot;, &quot;household&quot;); Dialog.wiki(Story.get(&quot;Household Status&quot;).text); Dialog.open()&gt;&gt;
 &lt;&lt;/link&gt;&gt;&lt;/li&gt;
-&lt;&lt;if visited(&quot;May 1665&quot;) and $fled isnot 6 and $fled isnot 1 and $fled isnot 2 and passage() isnot &quot;FamPesthouse&quot; and passage() isnot &quot;Quarantine, Week 1&quot; and passage() isnot &quot;Quarantine Continues&quot; and passage() isnot &quot;sickPC&quot; and passage() isnot &quot;Hide&quot; and passage() isnot &quot;YouPesthouse&quot; and passage() isnot &quot;death&quot;&gt;&gt;&lt;li&gt;&lt;&lt;link &quot;Flight&quot;&gt;&gt;
+&lt;&lt;if visited(&quot;May 1665&quot;) and not visited(&quot;November 1666&quot;) and $fled isnot 6 and $fled isnot 1 and $fled isnot 2 and passage() isnot &quot;FamPesthouse&quot; and passage() isnot &quot;Quarantine, Week 1&quot; and passage() isnot &quot;Quarantine Continues&quot; and passage() isnot &quot;sickPC&quot; and passage() isnot &quot;Hide&quot; and passage() isnot &quot;YouPesthouse&quot; and passage() isnot &quot;death&quot;&gt;&gt;&lt;li&gt;&lt;&lt;link &quot;Flight&quot;&gt;&gt;
     &lt;&lt;run Dialog.setup(&quot;Flight&quot;, &quot;flight&quot;); Dialog.wiki(Story.get(&quot;Flight&quot;).text); Dialog.open()&gt;&gt;
 &lt;&lt;/link&gt;&gt;&lt;/li&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="73" name="empty" tags="" position="150,1300" size="100,100">/* use as needed */</tw-passagedata><tw-passagedata pid="74" name="Household Status" tags="" position="650,25" size="100,100">Player stats:
@@ -6092,8 +6094,8 @@ The &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; grows worse and the streets are
 &lt;&lt;if passage() is &quot;April 1666&quot;&gt;&gt;
 /* Always-skip: apply penalty silently */
 &lt;&lt;elseif $skipServices is 1&gt;&gt;
-&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Skipped Church of England services (fined 48d.)&quot;, money: -48, repDelta: -1, repBefore: $reputation, infectPct: null})&gt;&gt;
-&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;
+&lt;&lt;set _repLoss to 0&gt;&gt;&lt;&lt;if $churchSkipRepPenalty is 0&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;&lt;&lt;set $churchSkipRepPenalty to 1&gt;&gt;&lt;&lt;set _repLoss to -1&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Skipped Church of England services (fined 48d.)&quot;, money: -48, repDelta: _repLoss, repBefore: $reputation, infectPct: null})&gt;&gt;
 &lt;&lt;set $money to Math.clamp($money - 48, -Infinity, Infinity)&gt;&gt;
 /* Forced to attend due to debt - 2% plague risk */
 &lt;&lt;elseif $debtForcedAttend is 1 and $money lt 0&gt;&gt;
@@ -6104,16 +6106,16 @@ You return to the Church of England services this month. You cannot afford to pa
 &lt;&lt;elseif $money gte 0&gt;&gt;
 &lt;span id=&quot;churchChoice&quot;&gt;As a $religion, do you want to attend services at your parish Church of England this month?&lt;br&gt;&lt;br&gt;
 &lt;&lt;link &quot;Always avoid Church of England services&quot;&gt;&gt;&lt;&lt;replace &quot;#churchChoice&quot;&gt;&gt;
-&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Skipped Church of England services (fined 48d.)&quot;, money: -48, repDelta: -1, repBefore: $reputation, infectPct: null})&gt;&gt;
+&lt;&lt;set _repLoss to 0&gt;&gt;&lt;&lt;if $churchSkipRepPenalty is 0&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;&lt;&lt;set $churchSkipRepPenalty to 1&gt;&gt;&lt;&lt;set _repLoss to -1&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Skipped Church of England services (fined 48d.)&quot;, money: -48, repDelta: _repLoss, repBefore: $reputation, infectPct: null})&gt;&gt;
 &lt;&lt;set $skipServices to 1&gt;&gt;
-&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;
 &lt;&lt;set $money to Math.clamp($money - 48, -Infinity, Infinity)&gt;&gt;
-You resolve to stop attending services at the Church of England. You are fined 48d. for non-attendance and your reputation suffers.&lt;br&gt;&lt;br&gt;
+You resolve to stop attending services at the Church of England. You are fined 48d. for non-attendance&lt;&lt;if _repLoss is -1&gt;&gt; and your reputation suffers&lt;&lt;/if&gt;&gt;.&lt;br&gt;&lt;br&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;Skip Church of England services this month&quot;&gt;&gt;&lt;&lt;replace &quot;#churchChoice&quot;&gt;&gt;
-&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Skipped Church of England services (fined 48d.)&quot;, money: -48, repDelta: -1, repBefore: $reputation, infectPct: null})&gt;&gt;
-&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;
+&lt;&lt;set _repLoss to 0&gt;&gt;&lt;&lt;if $churchSkipRepPenalty is 0&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;&lt;&lt;set $churchSkipRepPenalty to 1&gt;&gt;&lt;&lt;set _repLoss to -1&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Skipped Church of England services (fined 48d.)&quot;, money: -48, repDelta: _repLoss, repBefore: $reputation, infectPct: null})&gt;&gt;
 &lt;&lt;set $money to Math.clamp($money - 48, -Infinity, Infinity)&gt;&gt;
-You skip services at your parish church this month and are fined 48d. for non-attendance.&lt;br&gt;&lt;br&gt;
+You skip services at your parish church this month and are fined 48d. for non-attendance.&lt;&lt;if _repLoss is -1&gt;&gt; Your reputation suffers.&lt;&lt;/if&gt;&gt;&lt;br&gt;&lt;br&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;Attend services&quot;&gt;&gt;&lt;&lt;replace &quot;#churchChoice&quot;&gt;&gt;
 &lt;&lt;set $plagueInfection to random(1,50)&gt;&gt;&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Attended parish church services&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: 2})&gt;&gt;
 You attend services at your parish church, though it goes against your beliefs as a $religion.&lt;br&gt;&lt;br&gt;

--- a/variables.md
+++ b/variables.md
@@ -622,8 +622,16 @@ This document lists all global (story) variables used in **Gaming the Great Plag
 - **Possible values:** `0` (attend services / ask each month), `1` (always skip)
 - **Initial value:** `0`
 - **Set by:** `random-character` widget (pid 14) initializes to `0`. Set to `1` when the player chooses "Always avoid Church of England services" in the `church-services` widget.
-- **Used for:** Controls whether non-Church of England characters skip weekly parish church services. When `1`, the 48d. fine and &minus;1 reputation penalty are applied automatically each month without prompting the player. Only available to characters not in debt (`$money gte 0`). Does not apply in April 1666 (Easter has its own service code).
+- **Used for:** Controls whether non-Church of England characters skip weekly parish church services. When `1`, the 48d. fine is applied automatically each month without prompting the player. The &minus;1 reputation penalty only fires on the first skip (tracked by `$churchSkipRepPenalty`). Only available to characters not in debt (`$money gte 0`). Does not apply in April 1666 (Easter has its own service code).
 - **Dependency:** Only meaningful when `$religion isnot "member of the Church of England"`. Interacts with `$money` (fine) and `$reputation` (penalty). Reset to `0` by the `debt-check` widget when the player enters debt, which also sets `$debtForcedAttend` to `1`.
+
+### `$churchSkipRepPenalty`
+- **Type:** Integer (boolean-like)
+- **Possible values:** `0` (reputation penalty not yet applied), `1` (reputation penalty already applied)
+- **Initial value:** `0` (set in `StoryInit`, pid 10)
+- **Set by:** The `church-services` widget (pid 115) sets this to `1` the first time a non-Church of England character skips church services.
+- **Used for:** Ensures the &minus;1 reputation penalty for skipping Church of England services only fires once (on the first skip). The 48d. monetary fine continues to apply every month the player skips.
+- **Dependencies:** Interacts with `$reputation`, `$skipServices`, and `$religion`.
 
 ### `$billSubscribed`
 - **Type:** Integer (boolean-like)


### PR DESCRIPTION
… v2.49

1. Remove Flight option from menu bar after October 1666 (plague officially over starting November 1666)
2. Initialize $office to "" in StoryInit so it is properly defined for all characters; household status popup already suppresses empty values
3. Reputation penalty for non-Church of England characters skipping church services now only fires the first time (tracked via $churchSkipRepPenalty); the 48d. monetary fine continues to accrue every month
4. Bio text now reads "born" instead of "born and raised" for characters with agenum <= 15

https://claude.ai/code/session_01KLiVNdnogfgAhcFiS714Rp