### PR TITLE
Fix duplicate families for single 16-29 & add housemates for single m…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.60" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.61" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -1184,9 +1184,22 @@ You were &lt;&lt;if $agenum lte 15&gt;&gt;born&lt;&lt;else&gt;&gt;born and raise
       &lt;&lt;set _x to random(2,6)&gt;&gt;&lt;&lt;for _i to 0; _i lt _x; _i++&gt;&gt;&lt;&lt;addChildNPC&gt;&gt;&lt;&lt;/for&gt;&gt;
     &lt;&lt;/if&gt;&gt;
    &lt;&lt;/if&gt;&gt;
+  &lt;&lt;if not ($agenum lte 29 and ($relationship is &quot;single&quot; or $relationship is &quot;betrothed&quot;))&gt;&gt;
   &lt;&lt;addParentNPC&gt;&gt;
   &lt;&lt;set _usedSibNames to []&gt;&gt;
   &lt;&lt;set _x to random(0,3)&gt;&gt;&lt;&lt;for _i to 0; _i lt _x; _i++&gt;&gt;&lt;&lt;addSiblingsNPC&gt;&gt;&lt;&lt;/for&gt;&gt;
+  &lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+
+/* add single middle-aged adult family (non-servants) */
+&lt;&lt;if $agenum gte 30 and $agenum lte 59&gt;&gt;
+    &lt;&lt;if $relationship is &quot;single&quot; and $socio isnot &quot;servants&quot;&gt;&gt;
+      &lt;&lt;if random(1,2) is 1&gt;&gt;
+        &lt;&lt;set $NPCs.push({name: weightedEither($fNames), age: either(&quot;young adult&quot;, &quot;middle-aged adult&quot;), relationship: either(&quot;sister&quot;, &quot;niece&quot;), health: &quot;healthy&quot;})&gt;&gt;
+      &lt;&lt;else&gt;&gt;
+        &lt;&lt;set $NPCs.push({name: weightedEither($mNames), age: either (&quot;young adult&quot;, &quot;middle-aged adult&quot;), relationship: either(&quot;brother&quot;, &quot;nephew&quot;), health: &quot;healthy&quot;})&gt;&gt;
+      &lt;&lt;/if&gt;&gt;
+    &lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 
 /* add unmarried or widowed adult family */


### PR DESCRIPTION
…iddle-aged adults — bump to v2.61

- Guard lines 56-58 in bio passage so single/betrothed characters aged ≤29 (already given family by the ≤29 block) don't get a second parent + siblings from the ≥16 block.
- Add a new block for single middle-aged adults (30-59) who are not servants, giving them a sibling, niece, or nephew — paralleling the existing elderly single/widowed adult block.

Modified pid: 1 (bio)

https://claude.ai/code/session_013ghkTDi2kqpVAoeXCW4TSn