### PR TITLE
Add servant access for merchants and artisans — bump to v2.56

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.58" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.59" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -1225,7 +1225,7 @@ You were &lt;&lt;if $agenum lte 15&gt;&gt;born&lt;&lt;else&gt;&gt;born and raise
 &lt;&lt;elseif $NPCs.length eq 0&gt;&gt;You live alone.
 &lt;&lt;/if&gt;&gt;
 &lt;br&gt;&lt;br&gt;
-&lt;&lt;if $socio is &quot;nobles&quot;&gt;&gt;Your &lt;&lt;defHousehold &quot;household&quot;&gt;&gt; also includes $servants servants.&lt;br&gt;&lt;br&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if $socio is &quot;nobles&quot;&gt;&gt;Your &lt;&lt;defHousehold &quot;household&quot;&gt;&gt; also includes $servants servants.&lt;br&gt;&lt;br&gt;&lt;&lt;elseif ($socio is &quot;merchants&quot; or $socio is &quot;artisans&quot;) and $servants gt 0&gt;&gt;Your &lt;&lt;defHousehold &quot;household&quot;&gt;&gt; also includes &lt;&lt;if $servants eq 1&gt;&gt;a servant&lt;&lt;else&gt;&gt;$servants servants&lt;&lt;/if&gt;&gt;.&lt;br&gt;&lt;br&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;if $NPCsExtended.length gt 0&gt;&gt;Your 
   &lt;&lt;for _e, _idx range $NPCsExtended&gt;&gt;
     &lt;&lt;if $NPCsExtended.length eq 1&gt;&gt;$NPCsExtended[_e].relationship, $NPCsExtended[_e].name
@@ -1954,6 +1954,22 @@ But those are worries for the future! For now, it is time to eat, drink, and pla
   &lt;&lt;/for&gt;&gt;
 &lt;&lt;elseif $socio is &quot;merchants&quot;&gt;&gt;
   &lt;&lt;set $servants to random(1,3)&gt;&gt;
+  &lt;&lt;for _s to 0; _s lt $servants; _s++&gt;&gt;
+    &lt;&lt;if random(1,2) eq 1&gt;&gt;
+      &lt;&lt;set $NPCsServants.push({name: weightedEither($fNames), age: either(&quot;young adult&quot;, &quot;middle-aged adult&quot;), relationship: &quot;servant&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
+    &lt;&lt;else&gt;&gt;
+      &lt;&lt;set $NPCsServants.push({name: weightedEither($mNames), age: either(&quot;young adult&quot;, &quot;middle-aged adult&quot;), relationship: &quot;servant&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
+    &lt;&lt;/if&gt;&gt;
+  &lt;&lt;/for&gt;&gt;
+&lt;&lt;elseif $socio is &quot;artisans&quot;&gt;&gt;
+  &lt;&lt;set $servants to either(0,1)&gt;&gt;
+  &lt;&lt;if $servants gt 0&gt;&gt;
+    &lt;&lt;if random(1,2) eq 1&gt;&gt;
+      &lt;&lt;set $NPCsServants.push({name: weightedEither($fNames), age: either(&quot;young adult&quot;, &quot;middle-aged adult&quot;), relationship: &quot;servant&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
+    &lt;&lt;else&gt;&gt;
+      &lt;&lt;set $NPCsServants.push({name: weightedEither($mNames), age: either(&quot;young adult&quot;, &quot;middle-aged adult&quot;), relationship: &quot;servant&quot;, health: &quot;healthy&quot;, location: $location})&gt;&gt;
+    &lt;&lt;/if&gt;&gt;
+  &lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;
 
@@ -3153,8 +3169,8 @@ As morning dawns, a terrible realization settles over your &lt;&lt;defHousehold 
     &lt;&lt;else&gt;&gt;
         &lt;&lt;set $NPCs to []&gt;&gt;
     &lt;&lt;/if&gt;&gt;
-    /* For nobles, keep 1-2 servants while the rest flee with the family */
-    &lt;&lt;if $socio is &quot;nobles&quot; and $NPCsServants.length gt 0&gt;&gt;
+    /* For nobles/merchants/artisans, keep 1-2 servants while the rest flee with the family */
+    &lt;&lt;if ($socio is &quot;nobles&quot; or $socio is &quot;merchants&quot; or $socio is &quot;artisans&quot;) and $NPCsServants.length gt 0&gt;&gt;
         &lt;&lt;set _keepCount to random(1,2)&gt;&gt;
         &lt;&lt;if _keepCount gt $NPCsServants.length&gt;&gt;&lt;&lt;set _keepCount to $NPCsServants.length&gt;&gt;&lt;&lt;/if&gt;&gt;
         &lt;&lt;set _totalServants to $NPCsServants.length&gt;&gt;
@@ -5059,6 +5075,10 @@ You &lt;&lt;if $hoh is 4&gt;&gt;convince your husband&lt;&lt;elseif $hoh isnot 1
 &lt;&lt;if $socio is &quot;nobles&quot;&gt;&gt;
     /* NTS: add text about what nobles do immediately after choosing to stay. */
  You help your &lt;&lt;defHousehold &quot;household&quot;&gt;&gt; to pack up and leave the city for safety in $hhlocation. You send your family with most of the servants, keeping only $NPCsServants.length for yourself. You promise to meet them should the situation grow worse.&lt;&lt;/if&gt;&gt;
+
+/* Merchants/Artisans with servants */
+&lt;&lt;if ($socio is &quot;merchants&quot; or $socio is &quot;artisans&quot;) and $NPCsServants.length gt 0&gt;&gt;
+ You send your family to safety in $hhlocation&lt;&lt;if $FledServants.length gt 0&gt;&gt;, along with &lt;&lt;if $FledServants.length eq 1&gt;&gt;your other servant&lt;&lt;else&gt;&gt;your other $FledServants.length servants&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if $NPCsServants.length gt 0&gt;&gt;, keeping &lt;&lt;if $NPCsServants.length eq 1&gt;&gt;your servant&lt;&lt;else&gt;&gt;$NPCsServants.length servants&lt;&lt;/if&gt;&gt; with you&lt;&lt;/if&gt;&gt;. You promise to meet them should the situation grow worse.&lt;&lt;/if&gt;&gt;
 &lt;br&gt;&lt;br&gt;
 While you remain in the city, you can take measures to protect yourself&lt;&lt;if $NPCs.length gt 1&gt;&gt; and your household&lt;&lt;/if&gt;&gt; from the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt;. You can:
     &lt;&lt;preventative&gt;&gt;


### PR DESCRIPTION
Merchants now get 1-3 servant NPCs (previously only the count was set but no NPCs were generated). Artisans now get 0 or 1 servant.

Changes:
- addServantNPC widget (pid 14): generate actual servant NPC objects for merchants and add new artisan branch
- Bio passage (pid 1): display servant count for merchants/artisans
- sick-fam-widget (pid 40): include merchants/artisans in flee servant-keeping logic
- Stay passage (pid 89): add text describing servant arrangements when merchants/artisans choose to stay

https://claude.ai/code/session_019i1c2RRKrtYJVLvGEWxV8V