### PR TITLE
Add child-service-check and forced-child-service widgets — bump to v2.71

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.70" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.71" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -1652,6 +1652,7 @@ When you go to church on Easter Sunday, you are reminded of how lucky you are as
 &lt;&lt;set $billSubscribed to 0&gt;&gt;
 &lt;&lt;set $debtWarned to 0&gt;&gt;
 &lt;&lt;set $debtForcedAttend to 0&gt;&gt;
+&lt;&lt;set $childServiceOffered to -1&gt;&gt;
 &lt;&lt;set $disability to 0&gt;&gt;
 &lt;&lt;set $reputation to 6&gt;&gt;
 &lt;&lt;set $office to &quot;&quot;&gt;&gt;
@@ -1718,7 +1719,7 @@ John: 1500, Thomas: 1300, William: 1300, Richard: 620, Robert: 600, Henry: 500, 
 &lt;&lt;/silently&gt;&gt;
 &lt;&lt;if tags().includes(&quot;storyline&quot;)&gt;&gt;&lt;h2&gt;&lt;&lt;print passage()&gt;&gt;, $location&lt;/h2&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;if tags().includes(&quot;quarantine&quot;)&gt;&gt;&lt;h2&gt;&lt;&lt;print passage()&gt;&gt;&lt;/h2&gt;&lt;&lt;/if&gt;&gt;
-&lt;&lt;if tags().includes(&quot;storyline&quot;) and visited() lte 1&gt;&gt;&lt;&lt;debt-check&gt;&gt;&lt;&lt;debtor&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if tags().includes(&quot;storyline&quot;) and visited() lte 1&gt;&gt;&lt;&lt;debt-check&gt;&gt;&lt;&lt;child-service-check&gt;&gt;&lt;&lt;debtor&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;silently&gt;&gt;
 &lt;&lt;if $location is &quot;inside the City walls&quot; and hasVisited(&quot;June 1665&quot;)&gt;&gt;&lt;&lt;set $apothecary to 1&gt;&gt; /*this is OBE since currently apothecary set to always show*/
 	&lt;&lt;elseif $location isnot &quot;in another part of the western suburbs&quot;&gt;&gt;
@@ -3661,6 +3662,9 @@ You never have much money to spare, but things have gone more poorly than usual 
 &lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;
 
 &lt;&lt;widget &quot;prison&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
+/* Forced child service: remove children/adolescents/young adults lte 21 for qualifying classes */
+&lt;&lt;forced-child-service&gt;&gt;
+&lt;&lt;if not _forcedServicePC&gt;&gt;
 &lt;&lt;set _hohNPCName to &quot;&quot;&gt;&gt;
 &lt;&lt;set _hohNPCRel to &quot;&quot;&gt;&gt;
 &lt;&lt;set _servantHandled to false&gt;&gt;
@@ -3717,6 +3721,7 @@ Your household has fallen so far into debt that creditors have demanded someone 
 /* Independent head of household (hoh 1) or no qualifying NPC found — player goes to prison */
 &lt;&lt;else&gt;&gt;
 To your humiliation, you&#39;ve fallen so far into debt that your creditors have demanded you be thrown in debtor&#39;s prison. &lt;&lt;if $reputation gte 6&gt;&gt;To your relief, your creditors agree to &lt;&lt;storyline-return &quot;wait a little longer&quot;&gt;&gt; due to your good reputation. &lt;&lt;else&gt;&gt;You are committed to the Fleet and forced to reside there until you reduce your debts. &lt;&lt;set $plagueInfection to random (0,1)&gt;&gt;&lt;&lt;if $plagueInfection eq 1&gt;&gt;&lt;&lt;sickPC&gt;&gt;&lt;&lt;elseif  _infectedFamily.length gte 1&gt;&gt;&lt;&lt;sickFam&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;storyline-return &quot;You hope it won&#39;t take long.&quot; 1 0 -2&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;&lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="59" name="Quarantine, Week 1" tags="quarantine" position="150,325" size="100,100">/* Quarantine Week 1*/
@@ -6351,6 +6356,183 @@ You have successfully evaded the warder outside your house and managed to bring 
 
 &lt;span id=&quot;lodger&quot;&gt;Do you want to accept lodgers into your home?&lt;br&gt;&lt;br&gt;
 &lt;&lt;link &quot;Yes, and charge extra rent&quot;&gt;&gt;&lt;&lt;replace &quot;#lodger&quot;&gt;&gt;&lt;&lt;add-lodgers&gt;&gt;&lt;&lt;set $lodger to 1&gt;&gt;&lt;&lt;set $lodgerRent to _baseRent * 2&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 2, 0, 10)&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;October 1666: Accepted lodgers at high rent&quot;, money: 0, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: null})&gt;&gt;&lt;&lt;print _decide&gt;&gt; _lodgerDesc to your household. You welcome their rent money even though your reputation takes a hit for profiting off the disaster.&lt;&lt;storyline-return&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;Yes, and charge a low rent&quot;&gt;&gt;&lt;&lt;replace &quot;#lodger&quot;&gt;&gt;&lt;&lt;add-lodgers&gt;&gt;&lt;&lt;set $lodger to 1&gt;&gt;&lt;&lt;set $lodgerRent to _baseRent&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;October 1666: Accepted lodgers at low rent&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;print _decide&gt;&gt; _lodgerDesc to your household. You welcome their rent money as even a little bit extra helps.&lt;&lt;storyline-return&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#lodger&quot;&gt;&gt;&lt;&lt;print _decideNot&gt;&gt; any lodgers. Things are crowded enough without adding strangers to the household.&lt;&lt;storyline-return&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
+&lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;
+
+&lt;&lt;widget &quot;child-service-check&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
+/* Voluntary child service: fires when $money lte 0 for beggars/day labourers/artisans.
+   Offers to put eldest child/adolescent into service, or the PC themselves if they are a child/adolescent.
+   Only fires once per month (tracked by $childServiceOffered). */
+&lt;&lt;if $money lte 0 and ($socio is &quot;beggars&quot; or $socio is &quot;day labourers&quot; or $socio is &quot;artisans&quot;) and $childServiceOffered isnot $monthIndex&gt;&gt;
+
+/* Find eligible NPC children/adolescents (not infant, not deceased) */
+&lt;&lt;set _csEligible to []&gt;&gt;
+&lt;&lt;for _ci = 0; _ci &lt; $NPCs.length; _ci++&gt;&gt;
+  &lt;&lt;if ($NPCs[_ci].age is &quot;child&quot; or $NPCs[_ci].age is &quot;adolescent&quot;) and $NPCs[_ci].health isnot &quot;deceased&quot;&gt;&gt;
+    &lt;&lt;set _csEligible.push(_ci)&gt;&gt;
+  &lt;&lt;/if&gt;&gt;
+&lt;&lt;/for&gt;&gt;
+
+&lt;&lt;if $agenum lte 15&gt;&gt;
+  /* PC is a child/adolescent — they may be put into service */
+  &lt;&lt;set $childServiceOffered to $monthIndex&gt;&gt;
+  /* Find the relationship label of whoever is suggesting this */
+  &lt;&lt;set _csSuggestor to &quot;&quot;&gt;&gt;
+  &lt;&lt;for _ci = 0; _ci &lt; $NPCs.length; _ci++&gt;&gt;
+    &lt;&lt;if _csSuggestor is &quot;&quot; and ($NPCs[_ci].relationship is &quot;father&quot; or $NPCs[_ci].relationship is &quot;step-father&quot; or $NPCs[_ci].relationship is &quot;mother&quot; or $NPCs[_ci].relationship is &quot;step-mother&quot;) and $NPCs[_ci].health isnot &quot;deceased&quot;&gt;&gt;
+      &lt;&lt;set _csSuggestor to $NPCs[_ci].relationship&gt;&gt;
+    &lt;&lt;/if&gt;&gt;
+  &lt;&lt;/for&gt;&gt;
+  &lt;&lt;if _csSuggestor is &quot;&quot;&gt;&gt;
+    &lt;&lt;for _ci = 0; _ci &lt; $NPCs.length; _ci++&gt;&gt;
+      &lt;&lt;if _csSuggestor is &quot;&quot; and ($NPCs[_ci].relationship is &quot;uncle&quot; or $NPCs[_ci].relationship is &quot;aunt&quot; or $NPCs[_ci].relationship is &quot;widowed aunt&quot; or $NPCs[_ci].relationship is &quot;guardian&quot;) and $NPCs[_ci].health isnot &quot;deceased&quot;&gt;&gt;
+        &lt;&lt;set _csSuggestor to $NPCs[_ci].relationship&gt;&gt;
+      &lt;&lt;/if&gt;&gt;
+    &lt;&lt;/for&gt;&gt;
+  &lt;&lt;/if&gt;&gt;
+
+  &lt;span id=&quot;childService&quot;&gt;Your family is struggling to make ends meet. &lt;&lt;if _csSuggestor isnot &quot;&quot;&gt;&gt;Your _csSuggestor suggests you might find a position as a servant in a nearby household.&lt;&lt;else&gt;&gt;You wonder if you might find a position as a servant in a nearby household.&lt;&lt;/if&gt;&gt; Would you like to go into service?&lt;br&gt;&lt;br&gt;
+  &lt;&lt;link &quot;Go into service&quot;&gt;&gt;&lt;&lt;replace &quot;#childService&quot;&gt;&gt;
+  /* Move surviving child/adolescent NPC siblings to extended */
+  &lt;&lt;set _csSurvivors to []&gt;&gt;
+  &lt;&lt;for _ci = 0; _ci &lt; $NPCs.length; _ci++&gt;&gt;
+    &lt;&lt;if ($NPCs[_ci].age is &quot;child&quot; or $NPCs[_ci].age is &quot;adolescent&quot;) and $NPCs[_ci].health isnot &quot;deceased&quot;&gt;&gt;
+      &lt;&lt;set _csSurvivors.push($NPCs[_ci])&gt;&gt;
+    &lt;&lt;/if&gt;&gt;
+  &lt;&lt;/for&gt;&gt;
+  &lt;&lt;set $NPCsExtended to $NPCsExtended.concat(_csSurvivors)&gt;&gt;
+  &lt;&lt;set $NPCs to []&gt;&gt;
+  &lt;&lt;set $NPCsMaster to []&gt;&gt;
+  &lt;&lt;addMasterHousehold&gt;&gt;
+  &lt;&lt;set $NPCs to $NPCsMaster.slice()&gt;&gt;
+  &lt;&lt;set $NPCsMaster to []&gt;&gt;
+  &lt;&lt;NPCpronouns&gt;&gt;
+  &lt;&lt;set $socio to &quot;servants&quot;&gt;&gt;
+  &lt;&lt;set-hoh&gt;&gt;
+  &lt;&lt;set _MasterTrade to either(&quot;baker&quot;, &quot;chandler&quot;, &quot;grocer&quot;, &quot;tailor&quot;, &quot;weaver&quot;)&gt;&gt;
+  Your &lt;&lt;defParish &quot;Parish&quot;&gt;&gt; &lt;&lt;defOverseersOfThePoor &quot;Overseers of the Poor&quot;&gt;&gt; have found you a position as a servant in a local _MasterTrade&#39;s household.&lt;br&gt;&lt;br&gt;
+  &lt;&lt;storyline-return&gt;&gt;
+  &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;Stay with your family&quot;&gt;&gt;&lt;&lt;replace &quot;#childService&quot;&gt;&gt;You decide to stay with your family for now, even though times are hard.&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;
+  &lt;/span&gt;
+
+&lt;&lt;elseif _csEligible.length gt 0&gt;&gt;
+  /* PC is an adult — offer to send eldest child/adolescent into service */
+  /* Sort eligible indices by NPC agenum descending to find eldest */
+  &lt;&lt;set _csEligible.sort(function(a, b) { return ($NPCs[b].agenum || 0) - ($NPCs[a].agenum || 0); })&gt;&gt;
+  &lt;&lt;set _csIdx to _csEligible[0]&gt;&gt;
+  &lt;&lt;set _csName to $NPCs[_csIdx].name&gt;&gt;
+  &lt;&lt;set _csRel to $NPCs[_csIdx].relationship&gt;&gt;
+  &lt;&lt;set _csHeshe to $NPCs[_csIdx].heshe || &quot;they&quot;&gt;&gt;
+  &lt;&lt;set $childServiceOffered to $monthIndex&gt;&gt;
+
+  /* HoH gating */
+  &lt;&lt;if $hoh is 4&gt;&gt;&lt;&lt;set _csDecide to &quot;You and your husband discuss whether&quot;&gt;&gt;&lt;&lt;set _csDecideNot to &quot;You and your husband decide not&quot;&gt;&gt;
+  &lt;&lt;elseif $hoh is 2&gt;&gt;&lt;&lt;set _csDecide to &quot;Your family discusses whether&quot;&gt;&gt;&lt;&lt;set _csDecideNot to &quot;Your family decides not&quot;&gt;&gt;
+  &lt;&lt;else&gt;&gt;&lt;&lt;set _csDecide to &quot;You consider whether&quot;&gt;&gt;&lt;&lt;set _csDecideNot to &quot;You decide not&quot;&gt;&gt;
+  &lt;&lt;/if&gt;&gt;
+
+  &lt;span id=&quot;childService&quot;&gt;Your household is struggling. &lt;&lt;print _csDecide&gt;&gt; to put your _csRel, _csName, into service with a nearby household.&lt;br&gt;&lt;br&gt;
+  &lt;&lt;link &quot;Put them into service&quot;&gt;&gt;&lt;&lt;replace &quot;#childService&quot;&gt;&gt;
+  &lt;&lt;set $NPCsExtended.push($NPCs[_csIdx])&gt;&gt;
+  &lt;&lt;set $NPCs.splice(_csIdx, 1)&gt;&gt;
+  &lt;&lt;NPCpronouns&gt;&gt;
+  Your _csRel, _csName, has been placed into service with a local household. You hope _csHeshe will be well cared for.&lt;br&gt;&lt;br&gt;
+  &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;Keep your family together&quot;&gt;&gt;&lt;&lt;replace &quot;#childService&quot;&gt;&gt;&lt;&lt;print _csDecideNot&gt;&gt; to send _csName away. You&#39;ll find another way to manage.&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;
+  &lt;/span&gt;
+
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;
+
+&lt;&lt;widget &quot;forced-child-service&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
+/* Forced child service: called from the prison widget when debt ceiling is exceeded.
+   For beggars/day labourers/artisans, all children, adolescents, and young adults (agenum lte 21)
+   are removed from the household and put into service by the parish Overseers of the Poor.
+   Infants always remain with their parents.
+   Sets _forcedServicePC to true if the PC themselves is put into service (skips prison logic). */
+&lt;&lt;set _forcedServicePC to false&gt;&gt;
+&lt;&lt;if $socio is &quot;beggars&quot; or $socio is &quot;day labourers&quot; or $socio is &quot;artisans&quot;&gt;&gt;
+
+/* Find eligible NPCs: children, adolescents, young adults lte 21; exclude infants and deceased */
+&lt;&lt;set _fsEligible to []&gt;&gt;
+&lt;&lt;set _fsInfantNames to []&gt;&gt;
+&lt;&lt;for _fi = 0; _fi &lt; $NPCs.length; _fi++&gt;&gt;
+  &lt;&lt;if $NPCs[_fi].health isnot &quot;deceased&quot;&gt;&gt;
+    &lt;&lt;if $NPCs[_fi].age is &quot;child&quot; or $NPCs[_fi].age is &quot;adolescent&quot; or ($NPCs[_fi].age is &quot;young adult&quot; and $NPCs[_fi].agenum lte 21)&gt;&gt;
+      &lt;&lt;set _fsEligible.push(_fi)&gt;&gt;
+    &lt;&lt;elseif $NPCs[_fi].age is &quot;infant&quot;&gt;&gt;
+      &lt;&lt;set _fsInfantNames.push($NPCs[_fi].relationship + &quot; &quot; + $NPCs[_fi].name)&gt;&gt;
+    &lt;&lt;/if&gt;&gt;
+  &lt;&lt;/if&gt;&gt;
+&lt;&lt;/for&gt;&gt;
+
+/* Check if PC qualifies (agenum lte 21 and not infant) */
+&lt;&lt;set _fsPCEligible to ($agenum lte 21 and $age isnot &quot;infant&quot;)&gt;&gt;
+
+&lt;&lt;if _fsPCEligible&gt;&gt;
+  /* PC is put into service by the Overseers */
+  &lt;&lt;set _forcedServicePC to true&gt;&gt;
+
+  /* Collect names of eligible NPCs before removing */
+  &lt;&lt;set _fsRemoved to []&gt;&gt;
+  &lt;&lt;for _fi = 0; _fi &lt; _fsEligible.length; _fi++&gt;&gt;
+    &lt;&lt;set _fsRemoved.push({name: $NPCs[_fsEligible[_fi]].name, relationship: $NPCs[_fsEligible[_fi]].relationship})&gt;&gt;
+  &lt;&lt;/for&gt;&gt;
+
+  /* Move all eligible NPCs to extended — splice in reverse order to preserve indices */
+  &lt;&lt;set _fsReverse to _fsEligible.slice().sort(function(a, b) { return b - a; })&gt;&gt;
+  &lt;&lt;for _fi = 0; _fi &lt; _fsReverse.length; _fi++&gt;&gt;
+    &lt;&lt;set $NPCsExtended.push($NPCs[_fsReverse[_fi]])&gt;&gt;
+    &lt;&lt;set $NPCs.splice(_fsReverse[_fi], 1)&gt;&gt;
+  &lt;&lt;/for&gt;&gt;
+
+  /* PC becomes a servant in a new household */
+  &lt;&lt;set $NPCs to []&gt;&gt;
+  &lt;&lt;set $NPCsMaster to []&gt;&gt;
+  &lt;&lt;addMasterHousehold&gt;&gt;
+  &lt;&lt;set $NPCs to $NPCsMaster.slice()&gt;&gt;
+  &lt;&lt;set $NPCsMaster to []&gt;&gt;
+  &lt;&lt;NPCpronouns&gt;&gt;
+  &lt;&lt;set $socio to &quot;servants&quot;&gt;&gt;
+  &lt;&lt;set-hoh&gt;&gt;
+  &lt;&lt;set _MasterTrade to either(&quot;baker&quot;, &quot;chandler&quot;, &quot;grocer&quot;, &quot;tailor&quot;, &quot;weaver&quot;)&gt;&gt;
+
+  Your household&#39;s debts have grown so great that the &lt;&lt;defParish &quot;parish&quot;&gt;&gt; &lt;&lt;defOverseersOfThePoor &quot;Overseers of the Poor&quot;&gt;&gt; have stepped in.
+  &lt;&lt;if _fsRemoved.length gt 0&gt;&gt;
+    &lt;&lt;if _fsRemoved.length eq 1&gt;&gt; You and your _fsRemoved[0].relationship, _fsRemoved[0].name, have been removed from your family and bound into service.
+    &lt;&lt;else&gt;&gt; You and your &lt;&lt;for _fn = 0; _fn &lt; _fsRemoved.length; _fn++&gt;&gt;&lt;&lt;if _fn &lt; _fsRemoved.length - 1&gt;&gt;_fsRemoved[_fn].relationship _fsRemoved[_fn].name, &lt;&lt;else&gt;&gt;and _fsRemoved[_fn].relationship _fsRemoved[_fn].name&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt; have been removed from your family and bound into service.
+    &lt;&lt;/if&gt;&gt;
+    &lt;&lt;if random(1,2) is 1&gt;&gt; Your siblings have been placed in the same household as you.&lt;&lt;else&gt;&gt; You have been separated from your siblings and placed in different households.&lt;&lt;/if&gt;&gt;
+  &lt;&lt;else&gt;&gt; You have been removed from your family and bound into service.
+  &lt;&lt;/if&gt;&gt;
+  &lt;&lt;if _fsInfantNames.length gt 0&gt;&gt; Your &lt;&lt;print _fsInfantNames.join(&quot; and &quot;)&gt;&gt; &lt;&lt;if _fsInfantNames.length eq 1&gt;&gt;remains&lt;&lt;else&gt;&gt;remain&lt;&lt;/if&gt;&gt; with your parents, too young to be put into service.&lt;&lt;/if&gt;&gt;
+  You have been placed as a servant in a local _MasterTrade&#39;s household.&lt;br&gt;&lt;br&gt;
+  &lt;&lt;storyline-return&gt;&gt;
+
+&lt;&lt;elseif _fsEligible.length gt 0&gt;&gt;
+  /* PC is an adult — all eligible NPCs are forcibly removed */
+  /* Collect names before splicing */
+  &lt;&lt;set _fsNames to []&gt;&gt;
+  &lt;&lt;for _fi = 0; _fi &lt; _fsEligible.length; _fi++&gt;&gt;
+    &lt;&lt;set _fsNames.push({name: $NPCs[_fsEligible[_fi]].name, relationship: $NPCs[_fsEligible[_fi]].relationship, heshe: $NPCs[_fsEligible[_fi]].heshe || &quot;they&quot;})&gt;&gt;
+  &lt;&lt;/for&gt;&gt;
+
+  /* Splice in reverse order to preserve indices */
+  &lt;&lt;set _fsReverse to _fsEligible.slice().sort(function(a, b) { return b - a; })&gt;&gt;
+  &lt;&lt;for _fi = 0; _fi &lt; _fsReverse.length; _fi++&gt;&gt;
+    &lt;&lt;set $NPCsExtended.push($NPCs[_fsReverse[_fi]])&gt;&gt;
+    &lt;&lt;set $NPCs.splice(_fsReverse[_fi], 1)&gt;&gt;
+  &lt;&lt;/for&gt;&gt;
+  &lt;&lt;NPCpronouns&gt;&gt;
+
+  &lt;&lt;if _fsNames.length eq 1&gt;&gt;The &lt;&lt;defParish &quot;parish&quot;&gt;&gt; &lt;&lt;defOverseersOfThePoor &quot;Overseers of the Poor&quot;&gt;&gt; have taken your _fsNames[0].relationship, _fsNames[0].name, and bound _fsNames[0].heshe into service with another family.
+  &lt;&lt;else&gt;&gt;The &lt;&lt;defParish &quot;parish&quot;&gt;&gt; &lt;&lt;defOverseersOfThePoor &quot;Overseers of the Poor&quot;&gt;&gt; have taken your &lt;&lt;for _fn = 0; _fn &lt; _fsNames.length; _fn++&gt;&gt;&lt;&lt;if _fn &lt; _fsNames.length - 1&gt;&gt;_fsNames[_fn].relationship _fsNames[_fn].name, &lt;&lt;else&gt;&gt;and _fsNames[_fn].relationship _fsNames[_fn].name&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt; and bound them into service.
+  &lt;&lt;if random(1,2) is 1&gt;&gt; They have been placed together in the same household.&lt;&lt;else&gt;&gt; They have been separated and placed in different households.&lt;&lt;/if&gt;&gt;
+  &lt;&lt;/if&gt;&gt;
+  &lt;&lt;if _fsInfantNames.length gt 0&gt;&gt; Your &lt;&lt;print _fsInfantNames.join(&quot; and &quot;)&gt;&gt; &lt;&lt;if _fsInfantNames.length eq 1&gt;&gt;remains&lt;&lt;else&gt;&gt;remain&lt;&lt;/if&gt;&gt; with you, too young to be put into service.&lt;&lt;/if&gt;&gt;
+  &lt;br&gt;&lt;br&gt;
+
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="115" name="june-1665-helper-widget" tags="widget" position="1475,325" size="100,100">&lt;&lt;widget &quot;june-1665-helper&quot;&gt;&gt;
 &lt;&lt;nobr&gt;&gt;
 The &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; grows worse and the streets are soon filled with coaches and wagons full of people fleeing with their goods to the countryside. The &lt;&lt;defQueenMother &quot;Queen Mother&quot;&gt;&gt; &lt;&lt;defHenriettaMaria &quot;Henrietta Maria&quot;&gt;&gt; moves back to France&lt;&lt;if $religion is &quot;Catholic&quot;&gt;&gt;, much to your dismay, and that of your fellow Catholics who flock to her chapel each week&lt;&lt;else&gt;&gt;, much to your relief, and that of all your fellow God-fearing &lt;&lt;defProtestants &quot;Protestants&quot;&gt;&gt;&lt;&lt;/if&gt;&gt;. On June 29th, the King packs up his entire &lt;&lt;defHousehold &quot;household&quot;&gt;&gt; in 148 carriages and moves 12 miles away, to his palace at &lt;&lt;defHamptonCourt &quot;Hampton Court&quot;&gt;&gt;.

--- a/variables.md
+++ b/variables.md
@@ -681,6 +681,14 @@ This document lists all global (story) variables used in **Gaming the Great Plag
 - **Used for:** In the `church-services` widget (pid 115), when `$debtForcedAttend is 1` and `$money lt 0`, the player is automatically enrolled in Church of England services (2% plague infection risk) with a message explaining they cannot afford the fine for non-attendance. Once `$money` recovers to &ge; 0, the normal three-way choice (always skip / skip this month / attend) is presented again.
 - **Dependencies:** Interacts with `$skipServices`, `$money`, `$religion`, and `$plagueInfection`.
 
+### `$childServiceOffered`
+- **Type:** Integer (month index)
+- **Possible values:** `-1` (never offered), or a valid `$monthIndex` value (0–21)
+- **Initial value:** `-1` (set in `StoryInit`, pid 10)
+- **Set by:** The `child-service-check` widget (pid 114) sets this to the current `$monthIndex` when the voluntary child-service choice is presented to the player. This prevents the same choice from being offered more than once per month.
+- **Used for:** Gate in the `child-service-check` widget — the widget only fires when `$childServiceOffered isnot $monthIndex`, ensuring the player is not repeatedly asked about putting children into service during the same month.
+- **Dependencies:** Interacts with `$money` (trigger condition: `$money lte 0`), `$socio` (only fires for `"beggars"`, `"day labourers"`, `"artisans"`), `$monthIndex` (comparison key), and `$NPCs` (checks for eligible child/adolescent NPCs).
+
 ### `$timeline`
 - **Type:** Array of strings
 - **Value:** `["December 1664", "January 1665", "May 1665", "June 1665", "July 1665", "August 1665", "September 1665", "October 1665", "November 1665", "December 1665", "January 1666", "February 1666", "March 1666", "April 1666", "May 1666", "June 1666", "July 1666", "August 1666", "September 1666", "October 1666", "November 1666", "December 1666"]`


### PR DESCRIPTION
Two new widgets for putting children into service when household finances collapse:

- child-service-check (voluntary): When $money <= 0 for beggars/day labourers/artisans, offers to put the eldest child/adolescent into service (PC or NPC). PC children can choose to go into service as a servant. Adult PCs can send their eldest child. HoH gating adjusts text for married women. Fires once per month.

- forced-child-service (at debtor threshold): When debt ceiling is exceeded, all children, adolescents, and young adults (agenum <= 21) are forcibly removed by the parish Overseers of the Poor. Includes PC if eligible. Infants always remain with parents. Siblings may be placed together or separated (flavor text).

Integration: child-service-check runs in PassageHeader between debt-check and debtor. forced-child-service runs at the start of the prison widget and skips prison logic if the PC is put into service.

New variable: $childServiceOffered (tracks month to prevent repeat offers).

https://claude.ai/code/session_01DKsKPZkQvFqnt7JfsENREs