### PR TITLE
Fix plague concealment: single -3 rep, 12p pesthouse fee, route throu…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.82" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.83" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -1708,6 +1708,7 @@ John: 1500, Thomas: 1300, William: 1300, Richard: 620, Robert: 600, Henry: 500, 
 &lt;&lt;set $lodgerRent to 0&gt;&gt;
 &lt;&lt;set $quarantine to 0&gt;&gt;
 &lt;&lt;set $plagueRevealed to 0&gt;&gt;
+&lt;&lt;set $pesthouseReparation to 0&gt;&gt;
 &lt;&lt;set $timeline to [&quot;December 1664&quot;, &quot;January 1665&quot;, &quot;May 1665&quot;, &quot;June 1665&quot;, &quot;July 1665&quot;, &quot;August 1665&quot;, &quot;September 1665&quot;, &quot;October 1665&quot;, &quot;November 1665&quot;, &quot;December 1665&quot;, &quot;January 1666&quot;, &quot;February 1666&quot;, &quot;March 1666&quot;, &quot;April 1666&quot;, &quot;May 1666&quot;, &quot;June 1666&quot;, &quot;July 1666&quot;, &quot;August 1666&quot;, &quot;September 1666&quot;, &quot;October 1666&quot;, &quot;November 1666&quot;, &quot;December 1666&quot;
 ]&gt;&gt;
 &lt;&lt;initDeathData&gt;&gt;
@@ -2972,7 +2973,14 @@ It is a difficult decision, but &lt;&lt;if $hoh is 0&gt;&gt;&lt;&lt;if _authorit
 &lt;&lt;if $reputation lte 2&gt;&gt;To your horror, rumors swirl that your family have actually murdered a member of your household and hidden the body! &lt;&lt;if $murder gte 1&gt;&gt; Remembering the rumors of murder that circulated last time  your family sent someone to the household, you &lt;&lt;/if&gt;&gt;&lt;&lt;if $murder lte 1&gt;&gt;You&lt;&lt;/if&gt;&gt; send to the master of the pesthouse to produce a certificate for you that proves the rumor is a lie.
 &lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;&lt;&lt;set $murder =1&gt;&gt;
 &lt;&lt;/if&gt;&gt;
-&lt;&lt;set $money -= 5&gt;&gt;
+/* Charge 12p per person sent to the pesthouse, if funds are available */
+&lt;&lt;silently&gt;&gt;
+&lt;&lt;set _pesthouseCount to 0&gt;&gt;
+&lt;&lt;for _pi = 0; _pi &lt; $NPCs.length; _pi++&gt;&gt;&lt;&lt;if $NPCs[_pi].health is &quot;infected&quot;&gt;&gt;&lt;&lt;set _pesthouseCount += 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
+&lt;&lt;for _pi = 0; _pi &lt; $NPCsServants.length; _pi++&gt;&gt;&lt;&lt;if $NPCsServants[_pi].health is &quot;infected&quot;&gt;&gt;&lt;&lt;set _pesthouseCount += 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
+&lt;&lt;set _pesthouseFee to _pesthouseCount * 12&gt;&gt;
+&lt;&lt;if $money gte _pesthouseFee&gt;&gt;&lt;&lt;set $money -= _pesthouseFee&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/silently&gt;&gt;
 
 &lt;&lt;silently&gt;&gt;
 /* Resolve infected household NPCs at the pesthouse */
@@ -3386,27 +3394,37 @@ As morning dawns, a terrible realization settles over your &lt;&lt;defHousehold 
 You attempt to hide your illness from everyone, hoping that if you just ignore it then the lump will go away.&lt;br&gt;&lt;br&gt;
 Unfortunately, that&#39;s not how &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; works. The lump gets bigger and is soon joined by even more lumps. They are now undeniably plague &lt;&lt;defBuboes &quot;buboes&quot;&gt;&gt;. 
 &lt;br&gt;&lt;br&gt;
-&lt;&lt;if $socio is &quot;nobles&quot;&gt;&gt;The King is furious at your deception and [[banishes you to your country estate-&gt;banished][$reputation to Math.clamp($reputation - 3, 0, 10)]]. &lt;&lt;else&gt;&gt;Your neighbors realize you attempted to hide your sickness and decide you can no longer be trusted. Not only do they shut up your household, they also conspire to have you [[removed to the pesthouse-&gt;YouPesthouse][$reputation to Math.clamp($reputation - 3, 0, 10)]]&lt;&lt;if $socio is &quot;merchants&quot;&gt;&gt; despite your high social status &lt;&lt;/if&gt;&gt; to keep the plague from spreading further.&lt;&lt;/if&gt;&gt;
+&lt;&lt;if $socio is &quot;nobles&quot;&gt;&gt;The King is furious at your deception and [[banishes you to your country estate-&gt;banished]]. &lt;&lt;else&gt;&gt;Your neighbors realize you attempted to hide your sickness and decide you can no longer be trusted. Not only do they shut up your household, they also conspire to have you [[removed to the pesthouse-&gt;YouPesthouse]]&lt;&lt;if $socio is &quot;merchants&quot;&gt;&gt; despite your high social status &lt;&lt;/if&gt;&gt; to keep the plague from spreading further.&lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="43" name="banished" tags="" position="1775,350" size="100,100">&lt;&lt;nobr&gt;&gt;&lt;&lt;set $plagueInfection to 2&gt;&gt;All but the most loyal—or desperate—servants flee from your country estate. The villagers refuse to receive your servants and even the local priest hesitates to come pray for you.
 &lt;&lt;linkreplace &quot;You take to your sickbed as your fever spikes and you fear for your life.&quot;&gt;&gt;&lt;&lt;linkreplace &quot;It occurs to you that perhaps you ought to write your will.&quot;&gt;&gt;
 &lt;&lt;if random(1,2) is 1&gt;&gt;Luckily, you will be too delirious to notice that the remainder of your servants all abandon you in the hours before your [[death]].
-&lt;&lt;else&gt;&gt;Luckily, despite your disgrace, your final few servants stay by your side, praying for your life and administering every &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; remedy known to mankind. 
+&lt;&lt;else&gt;&gt;Luckily, despite your disgrace, your final few servants stay by your side, praying for your life and administering every &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; remedy known to mankind.
 &lt;br&gt;&lt;br&gt;
 &lt;&lt;set $playerPlagueStatus to &quot;recovered&quot;&gt;&gt;You don&#39;t know which helps more, but after a few days you feel your fever break and your &lt;&lt;defBuboes &quot;buboes&quot;&gt;&gt; begin to go down. Thanks be to God, you have survived the plague.
 &lt;br&gt;&lt;br&gt;
+&lt;&lt;orphan-check&gt;&gt;
 Now you just have to figure out how to overcome your disgrace and find your way back into the King&#39;s good graces. Groveling will obviously have to be involved, but that won&#39;t be enough. Do you also:&lt;br&gt;
+&lt;&lt;if $hoh is 1&gt;&gt;
 &lt;ul&gt;
-&lt;li&gt;&lt;&lt;storyline-return &quot;help him find his next mistress.&quot; 1 -12800 -1&gt;&gt;&lt;/li&gt;
-&lt;li&gt;&lt;&lt;storyline-return &quot;give him money to fund the war effort&quot; 1 -25600 1&gt;&gt;&lt;/li&gt;
+&lt;li&gt;&lt;&lt;linkreplace &quot;help him find his next mistress&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;&lt;&lt;set $money -= $income&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Helped the King find his next mistress&quot;, money: 0 - $income, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: null})&gt;&gt;&lt;&lt;set $pesthouseReparation to 1&gt;&gt;[[You hope the King&#39;s favor will be restored soon enough.-&gt;Reconnecting]]&lt;&lt;/linkreplace&gt;&gt;&lt;/li&gt;
+&lt;li&gt;&lt;&lt;linkreplace &quot;give him money to fund the war effort&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;&lt;&lt;set $money -= $income&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Gave the King money to fund the war effort&quot;, money: 0 - $income, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: null})&gt;&gt;&lt;&lt;set $pesthouseReparation to 1&gt;&gt;[[You hope the King&#39;s favor will be restored soon enough.-&gt;Reconnecting]]&lt;&lt;/linkreplace&gt;&gt;&lt;/li&gt;
+&lt;li&gt;&lt;&lt;linkreplace &quot;write a letter to the Queen begging her to intercede on your behalf&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Wrote to the Queen begging her to intercede&quot;, money: 0, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: null})&gt;&gt;&lt;&lt;set $pesthouseReparation to 1&gt;&gt;[[You hope the King&#39;s favor will be restored soon enough.-&gt;Reconnecting]]&lt;&lt;/linkreplace&gt;&gt;&lt;/li&gt;
+&lt;li&gt;&lt;&lt;linkreplace &quot;write a letter to the King with poems composed in his honor&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Wrote poems in the King&#39;s honor&quot;, money: 0, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: null})&gt;&gt;&lt;&lt;set $pesthouseReparation to 1&gt;&gt;[[You hope the King&#39;s favor will be restored soon enough.-&gt;Reconnecting]]&lt;&lt;/linkreplace&gt;&gt;&lt;/li&gt;
 &lt;/ul&gt;
+&lt;&lt;else&gt;&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;&lt;linkreplace &quot;write a letter to the Queen begging her to intercede on your behalf&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Wrote to the Queen begging her to intercede&quot;, money: 0, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: null})&gt;&gt;&lt;&lt;set $pesthouseReparation to 1&gt;&gt;[[You hope the King&#39;s favor will be restored soon enough.-&gt;Reconnecting]]&lt;&lt;/linkreplace&gt;&gt;&lt;/li&gt;
+&lt;li&gt;&lt;&lt;linkreplace &quot;write a letter to the King with poems composed in his honor&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Wrote poems in the King&#39;s honor&quot;, money: 0, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: null})&gt;&gt;&lt;&lt;set $pesthouseReparation to 1&gt;&gt;[[You hope the King&#39;s favor will be restored soon enough.-&gt;Reconnecting]]&lt;&lt;/linkreplace&gt;&gt;&lt;/li&gt;
+&lt;/ul&gt;
+&lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/linkreplace&gt;&gt;
 &lt;&lt;/linkreplace&gt;&gt;
-&lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="44" name="YouPesthouse" tags="infection-rates" position="500,625" size="100,100">&lt;&lt;silently&gt;&gt;&lt;&lt;set $plagueInfection to 2&gt;&gt;&lt;&lt;set $money -= 5&gt;&gt;&lt;&lt;/silently&gt;&gt;
+&lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="44" name="YouPesthouse" tags="infection-rates" position="500,625" size="100,100">&lt;&lt;silently&gt;&gt;&lt;&lt;set $plagueInfection to 2&gt;&gt;&lt;&lt;if $money gte 12&gt;&gt;&lt;&lt;set $money -= 12&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/silently&gt;&gt;
 &lt;&lt;nobr&gt;&gt;
 The &lt;&lt;defPesthouse &quot;pesthouse&quot;&gt;&gt; is a terrible place to be confined, with countless sick people all crammed in close together so you can hear their every moan. They die terrifyingly fast and their cots refill just as quickly. You toss and turn in your dirty, sweat-soaked sheets, as your fever spikes and you fear for your life.
 &lt;br&gt;&lt;br&gt;
-&lt;&lt;if $socio is &quot;merchants&quot;&gt;&gt;It occurs to you that perhaps you ought to have written your will, but your reputation is so poor and the pesthouse is so terrifying that no one can be convinced to bring you the writing materials you need.&lt;br&gt;&lt;&lt;elseif $socio is &quot;artisans&quot;&gt;&gt;It occurs to you that perhaps you ought to have written your will, but your reputation is so poor and the pesthouse is so terrifying that you can&#39;t convince a &lt;&lt;defScrivener &quot;scrivener&quot;&gt;&gt; to come help you.&lt;br&gt;&lt;br&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if $socio is &quot;merchants&quot;&gt;&gt;It occurs to you that perhaps you ought to have written your will, but your reputation is so poor and the pesthouse is so terrifying that no one can be convinced to bring you the writing materials you need.&lt;br&gt;&lt;br&gt;&lt;&lt;elseif $socio is &quot;artisans&quot;&gt;&gt;It occurs to you that perhaps you ought to have written your will, but your reputation is so poor and the pesthouse is so terrifying that you can&#39;t convince a &lt;&lt;defScrivener &quot;scrivener&quot;&gt;&gt; to come help you.&lt;br&gt;&lt;br&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;if random(1,2) is 1&gt;&gt;Luckily, you will grow too delirious to notice how miserable you are in the hours before your [[death]].&lt;&lt;else&gt;&gt;You spend all your remaining energy in prayer that God will spare you from death. &lt;&lt;set $playerPlagueStatus to &quot;recovered&quot;&gt;&gt;Despite the neglect of the overworked pesthouse staff, after a few days you feel your fever break and your &lt;&lt;defBuboes &quot;buboes&quot;&gt;&gt; begin to go down. Thanks be to God, you have survived the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt;.
 &lt;br&gt;&lt;br&gt;
 &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/5/58/The_pest_house_and_plague_pit%2C_Moorfields%2C_London._Wellcome_V0013229.jpg&quot; width=&quot;100%&quot;&gt;
@@ -3415,22 +3433,26 @@ The &lt;&lt;defPesthouse &quot;pesthouse&quot;&gt;&gt; is a terrible place to be
 &lt;br&gt;&lt;br&gt;
 &lt;&lt;orphan-check&gt;&gt;
 Now you just have to figure out how to overcome your disgrace when you return home to your neighborhood. You decide to start by:&lt;br&gt;
-&lt;&lt;if $money gte 2&gt;&gt;
-&lt;&lt;linkreplace &quot;giving all your money to the poor&quot;&gt;&gt;&lt;&lt;set _penanceMoney to $money&gt;&gt;&lt;&lt;set $money to 0&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Gave all money to the poor as penance&quot;, money: 0 - _penanceMoney, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;
-&lt;&lt;storyline-return&gt;&gt;
-&lt;br&gt;
+&lt;&lt;if $hoh is 1 and $money gte $income&gt;&gt;
+&lt;&lt;linkreplace &quot;giving one month&#39;s income to the poor&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $money -= $income&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Gave one month&#39;s income to the poor as penance&quot;, money: 0 - $income, repDelta: 0, repBefore: _repBefore, infectPct: null})&gt;&gt;
+&lt;&lt;set $pesthouseReparation to 1&gt;&gt;[[You pray your penance is enough to restore your good name.-&gt;Reconnecting]]
 &lt;&lt;/linkreplace&gt;&gt;
-&lt;&lt;linkreplace &quot;giving all your money to the poor //and// performing public penance in church&quot;&gt;&gt;&lt;&lt;set _penanceMoney to $money&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;
-&lt;&lt;set $money to 0&gt;&gt;
-&lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;
-&lt;&lt;set $decisions.push({text: &quot;Gave all money and performed public penance&quot;, money: 0 - _penanceMoney, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: null})&gt;&gt;
-&lt;&lt;storyline-return&gt;&gt;
+&lt;&lt;linkreplace &quot;giving one month&#39;s income to the poor //and// performing public penance in church&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $money -= $income&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Gave one month&#39;s income and performed public penance&quot;, money: 0 - $income, repDelta: 0, repBefore: _repBefore, infectPct: null})&gt;&gt;
+&lt;&lt;set $pesthouseReparation to 1&gt;&gt;[[You pray your penance is enough to restore your good name.-&gt;Reconnecting]]
+&lt;&lt;/linkreplace&gt;&gt;
+&lt;&lt;linkreplace &quot;performing public penance in church&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Performed public penance in church&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;
+&lt;&lt;set $pesthouseReparation to 1&gt;&gt;[[You pray your penance is enough to restore your good name.-&gt;Reconnecting]]
+&lt;&lt;/linkreplace&gt;&gt;
+&lt;&lt;elseif $hoh is 1&gt;&gt;
+&lt;&lt;linkreplace &quot;giving one month&#39;s income to the poor //and// performing public penance in church&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $money -= $income&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Gave one month&#39;s income and performed public penance&quot;, money: 0 - $income, repDelta: 0, repBefore: _repBefore, infectPct: null})&gt;&gt;
+&lt;&lt;set $pesthouseReparation to 1&gt;&gt;[[You pray your penance is enough to restore your good name.-&gt;Reconnecting]]
+&lt;&lt;/linkreplace&gt;&gt;
+&lt;&lt;linkreplace &quot;performing public penance in church&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Performed public penance in church&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;
+&lt;&lt;set $pesthouseReparation to 1&gt;&gt;[[You pray your penance is enough to restore your good name.-&gt;Reconnecting]]
 &lt;&lt;/linkreplace&gt;&gt;
 &lt;&lt;else&gt;&gt;
-&lt;&lt;linkreplace &quot;performing public penance in church&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;
-&lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;
-&lt;&lt;set $decisions.push({text: &quot;Performed public penance in church&quot;, money: 0, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: null})&gt;&gt;
-&lt;&lt;storyline-return&gt;&gt;
+&lt;&lt;linkreplace &quot;performing public penance in church&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Performed public penance in church&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;
+&lt;&lt;set $pesthouseReparation to 1&gt;&gt;[[You pray your penance is enough to restore your good name.-&gt;Reconnecting]]
 &lt;&lt;/linkreplace&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
@@ -5103,9 +5125,24 @@ You have some &lt;&lt;defRemedies &quot;remedies&quot;&gt;&gt; on hand in your h
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="83" name="Reconnecting" tags="quarantine" position="500,375" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;check-NPCs&gt;&gt;
-&lt;&lt;if _infectedFamily.length gt 0&gt;&gt;Unfortunately, you&#39;re going to be here a while longer. Your &lt;&lt;defHousehold &quot;household&quot;&gt;&gt; is still infected.
-[[You continue to tend to the sick-&gt;Quarantine Continues]] 
-&lt;&lt;else&gt;&gt; 
+&lt;&lt;if $pesthouseReparation is 1&gt;&gt;
+/* Player arriving from pesthouse or banishment — skip quarantine checks */
+&lt;&lt;set $pesthouseReparation to 0&gt;&gt;
+You return to your &lt;&lt;defHousehold &quot;household&quot;&gt;&gt; and begin reconnecting with the outside world.
+
+&lt;&lt;catch-up&gt;&gt;
+
+&lt;&lt;return-children&gt;&gt;
+
+/* Funeral choices for NPCs who died while the player was away */
+&lt;&lt;for _qi = 0; _qi &lt; $NPCs.length; _qi++&gt;&gt;&lt;&lt;if $NPCs[_qi].health is &quot;deceased&quot; and !$NPCs[_qi].funeralDone&gt;&gt;&lt;&lt;funeral-choice $NPCs[_qi]&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;for _qi = 0; _qi &lt; $NPCsServants.length; _qi++&gt;&gt;&lt;&lt;if $NPCsServants[_qi].health is &quot;deceased&quot; and !$NPCsServants[_qi].funeralDone&gt;&gt;&lt;&lt;funeral-choice $NPCsServants[_qi]&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;for _qi = 0; _qi &lt; $NPCsMaster.length; _qi++&gt;&gt;&lt;&lt;if $NPCsMaster[_qi].health is &quot;deceased&quot; and !$NPCsMaster[_qi].funeralDone&gt;&gt;&lt;&lt;funeral-choice $NPCsMaster[_qi]&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;for _qi = 0; _qi &lt; $NPCsExtended.length; _qi++&gt;&gt;&lt;&lt;if $NPCsExtended[_qi].health is &quot;deceased&quot; and !$NPCsExtended[_qi].funeralDone&gt;&gt;&lt;&lt;funeral-choice $NPCsExtended[_qi]&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
+&lt;&lt;servant-master-death&gt;&gt;
+
+&lt;&lt;storyline-return&gt;&gt;
+&lt;&lt;health-update&gt;&gt;
+&lt;&lt;elseif _infectedFamily.length gt 0&gt;&gt;Unfortunately, you&#39;re going to be here a while longer. Your &lt;&lt;defHousehold &quot;household&quot;&gt;&gt; is still infected.
+[[You continue to tend to the sick-&gt;Quarantine Continues]]
+&lt;&lt;else&gt;&gt;
 Lord be praised, your &lt;&lt;defHousehold &quot;household&quot;&gt;&gt; has survived the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt;. You still need to finish  &lt;&lt;defQuarantine &quot;quarantine&quot;&gt;&gt;, but begin reconnecting with the outside world.
 
 &lt;&lt;catch-up&gt;&gt;

--- a/variables.md
+++ b/variables.md
@@ -234,6 +234,14 @@ This document lists all global (story) variables used in **Gaming the Great Plag
 - **Initial value:** `0`
 - **Used for:** Controls whether infected NPC health is displayed as "healthy" (hidden) or "infected" (revealed) in the sidebar
 
+### `$pesthouseReparation`
+- **Type:** Integer (boolean-like)
+- **Possible values:** `0` (default), `1` (player has completed pesthouse/banishment reparation choice)
+- **Initial value:** `0` (set in `StoryInit`, pid 10)
+- **Set by:** Set to `1` in `YouPesthouse` (pid 44) or `banished` (pid 43) when the player selects a reparation option after surviving plague in the pesthouse or country estate. Reset to `0` in `Reconnecting` (pid 83) after the reparation branch processes.
+- **Used for:** Routes players arriving at `Reconnecting` from pesthouse/banishment through a separate branch that skips quarantine-related checks (infected family, quarantine swap restoration) and instead provides catch-up summaries, funeral choices, and storyline return.
+- **Dependencies:** Checked in `Reconnecting` (pid 83). Set in `YouPesthouse` (pid 44) and `banished` (pid 43).
+
 ### `$quarantine`
 - **Type:** Integer
 - **Range:** 0 -- 6


### PR DESCRIPTION
…gh Reconnecting — bump to v2.83

- Remove duplicate -3 rep penalty from Hide→pesthouse/banished links (players now lose only -3 total)
- Update pesthouse charge to 12p per person sent, waived if insufficient funds (both FamPesthouse and YouPesthouse)
- Route YouPesthouse and banished recoveries through Reconnecting for proper catch-up, funerals, and storyline return
- Add orphan-check to banished passage for noble child characters
- Add $pesthouseReparation flag to gate Reconnecting branch for pesthouse/banishment arrivals
- Banished nobles (hoh=1): reparation options now cost 1 month income; added letter-to-Queen (-1 rep) and poems-for-King (+1 rep) options; non-hoh=1 nobles only see the two letter options
- YouPesthouse: giving money to poor gated to hoh=1, costs 1 month income; public penance no longer grants +1 rep
- Fix text inconsistency in YouPesthouse will section (merchants had <br>, artisans had <br><br>)
- Add $pesthouseReparation variable to StoryInit and variables.md

https://claude.ai/code/session_015KkBao7HzzW5Tns5doRDdW