### PR TITLE
Remove warder baseline pay/infection from corpse-work, add no-assignm…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.86" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.87" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -6076,7 +6076,7 @@ Unfortunately, you have suffered a miscarriage and are no longer pregnant.
 &lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="114" name="Claude-widgets" tags="widget" position="500,1225" size="100,100">/* all widgets generated via Claude  or other AI should be temporarily placed here then manually moved to new locations as needed */
 
 &lt;&lt;widget &quot;corpse-work&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
-&lt;&lt;if ($role is &quot;corpsebearer&quot; or $role is &quot;searcher&quot; or $role is &quot;warder&quot;) and $corpseBuried and $corpseBuried[$parish]&gt;&gt;
+&lt;&lt;if ($role is &quot;corpsebearer&quot; or $role is &quot;searcher&quot;) and $corpseBuried and $corpseBuried[$parish]&gt;&gt;
 &lt;&lt;set _cwBuried to $corpseBuried[$parish][$monthIndex]&gt;&gt;
 &lt;&lt;set _cwPlague to $corpsePlague[$parish][$monthIndex]&gt;&gt;
 &lt;&lt;if _cwBuried gt 0&gt;&gt;
@@ -6106,17 +6106,6 @@ You and your fellow searcher&lt;&lt;if _cwCrew gt 2&gt;&gt;s&lt;&lt;/if&gt;&gt; 
 &lt;&lt;set $plagueInfection to 1&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Examined plague corpses&quot;, money: _cwPay, repDelta: 0, repBefore: $reputation, infectPct: _cwInfectPct})&gt;&gt;
-&lt;&lt;/if&gt;&gt;
-&lt;&lt;elseif $role is &quot;warder&quot;&gt;&gt;
-&lt;&lt;set _cwWarderPay to 48&gt;&gt;
-&lt;&lt;set $money to Math.clamp($money - _cwPay + _cwWarderPay, -Infinity, Infinity)&gt;&gt;
-You stood guard outside quarantined houses this month and were paid &lt;&lt;print _cwWarderPay&gt;&gt;d. by the churchwardens for your service to the parish.
-&lt;&lt;if _cwPlague gt 0&gt;&gt; &lt;&lt;print _cwPlague&gt;&gt; of the shut-up houses had plague, may the Lord have mercy on their souls and protect you from sickness.&lt;&lt;/if&gt;&gt;
-&lt;&lt;if $playerPlagueStatus is &quot;healthy&quot; and _cwPlague gt 0&gt;&gt;
-&lt;&lt;if random(1, _cwRate) eq 1&gt;&gt;
-&lt;&lt;set $plagueInfection to 1&gt;&gt;
-&lt;&lt;/if&gt;&gt;
-&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Guarded quarantined houses&quot;, money: _cwWarderPay, repDelta: 0, repBefore: $reputation, infectPct: _cwInfectPct})&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;br&gt;&lt;br&gt;
@@ -6173,6 +6162,8 @@ You stand guard outside the marked door, listening to the weeping and prayers wi
 &lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Refused to guard a plague house&quot;, money: 0, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: 0})&gt;&gt;
 You refuse the assignment. The churchwardens are displeased — your reputation suffers.
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;&lt;br&gt;&lt;br&gt;
+&lt;&lt;elseif _wwPlague gt 0&gt;&gt;
+To your relief, you are not called upon to guard any shut up houses this month.&lt;br&gt;&lt;br&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 /* Bill of Mortality subscription report */


### PR DESCRIPTION
…ent fallback — bump to v2.87

- Remove warder from corpse-work widget: no more flat 48d baseline pay or occupational infection roll (eliminates double-dipping with guard choice)
- Add warder fallback message ("To your relief, you are not called upon to guard any shut up houses this month.") parallel to nurse's fallback

https://claude.ai/code/session_013neELyd9XvEgoqc5y6qn9p