### PR TITLE
Rebalance plague worker infection and earnings mechanics — bump to v2.74

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.73" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.74" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -5975,36 +5975,39 @@ Unfortunately, you have suffered a miscarriage and are no longer pregnant.
 &lt;&lt;if _cwBuried gt 0&gt;&gt;
 &lt;&lt;set _cwPay to _cwBuried * 4&gt;&gt;
 &lt;&lt;if $role is &quot;corpsebearer&quot; or $role is &quot;searcher&quot;&gt;&gt;&lt;&lt;if $location is &quot;inside the City walls&quot;&gt;&gt;&lt;&lt;set _cwCrew to 2&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set _cwCrew to random(4, 6)&gt;&gt;&lt;&lt;/if&gt;&gt;
+/* Triple crew during peak plague months Aug-Oct 1665 */
+&lt;&lt;if $monthIndex gte 5 and $monthIndex lte 7&gt;&gt;&lt;&lt;set _cwCrew to _cwCrew * 3&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;set _cwPay to Math.trunc(_cwPay / _cwCrew)&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;set $money to Math.clamp($money + _cwPay, 0, Infinity)&gt;&gt;
+/* Occupational infection: re-roll parish infection check (doubles effective chance) */
+&lt;&lt;set _cwRate to $parishRate[$parish][$monthIndex]&gt;&gt;
+&lt;&lt;set _cwInfectPct to Math.round(100 / _cwRate)&gt;&gt;
 &lt;&lt;if $role is &quot;corpsebearer&quot;&gt;&gt;
 You and your fellow corpsebearer&lt;&lt;if _cwCrew gt 2&gt;&gt;s&lt;&lt;/if&gt;&gt; transported &lt;&lt;print _cwBuried&gt;&gt; corpses this month and you were paid &lt;&lt;print _cwPay&gt;&gt;d. by the churchwardens for your service to the parish.
 &lt;&lt;if _cwPlague gt 0&gt;&gt; &lt;&lt;print _cwPlague&gt;&gt; of the dead had plague, may the Lord have mercy on their souls and protect you from sickness.&lt;&lt;/if&gt;&gt;
 &lt;&lt;if $playerPlagueStatus is &quot;healthy&quot; and _cwPlague gt 0&gt;&gt;
-&lt;&lt;set _cwRoll to random(1, 100)&gt;&gt;
-&lt;&lt;if _cwRoll lte _cwPlague&gt;&gt;
+&lt;&lt;if random(1, _cwRate) eq 1&gt;&gt;
 &lt;&lt;set $plagueInfection to 1&gt;&gt;
 &lt;&lt;/if&gt;&gt;
-&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Transported plague corpses&quot;, money: _cwPay, repDelta: 0, repBefore: $reputation, infectPct: _cwPlague})&gt;&gt;
+&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Transported plague corpses&quot;, money: _cwPay, repDelta: 0, repBefore: $reputation, infectPct: _cwInfectPct})&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;elseif $role is &quot;searcher&quot;&gt;&gt;
 You and your fellow searcher&lt;&lt;if _cwCrew gt 2&gt;&gt;s&lt;&lt;/if&gt;&gt; examined &lt;&lt;print _cwBuried&gt;&gt; corpses this month and you were paid &lt;&lt;print _cwPay&gt;&gt;d. by the churchwardens for your service to the parish.
  You determined &lt;&lt;print _cwPlague&gt;&gt; of the dead had plague, may the Lord have mercy on their souls and protect you from sickness.
 &lt;&lt;if $playerPlagueStatus is &quot;healthy&quot; and _cwPlague gt 0&gt;&gt;
-&lt;&lt;set _cwRoll to random(1, 100)&gt;&gt;
-&lt;&lt;if _cwRoll lte _cwPlague&gt;&gt;
+&lt;&lt;if random(1, _cwRate) eq 1&gt;&gt;
 &lt;&lt;set $plagueInfection to 1&gt;&gt;
 &lt;&lt;/if&gt;&gt;
+&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Examined plague corpses&quot;, money: _cwPay, repDelta: 0, repBefore: $reputation, infectPct: _cwInfectPct})&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;elseif $role is &quot;nurse&quot;&gt;&gt;
 You tended to the sick in your parish this month and were paid &lt;&lt;print _cwPay&gt;&gt;d. by the churchwardens for your service.
 &lt;&lt;if _cwPlague gt 0&gt;&gt; &lt;&lt;print _cwPlague&gt;&gt; of your patients had plague, may the Lord have mercy on their souls and protect you from sickness.&lt;&lt;/if&gt;&gt;
 &lt;&lt;if $playerPlagueStatus is &quot;healthy&quot; and _cwPlague gt 0&gt;&gt;
-&lt;&lt;set _cwRoll to random(1, 100)&gt;&gt;
-&lt;&lt;if _cwRoll lte _cwPlague&gt;&gt;
+&lt;&lt;if random(1, _cwRate) eq 1&gt;&gt;
 &lt;&lt;set $plagueInfection to 1&gt;&gt;
 &lt;&lt;/if&gt;&gt;
-&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Nursed plague patients&quot;, money: _cwPay, repDelta: 0, repBefore: $reputation, infectPct: _cwPlague})&gt;&gt;
+&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Nursed plague patients&quot;, money: _cwPay, repDelta: 0, repBefore: $reputation, infectPct: _cwInfectPct})&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;elseif $role is &quot;warder&quot;&gt;&gt;
 &lt;&lt;set _cwWarderPay to 48&gt;&gt;
@@ -6012,12 +6015,10 @@ You tended to the sick in your parish this month and were paid &lt;&lt;print _cw
 You stood guard outside quarantined houses this month and were paid &lt;&lt;print _cwWarderPay&gt;&gt;d. by the churchwardens for your service to the parish.
 &lt;&lt;if _cwPlague gt 0&gt;&gt; &lt;&lt;print _cwPlague&gt;&gt; of the shut-up houses had plague, may the Lord have mercy on their souls and protect you from sickness.&lt;&lt;/if&gt;&gt;
 &lt;&lt;if $playerPlagueStatus is &quot;healthy&quot; and _cwPlague gt 0&gt;&gt;
-&lt;&lt;set _cwWarderRisk to Math.min(_cwPlague * 2, 100)&gt;&gt;
-&lt;&lt;set _cwRoll to random(1, 100)&gt;&gt;
-&lt;&lt;if _cwRoll lte _cwWarderRisk&gt;&gt;
+&lt;&lt;if random(1, _cwRate) eq 1&gt;&gt;
 &lt;&lt;set $plagueInfection to 1&gt;&gt;
 &lt;&lt;/if&gt;&gt;
-&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Guarded quarantined houses&quot;, money: _cwWarderPay, repDelta: 0, repBefore: $reputation, infectPct: _cwWarderRisk})&gt;&gt;
+&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Guarded quarantined houses&quot;, money: _cwWarderPay, repDelta: 0, repBefore: $reputation, infectPct: _cwInfectPct})&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;br&gt;&lt;br&gt;
@@ -6783,12 +6784,7 @@ The &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; grows worse and the streets are
             &lt;&lt;if $role is &quot;corpsebearer&quot; or $role is &quot;searcher&quot; or $role is &quot;nurse&quot; or $role is &quot;warder&quot;&gt;&gt;
                 &lt;&lt;plague-work&gt;&gt;
                 &lt;br&gt;&lt;br&gt;Do you:
-                &lt;ul&gt;&lt;li&gt;
-                    &lt;&lt;if _fumes gt 0&gt;&gt;
-                        &lt;&lt;if random(1,6) is 1&gt;&gt;[[swallow your fears and go to do your Christian duty.-&gt;July 1665][$plagueInfection to 1]]&lt;&lt;else&gt;&gt;[[swallow your fears and go to do your Christian duty.-&gt;July 1665]]&lt;&lt;/if&gt;&gt;                
-                    &lt;&lt;else&gt;&gt;
-                        &lt;&lt;if random(1,3) eq 1&gt;&gt;[[swallow your fears and go to do your Christian duty.-&gt;July 1665][$plagueInfection to 1]]&lt;&lt;else&gt;&gt;[[swallow your fears and go to do your Christian duty.-&gt;July 1665]]&lt;&lt;/if&gt;&gt;
-                    &lt;&lt;/if&gt;&gt;&lt;/li&gt;
+                &lt;ul&gt;&lt;li&gt;[[swallow your fears and go to do your Christian duty.-&gt;July 1665]]&lt;/li&gt;
                     &lt;li&gt;[[refuse to do as you&#39;ve been tasked.-&gt;work-refusal][$reputation to 0]]&lt;/li&gt;
                 &lt;/ul&gt;
 			&lt;&lt;else&gt;&gt;No one has any charity right now for a healthy &lt;&lt;defBeggars &quot;beggar&quot;&gt;&gt;, but somehow you manage to scrape together enough food to last you to [[July 1665]].
@@ -6797,12 +6793,7 @@ The &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; grows worse and the streets are
             &lt;&lt;if $role is &quot;corpsebearer&quot; or $role is &quot;searcher&quot; or $role is &quot;nurse&quot; or $role is &quot;warder&quot;&gt;&gt;
                 &lt;&lt;plague-work&gt;&gt;
                 &lt;br&gt;&lt;br&gt;Do you:
-                &lt;ul&gt;&lt;li&gt;
-                &lt;&lt;if _fumes gt 0&gt;&gt;
-                    &lt;&lt;if random(1,6) is 1&gt;&gt;[[swallow your fears and go to do your Christian duty.-&gt;July 1665][$plagueInfection to 1]]&lt;&lt;else&gt;&gt;[[swallow your fears and go to do your Christian duty.-&gt;July 1665]]&lt;&lt;/if&gt;&gt;
-                &lt;&lt;else&gt;&gt;
-                    &lt;&lt;if random(1,3) is 1&gt;&gt;[[swallow your fears and go to do your Christian duty.-&gt;July 1665][$plagueInfection to 1]]&lt;&lt;else&gt;&gt;[[swallow your fears and go to do your Christian duty.-&gt;July 1665]]&lt;&lt;/if&gt;&gt;
-                &lt;&lt;/if&gt;&gt;&lt;/li&gt;
+                &lt;ul&gt;&lt;li&gt;[[swallow your fears and go to do your Christian duty.-&gt;July 1665]]&lt;/li&gt;
                 	&lt;li&gt;[[decide to quit and look for other work.-&gt;July 1665][$reputation to Math.clamp($reputation - 1, 0, 10)]]&lt;/li&gt;
                 &lt;/ul&gt;
 			&lt;&lt;else&gt;&gt;So many people are fleeing the city, there&#39;s plenty of work hauling their belongings to and fro... for now anyway. It&#39;s enough to get you through to [[July 1665]].


### PR DESCRIPTION
- Remove one-time plague infection roll when accepting plague work in June 1665 (both beggar and day labourer paths in june-1665-helper widget)
- Replace corpse-count-based occupational infection with a re-roll of the general parish infection check, effectively doubling monthly infection chance for all plague workers (searcher, corpsebearer, nurse, warder)
- Triple searcher/corpsebearer crew size during peak months Aug-Oct 1665 (monthIndex 5-7), reducing per-worker pay to 1/3 for those months
- Track infection percentage in decision log based on parish rate

https://claude.ai/code/session_01KbDHnp3qQ86GrzaNQd685N