### PR TITLE
Fix $money clamp lower bound in Claude-widgets (pid 114) — bump to v2.86

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.85" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.86" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -6085,7 +6085,7 @@ Unfortunately, you have suffered a miscarriage and are no longer pregnant.
 /* Triple crew during peak plague months Aug-Oct 1665 */
 &lt;&lt;if $monthIndex gte 5 and $monthIndex lte 7&gt;&gt;&lt;&lt;set _cwCrew to _cwCrew * 3&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;set _cwPay to Math.trunc(_cwPay / _cwCrew)&gt;&gt;&lt;&lt;/if&gt;&gt;
-&lt;&lt;set $money to Math.clamp($money + _cwPay, 0, Infinity)&gt;&gt;
+&lt;&lt;set $money to Math.clamp($money + _cwPay, -Infinity, Infinity)&gt;&gt;
 /* Occupational infection: re-roll parish infection check (doubles effective chance) */
 &lt;&lt;set _cwRate to $parishRate[$parish][$monthIndex]&gt;&gt;
 &lt;&lt;set _cwInfectPct to Math.round(100 / _cwRate)&gt;&gt;
@@ -6109,7 +6109,7 @@ You and your fellow searcher&lt;&lt;if _cwCrew gt 2&gt;&gt;s&lt;&lt;/if&gt;&gt; 
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;elseif $role is &quot;warder&quot;&gt;&gt;
 &lt;&lt;set _cwWarderPay to 48&gt;&gt;
-&lt;&lt;set $money to Math.clamp($money - _cwPay + _cwWarderPay, 0, Infinity)&gt;&gt;
+&lt;&lt;set $money to Math.clamp($money - _cwPay + _cwWarderPay, -Infinity, Infinity)&gt;&gt;
 You stood guard outside quarantined houses this month and were paid &lt;&lt;print _cwWarderPay&gt;&gt;d. by the churchwardens for your service to the parish.
 &lt;&lt;if _cwPlague gt 0&gt;&gt; &lt;&lt;print _cwPlague&gt;&gt; of the shut-up houses had plague, may the Lord have mercy on their souls and protect you from sickness.&lt;&lt;/if&gt;&gt;
 &lt;&lt;if $playerPlagueStatus is &quot;healthy&quot; and _cwPlague gt 0&gt;&gt;


### PR DESCRIPTION
Two Math.clamp calls for $money in the plague-work pay widget used 0 as the lower bound, preventing money from going negative. Changed to -Infinity to match the rest of the codebase (money is allowed to go into debt).

Lines fixed in passages/114-Claude-widgets.txt:
- Line 13: plague-work pay ($money + _cwPay)
- Line 37: warder pay ($money - _cwPay + _cwWarderPay)

All $reputation modifications were already correctly clamped to 0–10.

https://claude.ai/code/session_01Xoc9iVvbDF8XSPoQZMCxqq