### PR TITLE
Fix plague infection display to combine all NPC types into one sentence

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.76" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.77" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -3066,24 +3066,19 @@ As morning dawns, a terrible realization settles over your &lt;&lt;defHousehold 
                 &lt;&lt;/if&gt;&gt;
             &lt;&lt;/for&gt;&gt;
         &lt;&lt;/if&gt;&gt;&lt;&lt;/silently&gt;&gt;
-        &lt;&lt;for _n, _idx range _infectedFamily&gt;&gt;
-            &lt;&lt;if _infectedFamily.length eq 1&gt;&gt;
-        $NPCs[_idx].relationship $NPCs[_idx].name is infected with the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt;.&lt;br&gt;
-        &lt;&lt;elseif _n &lt; _infectedFamily.length - 1&gt;&gt;$NPCs[_idx].relationship, $NPCs[_idx].name,&lt;&lt;else&gt;&gt; and $NPCs[_idx].relationship, $NPCs[_idx].name are infected with the plague.&lt;br&gt;
-        &lt;&lt;/if&gt;&gt;
+        &lt;&lt;set _allInfected to []&gt;&gt;
+        &lt;&lt;for _idx range _infectedFamily&gt;&gt;
+            &lt;&lt;set _allInfected.push({rel: $NPCs[_idx].relationship, name: $NPCs[_idx].name})&gt;&gt;
         &lt;&lt;/for&gt;&gt;
-        &lt;&lt;for _n, _idx range _infectedServants&gt;&gt;
-            &lt;&lt;if _infectedServants.length eq 1&gt;&gt;
-        Your $NPCsServants[_idx].relationship $NPCsServants[_idx].name is infected with the plague.&lt;br&gt;
-        &lt;&lt;elseif _n &lt; _infectedServants.length - 1&gt;&gt;$NPCsServants[_idx].relationship, $NPCsServants[_idx].name,&lt;&lt;else&gt;&gt; and $NPCsServants[_idx].relationship, $NPCsServants[_idx].name are infected with the plague.&lt;br&gt;
-        &lt;&lt;/if&gt;&gt;
+        &lt;&lt;for _idx range _infectedServants&gt;&gt;
+            &lt;&lt;set _allInfected.push({rel: $NPCsServants[_idx].relationship, name: $NPCsServants[_idx].name})&gt;&gt;
         &lt;&lt;/for&gt;&gt;
-        &lt;&lt;for _n, _idx range _infectedMaster&gt;&gt;
-            &lt;&lt;if _infectedMaster.length eq 1&gt;&gt;
-        Your $NPCsMaster[_idx].relationship $NPCsMaster[_idx].name is infected with the plague.&lt;br&gt;
-        &lt;&lt;elseif _n &lt; _infectedMaster.length - 1&gt;&gt;$NPCsMaster[_idx].relationship, $NPCsMaster[_idx].name,&lt;&lt;else&gt;&gt; and $NPCsMaster[_idx].relationship, $NPCsMaster[_idx].name are infected with the plague.&lt;br&gt;
-        &lt;&lt;/if&gt;&gt;
+        &lt;&lt;for _idx range _infectedMaster&gt;&gt;
+            &lt;&lt;set _allInfected.push({rel: $NPCsMaster[_idx].relationship, name: $NPCsMaster[_idx].name})&gt;&gt;
         &lt;&lt;/for&gt;&gt;
+        &lt;&lt;if _allInfected.length eq 1&gt;&gt;_allInfected[0].rel _allInfected[0].name is infected with the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt;.&lt;br&gt;
+        &lt;&lt;elseif _allInfected.length gte 2&gt;&gt;&lt;&lt;for _n, _inf range _allInfected&gt;&gt;&lt;&lt;if _n lt _allInfected.length - 1&gt;&gt;_inf.rel, _inf.name, &lt;&lt;else&gt;&gt;and _inf.rel, _inf.name, are infected with the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt;.&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;br&gt;
+        &lt;&lt;/if&gt;&gt;
     &lt;br&gt;
     As a good Christian, it is your duty to look after the poor, sick, and needy. But as a good Christian, you also know it is a sin to needlessly risk your life. &lt;&lt;if $hoh is 0&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;&lt;&lt;set-caretaker&gt;&gt;With your &lt;&lt;print _caretakerLabel&gt;&gt; too ill to make decisions, the responsibility falls to you. Do you&lt;&lt;else&gt;&gt;Do you convince your household to&lt;&lt;/if&gt;&gt;&lt;&lt;elseif $hoh is 2&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;With your &lt;&lt;if $gender is &quot;male&quot;&gt;&gt;father&lt;&lt;else&gt;&gt;parent&lt;&lt;/if&gt;&gt; too ill to make decisions, the responsibility falls to you. Do you&lt;&lt;else&gt;&gt;Do you convince your family to&lt;&lt;/if&gt;&gt;&lt;&lt;elseif $hoh is 3&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;With your $masterTitle too ill to give orders, the decision falls to you. Do you&lt;&lt;else&gt;&gt;Do you convince your $masterTitle to&lt;&lt;/if&gt;&gt;&lt;&lt;elseif $hoh is 4&gt;&gt;&lt;&lt;if _authoritySick&gt;&gt;With your husband too ill to make decisions, you must decide for yourself. Do you&lt;&lt;else&gt;&gt;Do you convince your husband to&lt;&lt;/if&gt;&gt;&lt;&lt;else&gt;&gt;Do you&lt;&lt;/if&gt;&gt;:&lt;ul&gt;
 &lt;li&gt;[[Quarantine with your household-&gt;Quarantine, Week 1][$reputation to Math.clamp($reputation + 3, 0, 10)]]&lt;/li&gt;


### PR DESCRIPTION
When both household NPCs and servant NPCs become infected simultaneously, the sickFam widget now outputs a single combined sentence instead of separate sentences for each NPC type. For example: "Your brother, Thomas, and brother, Francis, and servant, Dorothy, and servant, Elizabeth, are infected with the plague." — bump to v2.77

https://claude.ai/code/session_017P6ZQ6eXCrccCGft4L9gqd