### PR TITLE
Fix corpse-work events being suppressed by random events — bump to v2.90

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v2.89" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v2.90" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -2290,8 +2290,8 @@ You&#39;ve been taken by a press gang&lt;&lt;if $impressed gte 2&gt;&gt; again&l
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="16" name="May 1665" tags="storyline 1665" position="1200,475" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
-&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
+&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;bill-subscribe&gt;&gt;
 As if war wasn’t bad enough, you begin to hear rumors around the city that several houses have been shut up because their inhabitants have &lt;&lt;defPlague &quot;plague&quot;&gt;&gt;.
 You &lt;span id=&quot;decision&quot;&gt;
@@ -2316,8 +2316,8 @@ You &lt;span id=&quot;decision&quot;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="17" name="June 1665" tags="storyline 1665" position="1325,475" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
-&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
+&lt;&lt;if not _randomEventFired&gt;&gt;
     On June 3rd, everyone throughout the city hears the sound of cannon fire—not the celebratory firing of cannons in ceremony but the sounds of battle. It is obvious that the English and Dutch &lt;&lt;defFleet &quot;fleets&quot;&gt;&gt; have engaged in battle, but where? How close are they to London? Who is winning? No one knows. &lt;&lt;if $origin is &quot;the Dutch Republic&quot;&gt;&gt;You keep your head down and hide from your neighbors as much as possible, for fear that they will turn on you.&lt;&lt;/if&gt;&gt;
     &lt;br&gt;&lt;br&gt;
    &lt;span id=&quot;decision&quot;&gt; Do you try to find out more?
@@ -2362,8 +2362,8 @@ You &lt;span id=&quot;decision&quot;&gt;
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="18" name="August 1665" tags="storyline 1665" position="1075,625" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
-&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
+&lt;&lt;if not _randomEventFired&gt;&gt;
  /* Beggar &amp; Day Labourer choices */
 /* nts: need text if day labourers don&#39;t have a job */
     &lt;&lt;if $role is &quot;corpsebearer&quot; or $role is &quot;searcher&quot; or $role is &quot;nurse&quot; or $role is &quot;warder&quot;&gt;&gt;
@@ -2401,8 +2401,8 @@ So many people are sick and shut up in their houses that the city has imposed a 
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="19" name="September 1665" tags="storyline 1665" position="1200,625" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
-&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
+&lt;&lt;if not _randomEventFired&gt;&gt;
 The deaths continue in such great numbers that you can hardly believe it.&lt;br&gt;&lt;br&gt;
 &lt;&lt;if $role is &quot;corpsebearer&quot;&gt;&gt;You are shocked to see that some bold people have begun attending &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; funerals, as if it were a child’s game or dare. &lt;br&gt;&lt;br&gt;
 &lt;&lt;sep-1665-helper&gt;&gt; 
@@ -2422,8 +2422,8 @@ The deaths continue in such great numbers that you can hardly believe it.&lt;br&
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="20" name="October 1665" tags="storyline 1665" position="1325,625" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
-&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
+&lt;&lt;if not _randomEventFired&gt;&gt;
 October is miserably rainy and cold. &lt;&lt;defPlague &quot;Plague&quot;&gt;&gt; numbers are--thanks be to God--finally starting to come down, but are still terrifyingly high and you see sick people brazenly out and about on the streets.&lt;br&gt;&lt;br&gt;
 &lt;span id=&quot;pesthouse&quot;&gt;Do you report the sick to the &lt;&lt;defPesthouse &quot;pesthouse&quot;&gt;&gt;? &lt;&lt;link &quot;Yes, I don&#39;t want them getting me sick&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Oct 1665: Reported the sick to the pesthouse&quot;, money: 0, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: _riskPct})&gt;&gt;&lt;&lt;replace &quot;#pesthouse&quot;&gt;&gt;You start reporting the sick people you see to the pesthouse, hoping to keep the streets free from their presence. You feel a bit bad about confining them to such an awful place, but your own safety is worth it.
 
@@ -2453,8 +2453,8 @@ You hope the cold will deepen--and plague numbers continue to fall--as you head 
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="21" name="November 1665" tags="storyline 1665" position="1450,625" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
-&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
+&lt;&lt;if not _randomEventFired&gt;&gt;
 The weather is terrible but &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; numbers are coming down and people start to trickle back into town. 
 &lt;span id=&quot;visit&quot;&gt;Do you go out to visit your returning friends and neighbors? &lt;&lt;link &quot;Yes, I&#39;ve missed them greatly&quot;&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Nov 1665: Visited returning neighbors&quot;, money: 0, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: _riskPct})&gt;&gt;&lt;&lt;replace &quot;#visit&quot;&gt;&gt;You go out in the streets to greet your returning friends and neighbors, glad to be reunited after these long months.
 You don&#39;t expect great things this Christmas, but you are still looking forward to [[December 1665]].&lt;br&gt;&lt;br&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No, it&#39;s still not safe for socializing&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Nov 1665: Avoided socializing with returning neighbors&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;replace &quot;#visit&quot;&gt;&gt;You don&#39;t go out in the streets to welcome back your friends and neighbors, but you do shout your greetings down from your window. You are glad to see them back. You don&#39;t expect great things this Christmas, but you are still looking forward to [[December 1665]].&lt;br&gt;&lt;br&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
@@ -2462,8 +2462,8 @@ You don&#39;t expect great things this Christmas, but you are still looking forw
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="22" name="December 1665" tags="storyline 1665" position="1075,775" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
-&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
+&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;defPlague &quot;Plague&quot;&gt;&gt; numbers are up, despite two great frosts, and the Christmas festivities are all cancelled. You hope it&#39;s the last gasp of the outbreak, even as you reflect at how much different things are now than the were last year.&lt;br&gt;&lt;br&gt;
 
 &lt;span id= &quot;decision&quot;&gt;Do you want to celebrate Christmas despite the risk? &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#decision&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;&lt;&lt;party-costs&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round((10000 / _rate) + 200) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if random(1, 50) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Dec 1665: Held a Christmas feast despite the plague&quot;, money: -_partyCost, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: _riskPct})&gt;&gt;&lt;&lt;if $hoh is 4&gt;&gt;You convince your husband, and you&lt;&lt;elseif $hoh is 3 or ($hoh is 0 and $socio is &quot;servants&quot;)&gt;&gt;You convince your $masterTitle, and you&lt;&lt;elseif $hoh isnot 1&gt;&gt;You convince your family, and you&lt;&lt;else&gt;&gt;You&lt;&lt;/if&gt;&gt; are planning a feast for a few friends to make up for the dour attitude across the city. You&#39;re looking forward to the opportunity to forget the plague for a few hours and feast on your favorite food &lt;&lt;set _food = [&quot;roasted herring&quot;, &quot;pigeon pie&quot;, &quot;lamprey pie&quot;, &quot;roasted veal&quot;, &quot;hogs pudding&quot;]&gt;&gt;&lt;&lt;listbox &quot;$food&quot;&gt;&gt;&lt;&lt;optionsfrom _food&gt;&gt;&lt;&lt;/listbox&gt;&gt;.&lt;br&gt;&lt;br&gt;&lt;&lt;if $socio is &quot;nobles&quot;&gt;&gt;
@@ -2478,8 +2478,8 @@ Maybe things will be better in [[1666-&gt;January 1666]].&lt;&lt;/replace&gt;&gt
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="23" name="January 1666" tags="storyline 1666" position="1200,775" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
-&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
+&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;defPlague &quot;Plague&quot;&gt;&gt; numbers continue to come down. &lt;&lt;defNoble &quot;Noble&quot;&gt;&gt; coaches fill the streets, &lt;&lt;defPorter &quot;porters&quot;&gt;&gt; are everywhere hauling the belongings of those who are returning to the city, all the shops are reopening, and &lt;&lt;defBeggars &quot;beggars&quot;&gt;&gt; overflow the highways.&lt;br&gt;&lt;br&gt;
 &lt;br&gt;
 &lt;&lt;if $socio is &quot;day labourers&quot; or $socio is &quot;beggars&quot;&gt;&gt;&lt;span id=&quot;help&quot;&gt;Do you offer your services as a porter? &lt;&lt;link &quot;Yes, I could use the extra money&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;&lt;&lt;set $money +=6&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jan 1666: Offered porter services&quot;, money: 6, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: _riskPct})&gt;&gt;&lt;&lt;replace &quot;#help&quot;&gt;&gt;You keep busy offering the returning families your services as a porter, earning a few coins as you do so. You are glad to see the city so lively again.
@@ -2498,8 +2498,8 @@ After six months of travel, the king finally returns the Court to &lt;&lt;defHam
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="24" name="February 1666" tags="storyline 1666" position="1325,775" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
-&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
+&lt;&lt;if not _randomEventFired&gt;&gt;
 The king has returned to London! People rejoice and return to their churches, knowing that if the king is willing to move back into his city palace of &lt;&lt;defWhitehall &quot;Whitehall&quot;&gt;&gt;, then the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; outbreak must be almost over. A great snow hides all the graves and it&#39;s as if the last year was all a terrible dream.&lt;br&gt;&lt;br&gt;
 
 And, as if you needed more opportunities to celebrate, it&#39;s almost &lt;&lt;defLent &quot;Lent.&quot;&gt;&gt; &lt;span id= &quot;decision&quot;&gt;Do you want to hold one last feast before it&#39;s time to begin fasting? &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#decision&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;&lt;&lt;party-costs&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round((10000 / _rate) + 200) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if random(1, 50) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Feb 1666: Held a pre-Lent feast&quot;, money: -_partyCost, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: _riskPct})&gt;&gt;&lt;&lt;if $hoh is 4&gt;&gt;You convince your husband, and you&lt;&lt;elseif $hoh is 3 or ($hoh is 0 and $socio is &quot;servants&quot;)&gt;&gt;You convince your $masterTitle, and you&lt;&lt;elseif $hoh isnot 1&gt;&gt;You convince your family, and you&lt;&lt;else&gt;&gt;You&lt;&lt;/if&gt;&gt; are planning a feast for a few friends. You&#39;re excited about all the things on the menu but especially your favorite dessert &lt;&lt;set _food = [&quot;minced pie&quot;, &quot;sweetmeats&quot;, &quot;currant cake&quot;, &quot;syllabub&quot;, &quot;tansy&quot;]&gt;&gt;&lt;&lt;listbox &quot;$food&quot;&gt;&gt;&lt;&lt;optionsfrom _food&gt;&gt;&lt;&lt;/listbox&gt;&gt;. Feasting costs money though, and things might be tight in the coming months, though your heart and stomach are full.&lt;br&gt;&lt;br&gt;
@@ -2512,8 +2512,8 @@ Your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; priest hasn&#39;t returned yet
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="25" name="March 1666" tags="storyline 1666" position="1450,775" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
-&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
+&lt;&lt;if not _randomEventFired&gt;&gt;
 The Queen of Portugal, mother to England&#39;s beloved &lt;&lt;defQueenCatherine &quot;Queen Catherine&quot;&gt;&gt;, has died.&lt;br&gt;&lt;br&gt;
 &lt;&lt;if $religion is &quot;Catholic&quot;&gt;&gt;&lt;span id=&quot;candle&quot;&gt;Do you go to church and light a candle for the queen?&lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#candle&quot;&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Mar 1666: Lit a candle for the Queen of Portugal&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;You go to church and light a candle for the late queen.
 &lt;&lt;march-1666-helper&gt;&gt;
@@ -2526,8 +2526,8 @@ The Queen of Portugal, mother to England&#39;s beloved &lt;&lt;defQueenCatherine
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="26" name="April 1666" tags="storyline 1666" position="1075,925" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
-&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
+&lt;&lt;if not _randomEventFired&gt;&gt;
 There&#39;s no denying it now. &lt;&lt;defPlague &quot;Plague&quot;&gt;&gt; cases are definitely on the rise. Luckily, Sweden has declared itself on England&#39;s side in the war against the Dutch so at least things are looking more promising there. The Lenten fast is over it&#39;s time to celebrate Christ&#39;s resurrection on earth with Easter and the return of spring.
 
 &lt;span id=&quot;Easter&quot;&gt;Do you want to attend Easter services at your parish church, despite the risk of plague?
@@ -2539,8 +2539,8 @@ You gather with your neighbors to celebrate Easter &lt;&lt;if $agenum lte 15&gt;
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="27" name="May 1666" tags="storyline 1666" position="1200,925" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
-&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
+&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;defPlague &quot;Plague&quot;&gt;&gt; is increasing throughout the city, but that doesn&#39;t stop all of London from celebrating the king&#39;s birthday and the anniversary of the &lt;&lt;defRestoration &quot;Restoration&quot;&gt;&gt; on May 29th with bonfires. &lt;&lt;defBeggars &quot;Beggars&quot;&gt;&gt; throng the streets but, for once, no one seems to mind. 
 
 &lt;&lt;if $religion isnot &quot;member of the Church of England&quot;&gt;&gt;&lt;span id=&quot;celebrate&quot;&gt;While the king&#39;s return didn&#39;t lead to $religion religious liberty, do you still want to celebrate?&lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;&lt;&lt;party-costs&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round((10000 / _rate) + 200) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if random(1, 50) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;May 1666: Celebrated the King&#39;s birthday&quot;, money: -_partyCost, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: _riskPct})&gt;&gt;&lt;&lt;replace &quot;#celebrate&quot;&gt;&gt;&lt;&lt;if $hoh is 4&gt;&gt;You convince your husband that the king&#39;s birthday is an important holiday, and you take part in the toasting and feasting.&lt;&lt;elseif $hoh is 3 or ($hoh is 0 and $socio is &quot;servants&quot;)&gt;&gt;You convince your $masterTitle that the king&#39;s birthday is an important holiday, and you take part in the toasting and feasting.&lt;&lt;elseif $hoh isnot 1&gt;&gt;You convince your family that the king&#39;s birthday is an important holiday, and you take part in the toasting and feasting.&lt;&lt;else&gt;&gt;You know that the king&#39;s birthday is an important holiday, and take part in the toasting and feasting.&lt;&lt;/if&gt;&gt;
@@ -2552,8 +2552,8 @@ You are still recovering from the festivities when the days tip over into [[June
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="28" name="June 1666" tags="storyline 1666" position="1325,925" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
-&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
+&lt;&lt;if not _randomEventFired&gt;&gt;
 
 The summer heat has hit London and everyone is feeling lethargic. Still, there are some things to do, like gossip with your neighbors. &lt;span id=&quot;decision&quot;&gt;Do you listen to the gossip? &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#decision&quot;&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jun 1666: Listened to the war gossip&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;
 
@@ -2587,8 +2587,8 @@ You avoid being pressed by keeping out of the way of the gangs. You don&#39;t kn
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="29" name="July 1666" tags="storyline 1666" position="1450,925" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
-&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
+&lt;&lt;if not _randomEventFired&gt;&gt;
 The heat of the city is oppressive but the worst is not the heat but the wails of women whose husbands have been &lt;&lt;defImpressed &quot;impressed&quot;&gt;&gt; into the &lt;&lt;defFleet &quot;Fleet&quot;&gt;&gt;. Many of the men who have been impressed attempt to escape but are recaptured.
 
 Those who remain in the city hear the sounds of another battle in the distance--but any battle that is close enough for you can hear the cannon fire is too close. 
@@ -2607,8 +2607,8 @@ You wonder if you will make it to [[August 1666]].
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="30" name="August 1666" tags="storyline 1666" position="1075,1075" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
-&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
+&lt;&lt;if not _randomEventFired&gt;&gt;
 As the summer heat engulfs the city, &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; numbers continue to rise. But at least there&#39;s good news on the war front, as you hear that the &lt;&lt;defFleet &quot;fleet&quot;&gt;&gt; has burnt more Dutch ships.
 &lt;br&gt;&lt;br&gt;
 &lt;&lt;if $agenum gte 16 and $gender isnot &quot;female&quot;&gt;&gt;&lt;span id=&quot;volunteer&quot;&gt;Do you want to join the victorious Navy and burn more Dutch ships?
@@ -2624,8 +2624,8 @@ You hope it will be enough to tide you through the last hot month of the year, a
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="31" name="September 1666" tags="fire storyline 1666" position="1200,1075" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
-&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
+&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;if $location is &quot;inside the City walls&quot; or $fireParishes.includes($parish)&gt;&gt;
 Early one Sunday morning, you wake to the frantic ringing of church bells.  This isn&#39;t the ordinary &lt;&lt;defCallToService &quot;call to service&quot;&gt;&gt;—&lt;&lt;if $religion is &quot;member of the Church of England&quot;&gt;&gt;something you were looking forward to attending after you slept in&lt;&lt;else&gt;&gt;as if you&#39;d ever attend a service in the Church of England!&lt;&lt;/if&gt;&gt;—but rather a call to arms.  When you stumble outside, you discover the city has caught fire around you.
 
@@ -2668,8 +2668,8 @@ You ask around and discover the fire began in the King&#39;s Baker&#39;s house o
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="32" name="October 1666" tags="storyline 1666" position="1325,1075" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
-&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
+&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;if $fireParishes.includes($parish)&gt;&gt;
 &lt;&lt;if $socio is &quot;beggars&quot;&gt;&gt;You spend the next several weeks living in a field. The local &lt;&lt;defParish &quot;parish&quot;&gt;&gt; church serves food three times a day to keep you and the others from starving, but winter is coming and you know that you&#39;ll freeze to death if you don&#39;t manage to find permanent shelter before then. &lt;&lt;if $reputation lte 2&gt;&gt;Unfortunately, the first frost comes and you are still homeless because no one would take you in on account of your low reputation.  &lt;&lt;if $origin is not &quot;London&quot;&gt;&gt; Your only choices are to [[return to your home in $origin-&gt;go quietly]] or to &lt;&lt;else&gt;&gt;You &lt;&lt;/if&gt;&gt;pray you don&#39;t [[freeze]].
 &lt;&lt;else&gt;&gt;Luckily, just as the first frost hits the city, you manage to find a friend-of-a-friend who is willing to let you sleep on the floor until you can get more [[permanent lodgings-&gt;November 1666]].
@@ -2692,8 +2692,8 @@ The weather may be miserable, but every disaster has a silver lining. Between th
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="33" name="November 1666" tags="storyline 1666" position="1450,1075" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
-&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
+&lt;&lt;if not _randomEventFired&gt;&gt;
 One November day, the church bells peal out in alarm again--not from the destroyed part of the city within its ancient walls, but from the king&#39;s palace at &lt;&lt;defWhitehall &quot;Whitehall&quot;&gt;&gt;, especially the area around &lt;&lt;defHorseGuards &quot;Horse Guards&quot;&gt;&gt;. Everyone rushes to put out the fire at all costs, unwilling to have a repeat of September&#39;s disaster. Thankfully, no lives are lost.
 
 Even better, the king declares the official thanksgiving day for the end of the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt;. Yes, some people are still dying, but the numbers are low enough and the epidemic has been going on long enough that most everyone is grateful for its official end.
@@ -2703,8 +2703,8 @@ As &lt;&lt;defLent &quot;Lent&quot;&gt;&gt; begins, you look forward to actually
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="34" name="December 1666" tags="storyline 1666" position="1600,1075" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
-&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
+&lt;&lt;if not _randomEventFired&gt;&gt;
 Fires still &lt;&lt;defSmolder &quot;smolder&quot;&gt;&gt; in cellars throughout the city. Trouble is brewing in Scotland. The &lt;&lt;defGeneralBill &quot;general bill of this year&#39;s deaths&quot;&gt;&gt; show many &lt;&lt;defLamentable &quot;lamentable&quot;&gt;&gt; &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; deaths. But you have made it through 1666 and you thank God you are still alive!
 
 Congratulations. You have [[survived the Great Plague of London-&gt;stats]]
@@ -2928,7 +2928,8 @@ You have no choice but to &lt;&lt;storyline-return &quot;accept your new role&qu
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="38" name="July 1665" tags="storyline 1665" position="1450,475" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
-&lt;&lt;if not _randomEventFired&gt;&gt;&lt;&lt;corpse-work&gt;&gt;
+&lt;&lt;corpse-work&gt;&gt;
+&lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;span id=&quot;plague-day-replace&quot;&gt;
 Despite the English &lt;&lt;defFleet &quot;fleet&#39;s&quot;&gt;&gt; victory, the war grinds on and rumors begin to circulate that the French are considering siding with the Dutch. &lt;&lt;if $origin is &quot;France&quot; or $origin is &quot;the Dutch Republic&quot;&gt;&gt;You make sure to talk loudly of your loyalty to the King and the superiority of the English fleet, whenever your neighbors mention the war.&lt;&lt;/if&gt;&gt;
 &lt;br&gt;&lt;br&gt;


### PR DESCRIPTION
Move <<corpse-work>> outside the <<if not _randomEventFired>> guard in all 19 monthly passages (pids 16–34, 38). Previously, when a random event fired (wedding, fever, pregnancy, etc.), corpse-work was entirely skipped — corpsebearers/searchers lost pay and infection rolls, nurses/warders lost patient/guard assignments. Now corpse-work always runs regardless of whether a random event also fires that month.

https://claude.ai/code/session_01369i7Re2AWtt7tUDjKLhTD