### PR TITLE
Fix incorrect pid references for Claude-widgets passage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ When asked to **analyze, review, search, or edit** passage text from the Twine f
 ### Passage creation rules
 
 - **Do not create new passages.** The `patch.js` script can only update existing `<tw-passagedata>` elements matched by `pid`. It cannot insert new passages into the HTML. Any new passage added to `passages.json` will be silently ignored during patching and will not appear in the game. Only the Twine editor can create new passages.
-- **New widgets go in the Claude-widgets passage (pid 115).** When you need to define a new `<<widget>>`, append its `<<widget "name">>...<</widget>>` block to the file `passages/115-Claude-widgets.txt`. Do not attempt to create a separate widget passage.
+- **New widgets go in the Claude-widgets passage (pid 114).** When you need to define a new `<<widget>>`, append its `<<widget "name">>...<</widget>>` block to the file `passages/114-Claude-widgets.txt`. Do not attempt to create a separate widget passage.
 
 ### Additional guardrails
 

--- a/supporting-code/update-passages.js
+++ b/supporting-code/update-passages.js
@@ -126,14 +126,14 @@ const widgetEncoded = encode(widgetPlain);
 
 const passages = JSON.parse(fs.readFileSync('passages.json', 'utf8'));
 
-// --- Update Claude-widgets (pid 115) ---
-const claudeWidgets = passages.find(p => p.pid === '115');
+// --- Update Claude-widgets (pid 114) ---
+const claudeWidgets = passages.find(p => p.pid === '114');
 if (!claudeWidgets) { console.error('Claude-widgets not found!'); process.exit(1); }
 claudeWidgets.content += '\n' + widgetEncoded;
-console.log('Added NPC-death widget to Claude-widgets (pid 115)');
+console.log('Added NPC-death widget to Claude-widgets (pid 114)');
 
-// --- Update random-events widget (pid 114) ---
-const randomEvents = passages.find(p => p.pid === '114');
+// --- Update random-events widget (pid 113) ---
+const randomEvents = passages.find(p => p.pid === '113');
 if (!randomEvents) { console.error('random-events widget not found!'); process.exit(1); }
 
 const insertMarker = '/* Servant dismissal for bad reputation */';
@@ -146,7 +146,7 @@ randomEvents.content = randomEvents.content.replace(
   insertMarker,
   '/* NPC death from non-plague causes */\n&lt;&lt;NPC-death&gt;&gt;\n\n' + insertMarker
 );
-console.log('Inserted <<NPC-death>> call into random-events widget (pid 114)');
+console.log('Inserted <<NPC-death>> call into random-events widget (pid 113)');
 
 fs.writeFileSync('passages.json', JSON.stringify(passages, null, 2));
 console.log('passages.json updated successfully');


### PR DESCRIPTION
Claude-widgets is pid 114, not 115. Fixed in:
- CLAUDE.md: passage creation rules referenced pid 115 and filename 115-Claude-widgets.txt
- supporting-code/update-passages.js: had pids swapped (115 for Claude-widgets, 114 for random-events); corrected to 114 and 113 respectively

https://claude.ai/code/session_013odMRpVpuVC1rQuKzRqCgR