### PR TITLE
Add child smuggling to quarantine passages with retrieval choices — b…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.53" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.54" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -1335,26 +1335,7 @@ Send not to know for whom the church bells toll. They toll for you.&lt;br&gt;&lt
     &lt;&lt;/if&gt;&gt;
     &lt;&lt;/if&gt;&gt;
     /* smuggle out any healthy children if your rep is good enough */
-    &lt;&lt;if $reputation gte 6&gt;&gt;
-      &lt;&lt;set $getaway = []&gt;&gt;
-        &lt;&lt;for _e, _household range $NPCs&gt;&gt;
-          &lt;&lt;if _household.health is &quot;healthy&quot; and (_household.age is &quot;child&quot; or _household.age is &quot;infant&quot;)&gt;&gt;
-            &lt;&lt;set $getaway.push(_e)&gt;&gt;
-          &lt;&lt;/if&gt;&gt;
-        &lt;&lt;/for&gt;&gt;
-    &lt;&lt;for _s range $getaway&gt;&gt;
-        &lt;&lt;set $NPCs[_s].location to &quot;the countryside&quot;&gt;&gt;&lt;&lt;set $NPCs[_s].health to &quot;safe from harm&quot;&gt;&gt;
-    &lt;&lt;/for&gt;&gt;
-    /* NTS: need to update text! */
-      &lt;&lt;if $getaway.length gt 0&gt;&gt;&lt;br&gt;&lt;br&gt;
-      In the meantime, your family has resorted to desperate measures to protect the health of the youngest. One evening, someone manages to smuggle 
-        &lt;&lt;for _f, _g range $getaway&gt;&gt;
-          &lt;&lt;if $getaway.length eq 1&gt;&gt;your $NPCs[_g].relationship $NPCs[_g].name,
-          &lt;&lt;elseif _f &lt; $getaway.length - 1&gt;&gt;your $NPCs[_g].relationship $NPCs[_g].name, &lt;&lt;else&gt;&gt;and your $NPCs[_g].relationship $NPCs[_g].name
-          &lt;&lt;/if&gt;&gt;
-        &lt;&lt;/for&gt;&gt;out of the house and to a safer location.
-      &lt;&lt;/if&gt;&gt;
-      &lt;&lt;/if&gt;&gt;&lt;br&gt;&lt;br&gt;
+    &lt;&lt;smuggle-children&gt;&gt;&lt;br&gt;&lt;br&gt;
   
     &lt;&lt;link &quot;The days continue to pass with agonizing slowness.&quot; `passage()`&gt;&gt;&lt;&lt;/link&gt;&gt;
   &lt;&lt;case 5&gt;&gt;
@@ -3787,6 +3768,8 @@ You have heard and read about different courses of treatment for the sick. &lt;&
     &lt;&lt;/for&gt;&gt;
     &lt;&lt;/if&gt;&gt;
 
+&lt;&lt;smuggle-children&gt;&gt;
+
 You must remain in &lt;&lt;defQuarantine &quot;quarantine&quot;&gt;&gt; for at least three more weeks, however, and only time will tell if the disease has spread.
 &lt;br&gt;&lt;br&gt;
 &lt;&lt;health-update&gt;&gt;
@@ -4898,6 +4881,8 @@ Lord be praised, your &lt;&lt;defHousehold &quot;household&quot;&gt;&gt; has sur
 &lt;&lt;/silently&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 
+&lt;&lt;return-children&gt;&gt;
+
 /* Funeral choices for NPCs who died during quarantine */
 &lt;&lt;for _qi = 0; _qi &lt; $NPCs.length; _qi++&gt;&gt;&lt;&lt;if $NPCs[_qi].health is &quot;deceased&quot; and !$NPCs[_qi].funeralDone&gt;&gt;&lt;&lt;funeral-choice $NPCs[_qi]&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;for _qi = 0; _qi &lt; $NPCsServants.length; _qi++&gt;&gt;&lt;&lt;if $NPCsServants[_qi].health is &quot;deceased&quot; and !$NPCsServants[_qi].funeralDone&gt;&gt;&lt;&lt;funeral-choice $NPCsServants[_qi]&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;for _qi = 0; _qi &lt; $NPCsMaster.length; _qi++&gt;&gt;&lt;&lt;if $NPCsMaster[_qi].health is &quot;deceased&quot; and !$NPCsMaster[_qi].funeralDone&gt;&gt;&lt;&lt;funeral-choice $NPCsMaster[_qi]&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;for _qi = 0; _qi &lt; $NPCsExtended.length; _qi++&gt;&gt;&lt;&lt;if $NPCsExtended[_qi].health is &quot;deceased&quot; and !$NPCsExtended[_qi].funeralDone&gt;&gt;&lt;&lt;funeral-choice $NPCsExtended[_qi]&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
 &lt;&lt;orphan-check&gt;&gt;
@@ -5939,6 +5924,44 @@ You are in debt and can no longer afford your recurring expenses.&lt;&lt;if _deb
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;
 
+&lt;&lt;widget &quot;smuggle-children&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
+/* Smuggle healthy children/infants out of a shut-up house if reputation is high enough */
+&lt;&lt;if $reputation gte 6&gt;&gt;
+&lt;&lt;set $getaway = []&gt;&gt;
+&lt;&lt;for _e, _household range $NPCs&gt;&gt;
+  &lt;&lt;if _household.health is &quot;healthy&quot; and (_household.age is &quot;child&quot; or _household.age is &quot;infant&quot;)&gt;&gt;
+    &lt;&lt;set $getaway.push(_e)&gt;&gt;
+  &lt;&lt;/if&gt;&gt;
+&lt;&lt;/for&gt;&gt;
+&lt;&lt;for _s range $getaway&gt;&gt;
+  &lt;&lt;set $NPCs[_s].location to &quot;the countryside&quot;&gt;&gt;&lt;&lt;set $NPCs[_s].health to &quot;safe from harm&quot;&gt;&gt;
+&lt;&lt;/for&gt;&gt;
+&lt;&lt;if $getaway.length gt 0&gt;&gt;&lt;br&gt;&lt;br&gt;
+In the meantime, your family has resorted to desperate measures to protect the health of the youngest. One evening, someone manages to smuggle &lt;&lt;for _f, _g range $getaway&gt;&gt;&lt;&lt;if $getaway.length eq 1&gt;&gt;your $NPCs[_g].relationship $NPCs[_g].name&lt;&lt;elseif _f &lt; $getaway.length - 1&gt;&gt;your $NPCs[_g].relationship $NPCs[_g].name, &lt;&lt;else&gt;&gt;and your $NPCs[_g].relationship $NPCs[_g].name&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt; out of the house and to a safer location.
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;
+
+&lt;&lt;widget &quot;return-children&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
+/* Offer to bring back any children with health &quot;safe from harm&quot; */
+&lt;&lt;set _safeKids to []&gt;&gt;
+&lt;&lt;for _sk = 0; _sk &lt; $NPCs.length; _sk++&gt;&gt;
+  &lt;&lt;if $NPCs[_sk].health is &quot;safe from harm&quot;&gt;&gt;
+    &lt;&lt;set _safeKids.push(_sk)&gt;&gt;
+  &lt;&lt;/if&gt;&gt;
+&lt;&lt;/for&gt;&gt;
+&lt;&lt;if _safeKids.length gt 0&gt;&gt;
+&lt;br&gt;&lt;br&gt;&lt;span id=&quot;return-children&quot;&gt;Your &lt;&lt;for _rc, _ri range _safeKids&gt;&gt;&lt;&lt;if _safeKids.length eq 1&gt;&gt;$NPCs[_ri].relationship $NPCs[_ri].name&lt;&lt;elseif _rc &lt; _safeKids.length - 1&gt;&gt;$NPCs[_ri].relationship $NPCs[_ri].name, &lt;&lt;else&gt;&gt;and $NPCs[_ri].relationship $NPCs[_ri].name&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt; survived safely in the countryside. Do you want to bring &lt;&lt;if _safeKids.length eq 1&gt;&gt;them&lt;&lt;else&gt;&gt;them all&lt;&lt;/if&gt;&gt; home?&lt;br&gt;&lt;br&gt;
+&lt;&lt;link &quot;Yes, bring them home&quot;&gt;&gt;&lt;&lt;replace &quot;#return-children&quot;&gt;&gt;
+&lt;&lt;for _rk range _safeKids&gt;&gt;&lt;&lt;set $NPCs[_rk].health to &quot;healthy&quot;&gt;&gt;&lt;&lt;set $NPCs[_rk].location to $location&gt;&gt;&lt;&lt;/for&gt;&gt;
+Your &lt;&lt;for _rc, _ri range _safeKids&gt;&gt;&lt;&lt;if _safeKids.length eq 1&gt;&gt;$NPCs[_ri].relationship $NPCs[_ri].name returns&lt;&lt;else&gt;&gt;&lt;&lt;if _rc &lt; _safeKids.length - 1&gt;&gt;$NPCs[_ri].relationship $NPCs[_ri].name, &lt;&lt;else&gt;&gt;and $NPCs[_ri].relationship $NPCs[_ri].name return&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt; home safely.
+&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;Not yet&quot;&gt;&gt;&lt;&lt;replace &quot;#return-children&quot;&gt;&gt;
+Your &lt;&lt;for _rc, _ri range _safeKids&gt;&gt;&lt;&lt;if _safeKids.length eq 1&gt;&gt;$NPCs[_ri].relationship&lt;&lt;else&gt;&gt;&lt;&lt;if _rc &lt; _safeKids.length - 1&gt;&gt;$NPCs[_ri].relationship, &lt;&lt;else&gt;&gt;and $NPCs[_ri].relationship&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt; &lt;&lt;if _safeKids.length eq 1&gt;&gt;remains&lt;&lt;else&gt;&gt;remain&lt;&lt;/if&gt;&gt; safely in the countryside for now.
+&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;
+&lt;/span&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;
+
 &lt;&lt;widget &quot;quarantine-costs&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
 &lt;&lt;expenses&gt;&gt;
 &lt;&lt;if $socio is &quot;nobles&quot;&gt;&gt;
@@ -6173,6 +6196,12 @@ You attend services at your parish church, though it goes against your beliefs a
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="116" name="Flight" tags="" position="775,25" size="100,100">&lt;&lt;nobr&gt;&gt;
+&lt;&lt;set _flightSafeKids to []&gt;&gt;
+&lt;&lt;for _fsk = 0; _fsk &lt; $NPCs.length; _fsk++&gt;&gt;
+  &lt;&lt;if $NPCs[_fsk].health is &quot;safe from harm&quot;&gt;&gt;
+    &lt;&lt;set _flightSafeKids.push(_fsk)&gt;&gt;
+  &lt;&lt;/if&gt;&gt;
+&lt;&lt;/for&gt;&gt;
 &lt;&lt;if $fled is 5&gt;&gt;
 Your &lt;&lt;defHousehold &quot;household&quot;&gt;&gt; is currently safe and sheltering from the plague outbreak in $hhlocation. Do you want to bring them back to London?&lt;br&gt;&lt;br&gt;
 &lt;&lt;link &quot;Yes, bring them back&quot;&gt;&gt;
@@ -6186,6 +6215,27 @@ Your &lt;&lt;defHousehold &quot;household&quot;&gt;&gt; is currently safe and sh
 &lt;&lt;link &quot;No, not yet&quot;&gt;&gt;
     &lt;&lt;run Dialog.close()&gt;&gt;
 &lt;&lt;/link&gt;&gt;
+&lt;&lt;if _flightSafeKids.length gt 0&gt;&gt;&lt;br&gt;&lt;br&gt;
+Your &lt;&lt;for _rc, _ri range _flightSafeKids&gt;&gt;&lt;&lt;if _flightSafeKids.length eq 1&gt;&gt;$NPCs[_ri].relationship $NPCs[_ri].name is&lt;&lt;elseif _rc &lt; _flightSafeKids.length - 1&gt;&gt;$NPCs[_ri].relationship $NPCs[_ri].name, &lt;&lt;else&gt;&gt;and $NPCs[_ri].relationship $NPCs[_ri].name are&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt; still safely sheltering in the countryside.&lt;br&gt;&lt;br&gt;
+&lt;&lt;link &quot;Bring them home&quot;&gt;&gt;
+    &lt;&lt;for _rk range _flightSafeKids&gt;&gt;&lt;&lt;set $NPCs[_rk].health to &quot;healthy&quot;&gt;&gt;&lt;&lt;set $NPCs[_rk].location to $location&gt;&gt;&lt;&lt;/for&gt;&gt;
+    &lt;&lt;run Dialog.close()&gt;&gt;
+&lt;&lt;/link&gt;&gt;&lt;br&gt;
+&lt;&lt;link &quot;Leave them there for now&quot;&gt;&gt;
+    &lt;&lt;run Dialog.close()&gt;&gt;
+&lt;&lt;/link&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;elseif _flightSafeKids.length gt 0&gt;&gt;
+Your &lt;&lt;for _rc, _ri range _flightSafeKids&gt;&gt;&lt;&lt;if _flightSafeKids.length eq 1&gt;&gt;$NPCs[_ri].relationship $NPCs[_ri].name is&lt;&lt;elseif _rc &lt; _flightSafeKids.length - 1&gt;&gt;$NPCs[_ri].relationship $NPCs[_ri].name, &lt;&lt;else&gt;&gt;and $NPCs[_ri].relationship $NPCs[_ri].name are&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt; still safely sheltering in the countryside. Do you want to bring &lt;&lt;if _flightSafeKids.length eq 1&gt;&gt;them&lt;&lt;else&gt;&gt;them all&lt;&lt;/if&gt;&gt; home?&lt;br&gt;&lt;br&gt;
+&lt;&lt;link &quot;Bring them home&quot;&gt;&gt;
+    &lt;&lt;for _rk range _flightSafeKids&gt;&gt;&lt;&lt;set $NPCs[_rk].health to &quot;healthy&quot;&gt;&gt;&lt;&lt;set $NPCs[_rk].location to $location&gt;&gt;&lt;&lt;/for&gt;&gt;
+    &lt;&lt;run Dialog.close()&gt;&gt;
+&lt;&lt;/link&gt;&gt;&lt;br&gt;
+&lt;&lt;link &quot;Leave them there for now&quot;&gt;&gt;
+    &lt;&lt;run Dialog.close()&gt;&gt;
+&lt;&lt;/link&gt;&gt;&lt;br&gt;&lt;br&gt;
+&lt;&lt;late-departure&gt;&gt;
+&lt;&lt;done&gt;&gt;&lt;&lt;run $(document).one(&#39;:passagestart&#39;, function() { Dialog.close(); })&gt;&gt;&lt;&lt;/done&gt;&gt;
 &lt;&lt;else&gt;&gt;
 &lt;&lt;late-departure&gt;&gt;
 &lt;&lt;done&gt;&gt;&lt;&lt;run $(document).one(&#39;:passagestart&#39;, function() { Dialog.close(); })&gt;&gt;&lt;&lt;/done&gt;&gt;


### PR DESCRIPTION
…ump to v2.54

- Extract inline smuggling logic from Sickness (pid 6) into reusable <<smuggle-children>> widget in Claude-widgets (pid 114)
- Add <<smuggle-children>> call to Quarantine, Week 1 (pid 59) so children can be smuggled out during quarantine as well as sickness
- Create <<return-children>> widget for offering to bring back children with "safe from harm" status
- Add return-children choice to Reconnecting (pid 83) at end of quarantine
- Add return-children option to Flight sidebar dialog (pid 116) so players can retrieve smuggled children at any later point

https://claude.ai/code/session_01KpYggfbQhTm5hyuxWttaBL