### PR TITLE
Clamp $reputation to 0–10 in storyline-return widget — bump to v2.81

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.80" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.81" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -3374,10 +3374,7 @@ As morning dawns, a terrible realization settles over your &lt;&lt;defHousehold 
     /* Output the link */
     &lt;&lt;link _linkText $timeline[_nextIndex]&gt;&gt;
 	&lt;&lt;set $money += _moneyOffset&gt;&gt;
-	&lt;&lt;set $reputation += _reputationOffset&gt;&gt;
-		&lt;&lt;if $reputation gte 10&gt;&gt;
-        	&lt;&lt;set $reputation to 10&gt;&gt;
-        &lt;&lt;/if&gt;&gt; /* using math clamp elsewhere, revisit this bit of code and check minimums as well */
+	&lt;&lt;set $reputation to Math.clamp($reputation + _reputationOffset, 0, 10)&gt;&gt;
 	&lt;&lt;if _plagueRisk gt 0&gt;&gt;
 		&lt;&lt;if random(1, 100) lte _plagueRisk&gt;&gt;
 			&lt;&lt;set $plagueInfection to 1&gt;&gt;

--- a/reputation-audit.md
+++ b/reputation-audit.md
@@ -71,9 +71,7 @@ Starting reputation: **4** (beggars), **6** (default), or **8** (nobles).
 
 | Passage (pid) | Line | Mechanism |
 |---|---|---|
-| `041-storyline-return-widget.txt` (pid 41) | 29 | Adds `_reputationOffset` (arg 3) to `$reputation`; capped at 10 but **no floor check** (see note below) |
-
-> **Note:** The `storyline-return` widget uses `$reputation += _reputationOffset` with a ceiling of 10 but does not clamp to 0. This differs from all other reputation changes which use `Math.clamp(..., 0, 10)`. A code comment on line 32 acknowledges this: *"using math clamp elsewhere, revisit this bit of code and check minimums as well"*.
+| `041-storyline-return-widget.txt` (pid 41) | 29 | Adds `_reputationOffset` (arg 3) to `$reputation`; clamped to 0–10 via `Math.clamp` |
 
 ---
 
@@ -207,7 +205,7 @@ Most decisions record `repBefore: $reputation` and `repDelta` in the `$decisions
 
 ### `storyline-return` widget (pid 41)
 
-This widget accepts an optional 4th argument for reputation offset. The reputation change uses `+=` with a ceiling of 10 but **no floor of 0**, unlike all other reputation changes that use `Math.clamp($reputation ± N, 0, 10)`. This is a known inconsistency acknowledged in a code comment.
+This widget accepts an optional 4th argument for reputation offset. The reputation change uses `Math.clamp($reputation + _reputationOffset, 0, 10)`, consistent with all other reputation changes in the codebase.
 
 ### Church attendance (`115-june-1665-helper-widget.txt`, pid 115)
 


### PR DESCRIPTION
Replace the ceiling-only cap (`$reputation += _reputationOffset` with `if gte 10` guard) with `Math.clamp($reputation + _reputationOffset, 0, 10)`, consistent with all other reputation changes in the codebase. Update reputation-audit.md to reflect the fix.

https://claude.ai/code/session_01Cj8iiQjnNDVJ1DCT9izdhm