### PR TITLE
Group smallpox/measles contagion messages instead of listing individu…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.75" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.76" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -5775,51 +5775,63 @@ After the dancing and feasting, you go home with your new spouse at your side.&l
 
 /* === Contagion: $NPCs === */
 &lt;&lt;if _npcContagion isnot &quot;&quot;&gt;&gt;
-&lt;&lt;for _di = 0; _di lt $NPCs.length; _di++&gt;&gt;
-&lt;&lt;if $NPCs[_di].health is &quot;healthy&quot;&gt;&gt;
+&lt;&lt;set _contagionDead to []&gt;&gt;&lt;&lt;set _contagionSurvived to []&gt;&gt;
+&lt;&lt;for _di = 0; _di lt $NPCs.length; _di++&gt;&gt;&lt;&lt;if $NPCs[_di].health is &quot;healthy&quot;&gt;&gt;
 &lt;&lt;set _cr to random(1,100)&gt;&gt;
 &lt;&lt;if _npcContagion is &quot;smallpox&quot;&gt;&gt;
-&lt;&lt;if _cr lte 30&gt;&gt;&lt;&lt;set $NPCs[_di].health to &quot;deceased&quot;&gt;&gt;Tragically, your $NPCs[_di].relationship $NPCs[_di].name has also died of smallpox.&lt;br&gt;&lt;&lt;funeral-choice $NPCs[_di]&gt;&gt;
-&lt;&lt;elseif _cr lte 90&gt;&gt;Your $NPCs[_di].relationship $NPCs[_di].name has contracted smallpox but survived.&lt;br&gt;&lt;br&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if _cr lte 30&gt;&gt;&lt;&lt;set $NPCs[_di].health to &quot;deceased&quot;&gt;&gt;&lt;&lt;set _contagionDead.push(_di)&gt;&gt;
+&lt;&lt;elseif _cr lte 90&gt;&gt;&lt;&lt;set _contagionSurvived.push(_di)&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;elseif _npcContagion is &quot;measles&quot;&gt;&gt;
-&lt;&lt;if _cr lte 10&gt;&gt;&lt;&lt;set $NPCs[_di].health to &quot;deceased&quot;&gt;&gt;Tragically, your $NPCs[_di].relationship $NPCs[_di].name has also died of measles.&lt;br&gt;&lt;&lt;funeral-choice $NPCs[_di]&gt;&gt;
-&lt;&lt;elseif _cr lte 90&gt;&gt;Your $NPCs[_di].relationship $NPCs[_di].name has contracted measles but survived.&lt;br&gt;&lt;br&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if _cr lte 10&gt;&gt;&lt;&lt;set $NPCs[_di].health to &quot;deceased&quot;&gt;&gt;&lt;&lt;set _contagionDead.push(_di)&gt;&gt;
+&lt;&lt;elseif _cr lte 90&gt;&gt;&lt;&lt;set _contagionSurvived.push(_di)&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
+&lt;&lt;if _contagionDead.length gt 0&gt;&gt;Tragically, &lt;&lt;for _gi = 0; _gi lt _contagionDead.length; _gi++&gt;&gt;&lt;&lt;if _gi gt 0&gt;&gt; and &lt;&lt;/if&gt;&gt;your $NPCs[_contagionDead[_gi]].relationship $NPCs[_contagionDead[_gi]].name&lt;&lt;/for&gt;&gt; &lt;&lt;if _contagionDead.length eq 1&gt;&gt;has&lt;&lt;else&gt;&gt;have&lt;&lt;/if&gt;&gt; also died of _npcContagion.&lt;br&gt;&lt;&lt;for _gi = 0; _gi lt _contagionDead.length; _gi++&gt;&gt;&lt;&lt;funeral-choice $NPCs[_contagionDead[_gi]]&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if _contagionSurvived.length gt 0&gt;&gt;&lt;&lt;for _gi = 0; _gi lt _contagionSurvived.length; _gi++&gt;&gt;&lt;&lt;if _gi gt 0&gt;&gt; and &lt;&lt;/if&gt;&gt;your $NPCs[_contagionSurvived[_gi]].relationship $NPCs[_contagionSurvived[_gi]].name&lt;&lt;/for&gt;&gt; &lt;&lt;if _contagionSurvived.length eq 1&gt;&gt;has&lt;&lt;else&gt;&gt;have&lt;&lt;/if&gt;&gt; contracted _npcContagion but survived.&lt;br&gt;&lt;br&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 
 /* === Contagion: $NPCsMaster === */
 &lt;&lt;if _masterContagion isnot &quot;&quot;&gt;&gt;
-&lt;&lt;for _di = 0; _di lt $NPCsMaster.length; _di++&gt;&gt;
-&lt;&lt;if $NPCsMaster[_di].health is &quot;healthy&quot;&gt;&gt;
+&lt;&lt;set _contagionDead to []&gt;&gt;&lt;&lt;set _contagionSurvived to []&gt;&gt;
+&lt;&lt;for _di = 0; _di lt $NPCsMaster.length; _di++&gt;&gt;&lt;&lt;if $NPCsMaster[_di].health is &quot;healthy&quot;&gt;&gt;
 &lt;&lt;set _cr to random(1,100)&gt;&gt;
 &lt;&lt;if _masterContagion is &quot;smallpox&quot;&gt;&gt;
-&lt;&lt;if _cr lte 30&gt;&gt;&lt;&lt;set $NPCsMaster[_di].health to &quot;deceased&quot;&gt;&gt;Tragically, the $NPCsMaster[_di].relationship $NPCsMaster[_di].name has also died of smallpox.&lt;br&gt;&lt;&lt;funeral-choice $NPCsMaster[_di]&gt;&gt;
-&lt;&lt;elseif _cr lte 90&gt;&gt;The $NPCsMaster[_di].relationship $NPCsMaster[_di].name has contracted smallpox but survived.&lt;br&gt;&lt;br&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if _cr lte 30&gt;&gt;&lt;&lt;set $NPCsMaster[_di].health to &quot;deceased&quot;&gt;&gt;&lt;&lt;set _contagionDead.push(_di)&gt;&gt;
+&lt;&lt;elseif _cr lte 90&gt;&gt;&lt;&lt;set _contagionSurvived.push(_di)&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;elseif _masterContagion is &quot;measles&quot;&gt;&gt;
-&lt;&lt;if _cr lte 10&gt;&gt;&lt;&lt;set $NPCsMaster[_di].health to &quot;deceased&quot;&gt;&gt;Tragically, the $NPCsMaster[_di].relationship $NPCsMaster[_di].name has also died of measles.&lt;br&gt;&lt;&lt;funeral-choice $NPCsMaster[_di]&gt;&gt;
-&lt;&lt;elseif _cr lte 90&gt;&gt;The $NPCsMaster[_di].relationship $NPCsMaster[_di].name has contracted measles but survived.&lt;br&gt;&lt;br&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if _cr lte 10&gt;&gt;&lt;&lt;set $NPCsMaster[_di].health to &quot;deceased&quot;&gt;&gt;&lt;&lt;set _contagionDead.push(_di)&gt;&gt;
+&lt;&lt;elseif _cr lte 90&gt;&gt;&lt;&lt;set _contagionSurvived.push(_di)&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
+&lt;&lt;if _contagionDead.length gt 0&gt;&gt;Tragically, &lt;&lt;for _gi = 0; _gi lt _contagionDead.length; _gi++&gt;&gt;&lt;&lt;if _gi gt 0&gt;&gt; and &lt;&lt;/if&gt;&gt;the $NPCsMaster[_contagionDead[_gi]].relationship $NPCsMaster[_contagionDead[_gi]].name&lt;&lt;/for&gt;&gt; &lt;&lt;if _contagionDead.length eq 1&gt;&gt;has&lt;&lt;else&gt;&gt;have&lt;&lt;/if&gt;&gt; also died of _masterContagion.&lt;br&gt;&lt;&lt;for _gi = 0; _gi lt _contagionDead.length; _gi++&gt;&gt;&lt;&lt;funeral-choice $NPCsMaster[_contagionDead[_gi]]&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if _contagionSurvived.length gt 0&gt;&gt;&lt;&lt;for _gi = 0; _gi lt _contagionSurvived.length; _gi++&gt;&gt;&lt;&lt;if _gi gt 0&gt;&gt; and &lt;&lt;/if&gt;&gt;the $NPCsMaster[_contagionSurvived[_gi]].relationship $NPCsMaster[_contagionSurvived[_gi]].name&lt;&lt;/for&gt;&gt; &lt;&lt;if _contagionSurvived.length eq 1&gt;&gt;has&lt;&lt;else&gt;&gt;have&lt;&lt;/if&gt;&gt; contracted _masterContagion but survived.&lt;br&gt;&lt;br&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 
 /* === Contagion: $NPCsExtended === */
 &lt;&lt;if _extendedContagion isnot &quot;&quot;&gt;&gt;
-&lt;&lt;for _di = 0; _di lt $NPCsExtended.length; _di++&gt;&gt;
-&lt;&lt;if $NPCsExtended[_di].health is &quot;healthy&quot;&gt;&gt;
+&lt;&lt;set _contagionDead to []&gt;&gt;&lt;&lt;set _contagionSurvived to []&gt;&gt;
+&lt;&lt;for _di = 0; _di lt $NPCsExtended.length; _di++&gt;&gt;&lt;&lt;if $NPCsExtended[_di].health is &quot;healthy&quot;&gt;&gt;
 &lt;&lt;set _cr to random(1,100)&gt;&gt;
 &lt;&lt;if _extendedContagion is &quot;smallpox&quot;&gt;&gt;
-&lt;&lt;if _cr lte 30&gt;&gt;&lt;&lt;set $NPCsExtended[_di].health to &quot;deceased&quot;&gt;&gt;Tragically, your $NPCsExtended[_di].relationship $NPCsExtended[_di].name has also died of smallpox.&lt;br&gt;&lt;&lt;funeral-choice $NPCsExtended[_di]&gt;&gt;
-&lt;&lt;elseif _cr lte 90&gt;&gt;Your $NPCsExtended[_di].relationship $NPCsExtended[_di].name has contracted smallpox but survived.&lt;br&gt;&lt;br&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if _cr lte 30&gt;&gt;&lt;&lt;set $NPCsExtended[_di].health to &quot;deceased&quot;&gt;&gt;&lt;&lt;set _contagionDead.push(_di)&gt;&gt;
+&lt;&lt;elseif _cr lte 90&gt;&gt;&lt;&lt;set _contagionSurvived.push(_di)&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;elseif _extendedContagion is &quot;measles&quot;&gt;&gt;
-&lt;&lt;if _cr lte 10&gt;&gt;&lt;&lt;set $NPCsExtended[_di].health to &quot;deceased&quot;&gt;&gt;Tragically, your $NPCsExtended[_di].relationship $NPCsExtended[_di].name has also died of measles.&lt;br&gt;&lt;&lt;funeral-choice $NPCsExtended[_di]&gt;&gt;
-&lt;&lt;elseif _cr lte 90&gt;&gt;Your $NPCsExtended[_di].relationship $NPCsExtended[_di].name has contracted measles but survived.&lt;br&gt;&lt;br&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if _cr lte 10&gt;&gt;&lt;&lt;set $NPCsExtended[_di].health to &quot;deceased&quot;&gt;&gt;&lt;&lt;set _contagionDead.push(_di)&gt;&gt;
+&lt;&lt;elseif _cr lte 90&gt;&gt;&lt;&lt;set _contagionSurvived.push(_di)&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
+&lt;&lt;if _contagionDead.length gt 0&gt;&gt;Tragically, &lt;&lt;for _gi = 0; _gi lt _contagionDead.length; _gi++&gt;&gt;&lt;&lt;if _gi gt 0&gt;&gt; and &lt;&lt;/if&gt;&gt;your $NPCsExtended[_contagionDead[_gi]].relationship $NPCsExtended[_contagionDead[_gi]].name&lt;&lt;/for&gt;&gt; &lt;&lt;if _contagionDead.length eq 1&gt;&gt;has&lt;&lt;else&gt;&gt;have&lt;&lt;/if&gt;&gt; also died of _extendedContagion.&lt;br&gt;&lt;&lt;for _gi = 0; _gi lt _contagionDead.length; _gi++&gt;&gt;&lt;&lt;funeral-choice $NPCsExtended[_contagionDead[_gi]]&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if _contagionSurvived.length gt 0&gt;&gt;&lt;&lt;for _gi = 0; _gi lt _contagionSurvived.length; _gi++&gt;&gt;&lt;&lt;if _gi gt 0&gt;&gt; and &lt;&lt;/if&gt;&gt;your $NPCsExtended[_contagionSurvived[_gi]].relationship $NPCsExtended[_contagionSurvived[_gi]].name&lt;&lt;/for&gt;&gt; &lt;&lt;if _contagionSurvived.length eq 1&gt;&gt;has&lt;&lt;else&gt;&gt;have&lt;&lt;/if&gt;&gt; contracted _extendedContagion but survived.&lt;br&gt;&lt;br&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 
 /* === Contagion: $NPCsServants === */
 &lt;&lt;if _servantsContagion isnot &quot;&quot;&gt;&gt;
-&lt;&lt;for _di = 0; _di lt $NPCsServants.length; _di++&gt;&gt;
-&lt;&lt;if $NPCsServants[_di].health is &quot;healthy&quot;&gt;&gt;
+&lt;&lt;set _contagionDead to []&gt;&gt;&lt;&lt;set _contagionSurvived to []&gt;&gt;
+&lt;&lt;for _di = 0; _di lt $NPCsServants.length; _di++&gt;&gt;&lt;&lt;if $NPCsServants[_di].health is &quot;healthy&quot;&gt;&gt;
 &lt;&lt;set _cr to random(1,100)&gt;&gt;
 &lt;&lt;if _servantsContagion is &quot;smallpox&quot;&gt;&gt;
-&lt;&lt;if _cr lte 30&gt;&gt;&lt;&lt;set $NPCsServants[_di].health to &quot;deceased&quot;&gt;&gt;Tragically, your servant $NPCsServants[_di].name has also died of smallpox.&lt;br&gt;&lt;&lt;funeral-choice $NPCsServants[_di]&gt;&gt;
-&lt;&lt;elseif _cr lte 90&gt;&gt;Your servant $NPCsServants[_di].name has contracted smallpox but survived.&lt;br&gt;&lt;br&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if _cr lte 30&gt;&gt;&lt;&lt;set $NPCsServants[_di].health to &quot;deceased&quot;&gt;&gt;&lt;&lt;set _contagionDead.push(_di)&gt;&gt;
+&lt;&lt;elseif _cr lte 90&gt;&gt;&lt;&lt;set _contagionSurvived.push(_di)&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;elseif _servantsContagion is &quot;measles&quot;&gt;&gt;
-&lt;&lt;if _cr lte 10&gt;&gt;&lt;&lt;set $NPCsServants[_di].health to &quot;deceased&quot;&gt;&gt;Tragically, your servant $NPCsServants[_di].name has also died of measles.&lt;br&gt;&lt;&lt;funeral-choice $NPCsServants[_di]&gt;&gt;
-&lt;&lt;elseif _cr lte 90&gt;&gt;Your servant $NPCsServants[_di].name has contracted measles but survived.&lt;br&gt;&lt;br&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if _cr lte 10&gt;&gt;&lt;&lt;set $NPCsServants[_di].health to &quot;deceased&quot;&gt;&gt;&lt;&lt;set _contagionDead.push(_di)&gt;&gt;
+&lt;&lt;elseif _cr lte 90&gt;&gt;&lt;&lt;set _contagionSurvived.push(_di)&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
+&lt;&lt;if _contagionDead.length gt 0&gt;&gt;Tragically, &lt;&lt;for _gi = 0; _gi lt _contagionDead.length; _gi++&gt;&gt;&lt;&lt;if _gi gt 0&gt;&gt; and &lt;&lt;/if&gt;&gt;your servant $NPCsServants[_contagionDead[_gi]].name&lt;&lt;/for&gt;&gt; &lt;&lt;if _contagionDead.length eq 1&gt;&gt;has&lt;&lt;else&gt;&gt;have&lt;&lt;/if&gt;&gt; also died of _servantsContagion.&lt;br&gt;&lt;&lt;for _gi = 0; _gi lt _contagionDead.length; _gi++&gt;&gt;&lt;&lt;funeral-choice $NPCsServants[_contagionDead[_gi]]&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if _contagionSurvived.length gt 0&gt;&gt;&lt;&lt;for _gi = 0; _gi lt _contagionSurvived.length; _gi++&gt;&gt;&lt;&lt;if _gi gt 0&gt;&gt; and &lt;&lt;/if&gt;&gt;your servant $NPCsServants[_contagionSurvived[_gi]].name&lt;&lt;/for&gt;&gt; &lt;&lt;if _contagionSurvived.length eq 1&gt;&gt;has&lt;&lt;else&gt;&gt;have&lt;&lt;/if&gt;&gt; contracted _servantsContagion but survived.&lt;br&gt;&lt;br&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 &lt;&lt;servant-master-death&gt;&gt;
 &lt;&lt;check-widowed&gt;&gt;
 &lt;&lt;set-hoh&gt;&gt;


### PR DESCRIPTION
…ally — bump to v2.76

Rewrite the four contagion sections in the NPC-death widget so that deaths and survivals from disease spread are collected into arrays and then displayed as grouped sentences (e.g. "Tragically, your daughter Dorothy and your son James have also died of smallpox.") instead of one line per NPC. Funeral choices still appear individually for each deceased NPC.

https://claude.ai/code/session_01YRnbiPTRgo8nM31Ri6TwFt