### PR TITLE
Add passage data extraction: passage IDs and user-facing text

### DIFF
--- a/extract-passage-text.js
+++ b/extract-passage-text.js
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+/**
+ * Extracts passage IDs and user-facing text from decoded passage files.
+ * Strips SugarCube macros, HTML tags, comments, and code to leave only
+ * the narrative text a player would see.
+ *
+ * Usage: node extract-passage-text.js
+ * Output: passage-data.md
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const index = JSON.parse(fs.readFileSync('passage-index.json', 'utf8'));
+
+// Passages that are purely programmatic / never shown to the player directly
+const SYSTEM_PASSAGE_NAMES = new Set([
+  'StoryInit', 'PassageHeader', 'StoryCaption', 'StoryInterface',
+  'storyLogo', 'gameTitle', 'storyAuthor', 'storyMenu',
+  '$args[0', 'empty'
+]);
+
+function stripUserFacingText(raw) {
+  let text = raw;
+
+  // Remove SugarCube block comments  /* ... */
+  text = text.replace(/\/\*[\s\S]*?\*\//g, '');
+
+  // Remove <<nobr>> / <</nobr>>
+  text = text.replace(/<<\/?nobr>>/g, '');
+
+  // Remove <<gate ...>> / <</gate>>
+  text = text.replace(/<<gate\b[^>]*>>/g, '');
+  text = text.replace(/<<\/gate>>/g, '');
+
+  // Remove <<set ...>> (single-line macro calls)
+  text = text.replace(/<<set\b[^>]*>>/g, '');
+
+  // Remove <<run ...>>
+  text = text.replace(/<<run\b[^>]*>>/g, '');
+
+  // Remove <<print ...>>  but try to keep what it prints if simple
+  text = text.replace(/<<print\b[^>]*>>/g, '');
+
+  // Remove <<unset ...>>
+  text = text.replace(/<<unset\b[^>]*>>/g, '');
+
+  // Remove <<include ...>>
+  text = text.replace(/<<include\b[^>]*>>/g, '');
+
+  // Remove <<widget ...>> / <</widget>>
+  text = text.replace(/<<\/?widget\b[^>]*>>/g, '');
+
+  // Remove <<replace ...>> / <</replace>>
+  text = text.replace(/<<\/?replace\b[^>]*>>/g, '');
+
+  // Remove <<append ...>> / <</append>>
+  text = text.replace(/<<\/?append\b[^>]*>>/g, '');
+
+  // Remove <<prepend ...>> / <</prepend>>
+  text = text.replace(/<<\/?prepend\b[^>]*>>/g, '');
+
+  // Remove <<timed ...>> / <</timed>>
+  text = text.replace(/<<\/?timed\b[^>]*>>/g, '');
+
+  // Remove <<listbox ...>> / <</listbox>>
+  text = text.replace(/<<\/?listbox\b[^>]*>>/g, '');
+
+  // Remove <<optionsfrom ...>>
+  text = text.replace(/<<optionsfrom\b[^>]*>>/g, '');
+
+  // Remove <<checkbox ...>>
+  text = text.replace(/<<checkbox\b[^>]*>>/g, '');
+
+  // Remove <<radiobutton ...>>
+  text = text.replace(/<<radiobutton\b[^>]*>>/g, '');
+
+  // Remove <<textbox ...>>
+  text = text.replace(/<<textbox\b[^>]*>>/g, '');
+
+  // Remove <<textarea ...>>
+  text = text.replace(/<<\/?textarea\b[^>]*>>/g, '');
+
+  // Remove <<button ...>> / <</button>>
+  text = text.replace(/<<\/?button\b[^>]*>>/g, '');
+
+  // Remove <<script>> / <</script>> blocks entirely
+  text = text.replace(/<<script>>[\s\S]*?<<\/script>>/g, '');
+
+  // Remove <<silently>> / <</silently>> blocks entirely
+  text = text.replace(/<<silently>>[\s\S]*?<<\/silently>>/g, '');
+
+  // Convert <<link "text">> ... <</link>> — extract link display text
+  text = text.replace(/<<link\s+"([^"]*)"[^>]*>>/g, '$1 ');
+  text = text.replace(/<<link\s+'([^']*)'[^>]*>>/g, '$1 ');
+  text = text.replace(/<<\/?link>>/g, '');
+
+  // Convert [[display text->target]] and [[display text|target]] to just display text
+  text = text.replace(/\[\[([^\]|>]+)->[^\]]*\]\]/g, '[$1]');
+  text = text.replace(/\[\[([^\]|>]+)\|[^\]]*\]\]/g, '[$1]');
+  // Plain [[text]] links
+  text = text.replace(/\[\[([^\]]*)\]\]/g, '[$1]');
+
+  // Remove <<if ...>>, <<elseif ...>>, <<else>>, <</if>>
+  text = text.replace(/<<\/?if\b[^>]*>>/g, '');
+  text = text.replace(/<<elseif\b[^>]*>>/g, '');
+  text = text.replace(/<<else>>/g, '');
+
+  // Remove <<for ...>> / <</for>>
+  text = text.replace(/<<\/?for\b[^>]*>>/g, '');
+
+  // Remove <<switch ...>> / <<case ...>> / <</switch>>
+  text = text.replace(/<<\/?switch\b[^>]*>>/g, '');
+  text = text.replace(/<<case\b[^>]*>>/g, '');
+  text = text.replace(/<<default>>/g, '');
+
+  // Remove any remaining custom widget calls <<widget-name>> or <<widget-name args>>
+  // These are invocations like <<december-1664-helper>>, <<defPlague "plague">>
+  // For definition macros <<defXxx "display text">>, extract the display text
+  text = text.replace(/<<def\w+\s+"([^"]*)"[^>]*>>/g, '$1');
+  text = text.replace(/<<def\w+\s+'([^']*)'[^>]*>>/g, '$1');
+
+  // Remove any remaining << ... >> macros
+  text = text.replace(/<<[^>]*>>/g, '');
+
+  // Convert <br> / <br/> to newlines
+  text = text.replace(/<br\s*\/?>/gi, '\n');
+
+  // Convert </li> and </ul> and </ol> to newlines
+  text = text.replace(/<\/li>/gi, '');
+  text = text.replace(/<\/?[uo]l>/gi, '\n');
+
+  // Convert <li> to bullet
+  text = text.replace(/<li>/gi, '- ');
+
+  // Remove <img ...> tags but note them
+  text = text.replace(/<img\b[^>]*>/gi, '[image]');
+
+  // Remove <span> tags (keep content)
+  text = text.replace(/<\/?span[^>]*>/gi, '');
+
+  // Remove other HTML tags but keep content
+  text = text.replace(/<\/?[a-z][a-z0-9]*[^>]*>/gi, '');
+
+  // Remove SugarCube italic markers //text// -> text
+  text = text.replace(/\/\/([^/]+)\/\//g, '$1');
+
+  // Remove SugarCube bold markers ''text'' -> text
+  text = text.replace(/''([^']+)''/g, '$1');
+
+  // Remove variable display references like $variable or _variable in isolation
+  // (keep them if embedded in narrative text since they represent dynamic values)
+  // Actually, keep $-prefixed words as [variable] placeholders
+  text = text.replace(/\$(\w+(?:\.\w+)*(?:\[\w+\])*)/g, '[$1]');
+  text = text.replace(/\b_(\w+)\b/g, '[$1]');
+
+  // Clean up extra whitespace
+  text = text.replace(/[ \t]+/g, ' ');
+  text = text.replace(/\n[ \t]+/g, '\n');
+  text = text.replace(/[ \t]+\n/g, '\n');
+  text = text.replace(/\n{3,}/g, '\n\n');
+  text = text.trim();
+
+  return text;
+}
+
+// Build the markdown output
+const lines = [];
+lines.push('# Passage Data: Gaming the Great Plague');
+lines.push('');
+lines.push('This file contains the passage ID, name, tags, and extracted user-facing text for each passage in the game.');
+lines.push('');
+lines.push('> **Note:** User-facing text has been extracted by stripping SugarCube macros, HTML tags, and code logic.');
+lines.push('> Dynamic content (variables, conditional branches) may result in multiple text variants shown together.');
+lines.push('> Widget and system passages are included but marked as such.');
+lines.push('');
+lines.push('---');
+lines.push('');
+
+for (const entry of index) {
+  const { pid, name, tags, filename, size } = entry;
+  const isWidget = tags.includes('widget');
+  const isSystem = SYSTEM_PASSAGE_NAMES.has(name);
+
+  lines.push(`## Passage ${pid}: ${name}`);
+  lines.push('');
+  if (tags) {
+    lines.push(`**Tags:** ${tags}`);
+    lines.push('');
+  }
+  if (isWidget) {
+    lines.push('*This is a widget passage (code/logic only — not directly displayed to players).*');
+    lines.push('');
+  }
+  if (isSystem) {
+    lines.push('*This is a system passage (engine infrastructure — not narrative content).*');
+    lines.push('');
+  }
+
+  // Read passage file
+  const filePath = path.join('passages', filename);
+  if (!fs.existsSync(filePath)) {
+    lines.push('*(passage file not found)*');
+    lines.push('');
+    lines.push('---');
+    lines.push('');
+    continue;
+  }
+
+  const raw = fs.readFileSync(filePath, 'utf8');
+
+  if (size === 0 || raw.trim() === '') {
+    lines.push('*(empty passage)*');
+    lines.push('');
+    lines.push('---');
+    lines.push('');
+    continue;
+  }
+
+  const userText = stripUserFacingText(raw);
+
+  if (userText.length === 0) {
+    lines.push('*(no user-facing text — code/logic only)*');
+  } else {
+    lines.push('```');
+    lines.push(userText);
+    lines.push('```');
+  }
+
+  lines.push('');
+  lines.push('---');
+  lines.push('');
+}
+
+const output = lines.join('\n');
+fs.writeFileSync('passage-data.md', output, 'utf8');
+console.log(`Wrote passage-data.md (${(output.length / 1024).toFixed(1)} KB, ${index.length} passages)`);

--- a/passage-data.md
+++ b/passage-data.md
@@ -1,0 +1,3145 @@
+# Passage Data: Gaming the Great Plague
+
+This file contains the passage ID, name, tags, and extracted user-facing text for each passage in the game.
+
+> **Note:** User-facing text has been extracted by stripping SugarCube macros, HTML tags, and code logic.
+> Dynamic content (variables, conditional branches) may result in multiple text variants shown together.
+> Widget and system passages are included but marked as such.
+
+---
+
+## Passage 1: bio
+
+```
+Your friends and family call you Your friends and family call you Your friends and family call you Your friends and family call you Your name is [name], and you are [agenum] years old. You are proud to be a , the only true and legal faithdespite the fact that it is illegal in England.
+
+You were bornborn and raised in London[origin], though you now make your home in London. You currently live in the parish of [parish], which is [location]. It is a good place for like you, as people take pity on you for your [disability] and are generous with their alms.It is a good place for like you and you have found success for yourself as a [role] despite your [disability.It] is a good place for like you and you have found success for yourself as a [role.It] is a good place for like you despite your [disability.It] is a good place for like you.
+
+You are currently betrothed to be married. Alas, your wifehusband died some time ago.
+
+Your [masterTitle] is an artisana merchanta noble. As an unmarried servant, you live in their household. with a household of [NPCsMaster.length] members.
+
+You live with your
+
+[NPCs[[i]]].relationship, [NPCs[[i]]].name.
+[NPCs[[i]]].relationship, [NPCs[[i]]].name;
+and [NPCs[[i]]].relationship, [NPCs[[i]]].name.
+
+You live alone.
+
+Your household also includes [servants] servants.
+
+Your household also includes a servant[servants] servants.
+
+Your
+
+[NPCsExtended[[e]]].relationship, [NPCsExtended[[e]]].name
+[NPCsExtended[[e]]].relationship, [NPCsExtended[[e]]].name;
+and [NPCsExtended[[e]]].relationship, [NPCsExtended[[e]]].name
+
+also lives in London.
+
+If that sounds right, [click this link to begin our story].
+
+If that doesn't sound right, you can refresh the game and start again.
+```
+
+---
+
+## Passage 2: December 1664
+
+**Tags:** storyline 1665
+
+```
+It is December 1664 and you are looking forward to the Christmas holidays. You aren't old enough to remember the days before King Charles II was restored to his rightful throne, when Christmas was banned as blasphemous, and it makes the weeks of celebration and feasting all the merrier.
+
+Not everything is perfect, though. Rumors swirl throughout the city about the possibility of a coming war with the Dutch Republic after several Dutch ships were captured and brought into Portsmouth as prizes. You make merry with your neighbors even while you fear they will turn against you in the months ahead. Worse, it is common knowledge that plague has been spreading in the Dutch fleet for months, though it hasn't yet reached English shores.
+
+Do you think you might have a better life if you join the English Navy?
+
+Volunteer for the navy You have enlisted on [HMS Royal Sovereign] | Stay out of the fighting
+
+Do you want to join the navy?Yes, I can disguise myself as a man You have enlisted on [HMS Royal Sovereign] | No, I don't want to get caught
+```
+
+---
+
+## Passage 3: start
+
+```
+This is a text-based adventure game. Click the underlined teal text to advance in the game. Hover over (or tap on mobile) the bold purple text for definitions. Check out the sidebar/menu for information on your household and inventory, to visit the apothecary, or to restart the game. Best of luck surviving!
+
+The year is 1664 and you are a resident of the great city of London in England. After decades of civil war and experimental government, the merry monarch King Charles II was restored to the thrones of England, Scotland, and Ireland just four years ago and (most of) the kingdoms rejoiced.
+
+But enough about the king! What about you?
+[Create your character]
+[Automatically generate a character]
+
+[image]
+Claude de Jongh - "View of London Bridge," 1632.
+```
+
+---
+
+## Passage 4: identity
+
+```
+While infant mortality is common in this era, God granted your parents a healthy who not only survived but thrived and you are now a .
+
+While the rich and powerful might get betrothed as children and marry as teenagers, most people wait until their mid or late 20s when they have enough wealth to establish their own households. You are currently .Most people get married in their mid or late 20s to start a family, and those who are widowed often remarry as well. You are currently
+
+The city has recently settled after the religious upset of the civil war, and now there is relative harmony between Catholics, members of the Church of England, and members of dissident Protestant churches. As a devout , you know God loves all His children.
+
+You are originally from and currently live in London, the greatest city in all the British Isles. It is a diverse city, with people of all ages, origins, and socioeconomic statuses. The city is home to nobles, artisans, and merchants, who employ day labourers and servants in their households and businesses. And there are also beggars living in all 97 parishes within its ancient walls. There are also more parishes spread out around those walls that can be considered part of its suburbs. This includes people living in the city of Westminster and those living across the river Thames, which can only be crossed by boat or by the London Bridge.
+
+It's a great city for people like you - - to live in.
+
+Your home is .
+
+[image]
+Map of London, before the Fire of 1666 by Wencelaus Holler. Wesleyan University Davison Art Center.
+```
+
+---
+
+## Passage 5: death
+
+**Tags:** infection-rates
+
+```
+Send not to know for whom the church bells toll. They toll for you.
+```
+
+---
+
+## Passage 6: Sickness
+
+**Tags:** infection-rates
+
+```
+''Lord have mercy! A strange lump has appeared on your
+
+leg
+armpit
+neck
+, and there's no hiding that you have caught the dreaded plague.''
+
+Worse yet, you learn that your
+
+[NPCs[[y]]].relationship, [NPCs[[y]]].name has also fallen ill.
+
+[NPCs[[y]]].relationship [NPCs[[y]]].name, and [NPCs[[y]]].relationship [NPCs[[y]]].name have also fallen ill.
+
+Your neighbors shut up the entrances to your house and paint a red cross with the words Lord Have Mercy on the front door.
+
+You pray that God does have mercy on you as you take to your sickbed.
+
+You pray the treatments work.
+
+Unfortunately, your fever spikes, you grow weak, and you fear for your life.
+
+[image]
+Italian drawing of two men who lie side by side affected by the plague, c. 17th century. Wellcome Images
+
+It occurs to you that perhaps you ought to write your will, but your reputation is so poor that no one can be convinced to bring you the writing materials you need.
+It occurs to you that perhaps you ought to write your will, but your reputation is so poor that you can't convince a scrivener to come help you..
+
+The days continue to pass with agonizing slowness.
+
+You spend most of your waking hours in a terrible, fevered state. In your brief moments of lucidity, you ask after your family and are grateful to hear no more have fallen ill... yet.
+
+You are grateful to hear that your
+
+[NPCs[[d]]].relationship [NPCs[[d]]].name has[NPCs[[d]]].relationship [NPCs[[d]]].name, and [NPCs[[d]]].relationship [NPCs[[d]]].name have
+
+started to recover from their illness.
+
+Unfortunately, not all have fared the same. Your
+
+[NPCs[[d]]].relationship [NPCs[[d]]].name has died. [NPCs[[d]]].relationship [NPCs[[d]]].name,and [NPCs[[d]]].relationship [NPCs[[d]]].name have died.
+
+Your servant [NPCsServants[[idx]]].name has died.servant [NPCsServants[[idx]]].name, and servant [NPCsServants[[idx]]].name have died.
+
+Your servant [NPCsServants[[idx]]].name has recovered.servant [NPCsServants[[idx]]].name, and servant [NPCsServants[[idx]]].name have recovered.
+
+In your [masterTitle]'s household, [NPCsMaster[[idx]]].relationship [NPCsMaster[[idx]]].name has died.[NPCsMaster[[idx]]].relationship [NPCsMaster[[idx]]].name, and [NPCsMaster[[idx]]].relationship [NPCsMaster[[idx]]].name have died.
+
+In your [masterTitle]'s household, [NPCsMaster[[idx]]].relationship [NPCsMaster[[idx]]].name has recovered.[NPCsMaster[[idx]]].relationship [NPCsMaster[[idx]]].name, and [NPCsMaster[[idx]]].relationship [NPCsMaster[[idx]]].name have recovered.
+
+Your [NPCsExtended[[idx]]].relationship [NPCsExtended[[idx]]].name has died.[NPCsExtended[[idx]]].relationship [NPCsExtended[[idx]]].name, and [NPCsExtended[[idx]]].relationship [NPCsExtended[[idx]]].name have died.
+
+Your [NPCsExtended[[idx]]].relationship [NPCsExtended[[idx]]].name has recovered.[NPCsExtended[[idx]]].relationship [NPCsExtended[[idx]]].name, and [NPCsExtended[[idx]]].relationship [NPCsExtended[[idx]]].name have recovered.
+
+As your condition declines, you pray constantly.
+
+Unfortunately, your reputation is so poor that you cannot convince any of your neighbors to bring food or medical supplies to your household any longer.
+Your friends and neighbors continue to bring you food and plague remedies, which they pass in through the windows taking care to keep their distance from you.
+
+But nothing works. At least you will grow too delirious to notice how miserable you are in the hours before your [death].
+But nothing works. At least you will grow too delirious to notice how miserable you are in the hours before your [death].
+Miraculously, after a few days you feel your fever break and your buboes begin to go down. Thanks be to God, you have survived the plague.
+
+[Too bad you and your household still have to be for the full 40 days, to make sure you don't spread the plague to anyone else.]
+```
+
+---
+
+## Passage 7: july-1665-helper widget
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+The graveyards are beginning to overflow and corpses are being flung into the open marshes of Tuttle-fields. There is still room in the New Chapel churchyard, that was walled in during the last plague at great public expenses, but only the rich whose families can afford to pay are being buried there now.
+
+[Worse, the first case of plague has appeared in your parish.]
+
+You have tried to slip a few corpses in from your parish and have been turned away. Luckily, their grieving families are still shut into their houses and can't come out to yell at you over the treatment of the dead.
+
+[image]
+Printed by R. Price, A corpse bearer; reproduction of an engraving from a series of London Cries, 1655. Wellcome Images
+
+A grieving family offers you a few pence to bury their dead without waiting for the searcher to come and examine the body. Do you \
+take the bribe take the bribe[Continue to August 1665]
+| refuse and wait for the searcher refuse and wait for the searcher[Continue to August 1665]?
+
+You stand watch outside quarantined houses, listening to the cries and pleas of those locked inside. Some beg you to let them out, swearing they are not sick, but you must hold your post.
+
+[image]
+A plague scene. Wellcome Collection
+
+Late one night, a desperate mother begs you to look the other way while she passes her healthy children out of the shut-up house. She presses a few coins into your hand. Do you \
+look the other way look the other way[Continue to August 1665]
+| refuse and hold your post refuse and hold your post[Continue to August 1665]?
+
+People attempt to bribe you to say that their loved ones died of something other than plague.
+
+[image]
+
+Nathaniel Parr, Three men loading plague victims from the street onto a cart to left, two of them smoking pipes to protect themselves, a figure with a bundle over his shoulder walking under an arch in the background to right; illustration to a 'History of England', c. 1747, published by Thomas Astley. British Museum.
+
+You say \
+yes yes[Continue to August 1665]
+| No no[Continue to August 1665].
+You fear death every day. You pray to God each morning for the strength to do your duty, and each night you pray for the souls of those patients who did not survive.
+
+[image]
+A man consuming many antidotes to the plague during the Great Plague of London. Etching by J. Franklin, 1841. Wellcome Collection
+
+A mother in one of the shut-up houses begs you to smuggle her healthy infant out before the sickness takes the child too. She offers you what little money she has. Do you \
+smuggle the infant out smuggle the infant out[Continue to August 1665]
+| refuse — the law is the law refuse[Continue to August 1665]?
+
+It feels like the church bells are ringing constantly, with each new death or funeral.
+
+The plague has followed the King's household to Hampton Court and one of his guards dies of plague at the end of the month.
+[Continue to August 1665]
+```
+
+---
+
+## Passage 8: august-1665-helper widget
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+The city has ordered public fasts and prayers to help combat the plague. You attempt to join a private meeting of your fellow Presbyterians in Covent Gardenbut are too poor and turned away, which is lucky for you because everyone who attends the meeting is arrested. They are told they can be released if they pay £5 each to help care for the poor of the city, but they refuse and so are imprisoned.
+
+Afraid of the worsening plague outbreak, the King removes his household even further away to the west, finally settling into the city of Salisbury. Unfortunately, there is no royal palace there and anyone who follows him will have to find their own makeshift lodgings somewhere else in the city.
+
+You can continue to try and prevent catching plague by visiting the apothecary, or you can:
+
+[Continue to September 1665]
+```
+
+---
+
+## Passage 9: January 1665
+
+**Tags:** storyline 1665
+
+```
+The Christmas festivities end with a great snowfall. It's bitterly cold and the frost doesn't break for over two weeks. Your family leaves you safe and warm at home while they attend on the king and queen at Court.That isn't enough to stop you from attending on the king and queen at Court and buying them expensive New Year's gifts to gain their favor. Freezing rain alternates with snow all winter and rumors swirl about the Dutch fleet.
+
+Even though you are one of the deserving poor and have a license to beg in your parish, few people are in a charitable mood. At least you have a roof over your head and receive bread each week, thanks to your parish's Overseers of the Poor
+, even if they put you to work to earn it
+.
+You are not freezing or starving to death, even if you are always cold and hungry.
+
+As the child of a day labourer, each member of your family has
+As a day labourer, you have
+to search for a job every day and the weather is so miserable that some days you can’t find work. But at least you have a roof over your head and there is enough money to buy at least bread for your household every week. You are not freezing or starving to death, even if you are always cold and hungry.
+
+As a servant, you spend as much time running errands outside as inside, but at least you have a roof over your head, warm clothes, and plenty to eat. But you can’t help but worry about how the war will impact your life.
+
+As
+the child of
+a , you spend much of your time working inside and are very glad to have a roof over your head, a fire in your hearth, and enough money for you and your <> to eat well. But you can’t help but worry about how the war will impact your
+family's
+trade.
+
+As the child of a merchant, you spend much of your time working inside and are very glad to have a roof over your head, a fire in each of your many hearths, and plenty of money to buy the latest fashions. But your family can’t help but worry about how the war will impact their trade.a merchant, you spend much of your time working inside and are very glad to have a roof over your head, a fire in each of your many hearths, and plenty of money to buy the latest fashions. But you can’t help but worry about how the war will impact your trade.
+
+As the child of a minor noble, you spend much of your time inside at the royal Court of King Charles II in hopes of securing more titles, honor, and riches for yourself and your family, especially since Queen Catherine and the Queen Mother both share your Catholic faith. You fill your days traveling among the royal family's various London palaces--including attending the Queen Mother's weekly social circle as faithfully as if it were church--and spending money on the latest fashions and trends. But you can’t help but worry about how the war will impact your life.
+
+[image]
+
+Anthony van Dyck, Queen Henrietta Maria of England, c. 1614-1641.
+
+It's almost a relief when war officially breaks out on March 4th.Things go from bad to worse for you when war officially breaks out on March 4th. Men pass back and forth through London, headed for the fleet—some voluntarily, some after having been impressed and forced into service.
+
+Finally, there is plenty of work to be had.
+You are doing laundry day in and day out in the city fields, which brings in enough money that you finally have enough to spend on things other than food and rent.
+
+Do you:
+
+- [[save it->May 1665][[money] to Math.clamp([money] + 120, -1000000, 1000000)]]
+- [[increase your donations to the poor->May 1665][[reputation] to Math.clamp([reputation] + 1, 0, 10); [money] to Math.clamp([money] - 120, -1000000, 1000000)]]
+- [[take a day off and splurge on a trip to the theatre->May 1665][[reputation] to Math.clamp([reputation] - 1, 0, 10); [money] to Math.clamp([money] - 120, -1000000, 1000000)]]
+
+A friend of one of your neighbors offers you twice your normal wages to help haul and cart goods for the Navy.
+
+Do you:
+
+- [[decide to accept this generous offer.|impressed][[impressed] += 1]][[decide to accept this generous offer.|May 1665][[money] to Math.clamp([money] + 480, -1000000, 1000000); [reputation] to Math.clamp([reputation] - 1, 0, 10)]]
+- [choose to continue working for one of your regular employers instead.]
+
+Your [masterTitle] warns you to keep a sharp eye out to avoid being impressed into the Navy yourself.
+
+Are you:
+
+- [careful to heed his warning]
+- [[not convinced it would be a worse life and spend as much of your--admittedly little--free time in the streets and alehouses as you did before|impressed][[impressed] += 1]][[not convinced it would be a worse life and spend as much of your--admittedly little--free time in the streets and alehouses as you did before|May 1665][[reputation] to Math.clamp([reputation] - 1, 0, 10)]]
+
+being harassed or mistaken for a woman of loose morals.
+
+Do you:
+
+- [[agree with his warning->May 1665][[reputation] to Math.clamp([reputation] + 1, 0, 10)]]
+- [[think he's overreacting and spend as much of your--admittedly little--free time in the streets and alehouses as you did before->May 1665][[reputation] to Math.clamp([reputation] - 1, 0, 10)]]
+
+For now, at least, your family's business is booming.
+
+When you go to church on Easter Sunday, you are reminded of how lucky you are as one of God’s chosen people.
+
+Do you:
+
+- [[celebrate your good fortune by increasing your donations to the poor->May 1665][[reputation] to Math.clamp([reputation] + 1, 0, 10); [money] to Math.clamp([money] - 560, -1000000, 1000000)]]
+- [[save your money in case of future misfortune->May 1665][[money] to Math.clamp([money] + 560, -1000000, 1000000)]]
+- [[take a day off and splurge on a trip to the theatre->May 1665][[reputation] to Math.clamp([reputation] - 1, 0, 10); [money] to Math.clamp([money] - 132, -1000000, 1000000)]]
+
+For now, at least, your family's business is booming.
+
+When you go to church on Easter Sunday, you are reminded of how lucky you are as one of God’s chosen people.
+
+Do you:
+
+- [[celebrate your good fortune by increasing your donations to the poor->May 1665][[reputation] to Math.clamp([reputation] + 1, 0, 10); [money] to Math.clamp([money] - 2800, -1000000, 1000000)]]
+- [[save your money in case of future misfortune->May 1665][[money] to Math.clamp([money] + 2800, -1000000, 1000000)]]
+- [[take some time off and go fox hunting in the countryside->May 1665][[reputation] to Math.clamp([reputation] - 1, 0, 10)]]
+
+Court is abuzz with gossip about the war and there’s plenty to keep an ambitious courtier busy.
+
+Do you:
+
+- [[throw in and help with the war effort->May 1665][[reputation] to Math.clamp([reputation] + 1, 0, 10); [money] to Math.clamp([money] - 10000, -1000000, 1000000)]]
+- [[keep yourself out of the fray and focus on your own needs->May 1665][[reputation] to Math.clamp([reputation] - 1, 0, 10)]]
+```
+
+---
+
+## Passage 10: StoryInit
+
+*This is a system passage (engine infrastructure — not narrative content).*
+
+*(no user-facing text — code/logic only)*
+
+---
+
+## Passage 11: PassageHeader
+
+*This is a system passage (engine infrastructure — not narrative content).*
+
+```
+, [location]
+```
+
+---
+
+## Passage 12: december-1664-helper widget
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+But those are worries for the future! For now, it is time to eat, drink, and play games with dice and cards to celebrate the Christmas season. You look forward to gathering with your neighbors in the parish church to celebrate the birth of Jesus Christ. You enjoy gathering with your fellow Catholics at the magnificent chapel attached to Somerset House, the Queen Mother Henrietta Maria's London home.
+
+You might not be able to celebrate as openly as a conforming member of the Church of England, or the papists who flock to the chapels of the Catholic Queen Catherine and Queen Mother Henrietta Maria, but you will still enjoy the holidays in the comfort and privacy of your home.
+
+Do you want to celebrate Christmas with a feast? Yes You convince your husband, and youYou convince your [masterTitle], and youYou convince your family, and youYou are planning a feast for a few friends. You're excited about all the things on the menu but especially your favorite dessert . Feasting costs money though, and things might be tight in the coming months, though your heart and stomach are full.
+
+On Christmas Eve, you see a comet in the sky and you wonder if it is [a sign of good things to come].
+
+[image]
+Great Comet of 1665
+| No You convince your husband to save money and forego a large feast for the holiday.You convince your [masterTitle] to save money and forego a large feast for the holiday.You convince your family to save money and forego a large feast for the holiday.You decide to save money and forego a large feast for the holiday.
+
+On Christmas Eve, you see a comet in the sky and you wonder if it is [a sign of good things to come].
+
+[image]
+Great Comet of 1665
+```
+
+---
+
+## Passage 13: NPC-funeral widget
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+Do you give [fName] a quick burial a quick burial. | a proper funeral a proper funeral.
+```
+
+---
+
+## Passage 14: char-gen-widgets
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+Household size: [hhSize]
+
+Household: fled to [hhlocation]
+
+[FledFamily[[i]]].name, [FledFamily[[i]]].age : healthy[FledFamily[[i]]].health.
+
+[NPCs[[i]]].name, [NPCs[[i]]].age : healthy[NPCs[[i]]].health.
+
+''Landlord's Household:
+
+[NPCs[[li]]].name, [NPCs[[li]]].age [NPCs[[li]]].relationship: [NPCs[[li]]].health.
+
+Extended family:
+
+[NPCsExtended[[e]]].name, [NPCsExtended[[e]]].age [NPCsExtended[[e]]].relationship: healthy[NPCsExtended[[e]]].health
+
+Household servants:
+
+[NPCsServants[[sv]]].name, [NPCsServants[[sv]]].age [NPCsServants[[sv]]].relationship: healthy[NPCsServants[[sv]]].health.
+
+Fled servants:
+[FledServants.length] fled to [hhlocation]
+
+Mistress'sMaster's Household:''
+[mhHealthy] healthy
+[mhInfected] infected
+[mhDeceased] deceased
+[mhRecovered] recovered
+```
+
+---
+
+## Passage 15: impressed
+
+```
+You've been taken by a press gang again!
+
+Luckily, you manage to prove to them that you are too young to be impressed into His Majesty's Navy. They turn you over to your Parish Overseers of the Poor, who decide that you are at risk of becoming one of the idle poor and have you with a local [MasterTrade]'s household.
+
+Luckily, you manage to prove to them that you are too olda woman and not eligible to be impressed into His Majesty's Navy. They turn you over to your Parish Overseers of the Poor, who have you in their next church service again.
+
+You have been impressed into His Majesty's Navy!
+
+Luckily for you, you are not a subject of the British monarch and should not have been impressed. You bribe a literate crewmate to write a letter to the Naval Board on your behalf, protesting your impressment.
+
+Your captain, on hearing about the letter, sends you back to London. While you successfully argue your case in front of the Naval Board, they are not pleased to hear they had a Dutchman on their ships. They imprison you as a spy and only release you at the end of the war in 1667.
+
+[How typical was your experience of the Great Plague of London? Let's find out!] where you successfully argue your case and are .
+
+As a subject of the British monarch, there is no escape from your impressment. You are put to work aboard a warship and spend the rest of the war at sea, far from the plague ravaging London.
+
+[How typical was your experience of the Great Plague of London? Let's find out!]
+```
+
+---
+
+## Passage 16: May 1665
+
+**Tags:** storyline 1665
+
+```
+As if war wasn’t bad enough, you begin to hear rumors around the city that several houses have been shut up because their inhabitants have plague.
+You
+decide to investigate investigate. After a few days, you decide to go see the truth of it for yourself and are horrified to find the rumors are true: several houses throughout the city had been locked up. Red crosses and the phrase Lord Have Mercy Upon Us have been painted on their front doors, to ensure that everyone knows this is a plague house.
+
+[You know that plague only grows worse as the weather warms and you dread the coming of June and the first real heat of summer.]
+
+[image]
+Lord haue mercy on London, c. 1665. | take their word for it. take their word for it and not investigate further.
+
+[You know that plague only grows worse as the weather warms and you dread the coming of June and the first real heat of summer.]
+```
+
+---
+
+## Passage 17: June 1665
+
+**Tags:** storyline 1665
+
+```
+On June 3rd, everyone throughout the city hears the sound of cannon fire—not the celebratory firing of cannons in ceremony but the sounds of battle. It is obvious that the English and Dutch fleets have engaged in battle, but where? How close are they to London? Who is winning? No one knows. You keep your head down and hide from your neighbors as much as possible, for fear that they will turn on you.
+
+Do you try to find out more?
+Yes
+You keep your ears open for news of the war. It takes almost a week, but news finally arrives of a great battle that killed many important men, especially on the ship of the Duke of York, James Stuart, the current heir to the throne—at least until the King and Queen manage to have children of their own. According to rumor, the battle came so close to killing the Duke that he was covered with blood and the head of a man named Mr. Boyle flew off and struck down the Duke. You happily repeat the rumors to anyone who will listen as bonfires break out in the street and people make merry, freely sharing their food and wine in celebration.
+
+[image]
+
+Peter Lely, James II, c. 1650-1675
+
+Do you want to be there for the next battle?
+
+Volunteer for the navy You have enlisted on [HMS Royal Sovereign] | Stay out of the fighting
+
+| No You don't listen to the gossip, but it's hard to ignore the shouts when news finally arrives of a great battle that killed many important men.
+
+Do you want to be there for the next battle?
+
+Volunteer for the navy You have enlisted on [HMS Royal Sovereign] | Stay out of the fighting
+```
+
+---
+
+## Passage 18: August 1665
+
+**Tags:** storyline 1665
+
+```
+People are dying so fast now that burials have to happen night and day to keep corpses from piling up throughout the city.
+
+As you take the dead to the graveyardsAlmost all the bodies you inspect are of plague victims andAs you stand guard outside quarantined houses, you see the dead being carried out in ever greater numbers andYour patients die almost as fast as you are assigned to care for them and you marvel at how much money is being wasted through the clothing that is buried with them. It’s illegal to take goods off the dead, and you know it’s dangerous as well.
+
+You decide to:
+
+- take some of the clothing to sell. You figure no one will notice, and you need the money.
+- leave things where they are.
+
+So many people are sick and shut up in their houses that the city has imposed a 9pm curfew for healthy people, so that the sick can go out for a bit of air.
+
+People are dying so fast now that burials have to happen night and day to keep corpses from piling up throughout the city.
+
+So many people are sick and shut up in their houses that the city has imposed a 9pm curfew for healthy people, so that the sick can go out for a bit of air. Do you adhere to the curfew? Yes, of course You keep to the curfew.
+
+[image]
+Nine images of the plague in London, 17th century, Wellcome Images.
+
+| No, I need to know more You step out, despite the curfew, hoping to hear more news. You learn that there is sickness in the fleet and everyone worries what that means for the war.
+
+[image]
+Nine images of the plague in London, 17th century, Wellcome Images.
+```
+
+---
+
+## Passage 19: September 1665
+
+**Tags:** storyline 1665
+
+```
+The deaths continue in such great numbers that you can hardly believe it.
+
+You are shocked to see that some bold people have begun attending plague funerals, as if it were a child’s game or dare.
+
+Some of those locked in their houses have grown desperate and you have had to physically restrain people trying to break out of quarantine.
+
+You have examined so many bodies, you sometimes wonder if anyone in your parish will survive.
+
+Some of your patients, furious at being locked in, have been trying to lean out windows to breathe and spit upon the healthy people walking past.
+
+Do you continue to go out in the city? No, better say inside for now You stay indoors.
+
+| Yes, you still need to go out to conduct business While out you see that a few brave souls have begun to attend plague funerals.
+Do you join them? Yes, I'll be fine You attend a few funerals for friends, confident that the low attendance will ensure your safety. Plus, it helps to be able to see the people you're mourning.
+
+| No, it's not safe You don't attend, but are secretly glad that the dead aren't being buried alone.
+```
+
+---
+
+## Passage 20: October 1665
+
+**Tags:** storyline 1665
+
+```
+October is miserably rainy and cold. Plague numbers are--thanks be to God--finally starting to come down, but are still terrifyingly high and you see sick people brazenly out and about on the streets.
+
+Do you report the sick to the pesthouse? Yes, I don't want them getting me sick You start reporting the sick people you see to the pesthouse, hoping to keep the streets free from their presence. You feel a bit bad about confining them to such an awful place, but your own safety is worth it.
+
+Rumors swirl about the Pope and the King of France dying, much to your alarm as a good Catholic and subject of the French monarchy, but to your relief you discoverbut alas they are only rumors.
+
+You hope the cold will deepen--and plague numbers continue to fall--as you head into [November 1665].
+| No, as long as they keep away from me You ignore the sick people you see, hoping that they keep to themselves.
+
+Rumors swirl about the Pope and the King of France dying, much to your alarm as a good Catholic and subject of the French monarchy, but to your relief you discoverbut alas they are only rumors.
+
+You hope the cold will deepen--and plague numbers continue to fall--as you head into [November 1665].
+```
+
+---
+
+## Passage 21: November 1665
+
+**Tags:** storyline 1665
+
+```
+The weather is terrible but plague numbers are coming down and people start to trickle back into town.
+Do you go out to visit your returning friends and neighbors? Yes, I've missed them greatly You go out in the streets to greet your returning friends and neighbors, glad to be reunited after these long months.
+You don't expect great things this Christmas, but you are still looking forward to [December 1665].
+
+| No, it's still not safe for socializing You don't go out in the streets to welcome back your friends and neighbors, but you do shout your greetings down from your window. You are glad to see them back. You don't expect great things this Christmas, but you are still looking forward to [December 1665].
+```
+
+---
+
+## Passage 22: December 1665
+
+**Tags:** storyline 1665
+
+```
+Plague numbers are up, despite two great frosts, and the Christmas festivities are all cancelled. You hope it's the last gasp of the outbreak, even as you reflect at how much different things are now than the were last year.
+
+Do you want to celebrate Christmas despite the risk? Yes You convince your husband, and youYou convince your [masterTitle], and youYou convince your family, and youYou are planning a feast for a few friends to make up for the dour attitude across the city. You're looking forward to the opportunity to forget the plague for a few hours and feast on your favorite food .
+
+The King decides to take the Court to Oxford to celebrate the Christmas festivities and settles into the Deanery at Christ Church College, the king's traditional lodgings when he is in residence. The rest of the Court is scattered in lodgings throughout the city.
+
+Do you wish to purchase a New Year's gift and send it to the King? Yes You send a fine jeweled cup to the King as a New Year's gift. In return, you receive a present of gilt silver plate. | No You decide not to send a gift this year.
+
+Maybe things will be better in [1666]. | No You convince your husband to stay safe and save money and forego a large feast for the holiday.You convince your [masterTitle] to stay safe and save money and forego a large feast for the holiday.You convince your family to stay safe and save money and forego a large feast for the holiday.You decide to stay safe and save money and forego a large feast for the holiday.
+
+The King decides to take the Court to Oxford to celebrate the Christmas festivities and settles into the Deanery at Christ Church College, the king's traditional lodgings when he is in residence. The rest of the Court is scattered in lodgings throughout the city.
+
+Do you wish to purchase a New Year's gift and send it to the King? Yes You send a fine jeweled cup to the King as a New Year's gift. In return, you receive a present of gilt silver plate. | No You decide not to send a gift this year.
+
+Maybe things will be better in [1666].
+```
+
+---
+
+## Passage 23: January 1666
+
+**Tags:** storyline 1666
+
+```
+Plague numbers continue to come down. Noble coaches fill the streets, porters are everywhere hauling the belongings of those who are returning to the city, all the shops are reopening, and beggars overflow the highways.
+
+Do you offer your services as a porter? Yes, I could use the extra money You keep busy offering the returning families your services as a porter, earning a few coins as you do so. You are glad to see the city so lively again.
+
+A bad storm blows down tiles from houses and shuts down river traffic, but all in all, it's a good month.
+
+You look forward to even better things in [February 1666]. | No, you keep out of people's way You don't venture out to help as a porter, hoping to avoid being run over by the many carts and carriages in the street. A bad storm blows down tiles from houses and shuts down river traffic, but all in all, it's a good month.
+
+You look forward to even better things in [February 1666].
+
+After six months of travel, the king finally returns the Court to Hampton Court Palace, so that he can be near to the City of London and the government officials working out of Westminster.
+
+You look forward to even better things in [February 1666].
+
+Do you offer to help any of your returning neighbors with their luggage? Yes You offer to help your returning neighbors carry some of their luggage. It is a good opportunity to catch up on all their news from their time in the country, and you are glad to talk to someone after the city has been so empty for so long. A bad storm blows down tiles from houses and shuts down river traffic, but all in all, it's a good month.
+
+You look forward to even better things in [February 1666]. | No You don't offer to help your returning neighbors, but you shout your greetings down to them, glad to see the city so lively again after it had been empty for so long. A bad storm blows down tiles from houses and shuts down river traffic, but all in all, it's a good month.
+
+You look forward to even better things in [February 1666].
+
+[image]
+Henry Petowe and Frank Percy Wilson, "London welcomes home her runaways". Taken from a woodcut in Henry Petowe's:The Countrie Ague, 1625. Wellcome Images
+```
+
+---
+
+## Passage 24: February 1666
+
+**Tags:** storyline 1666
+
+```
+The king has returned to London! People rejoice and return to their churches, knowing that if the king is willing to move back into his city palace of Whitehall, then the plague outbreak must be almost over. A great snow hides all the graves and it's as if the last year was all a terrible dream.
+
+And, as if you needed more opportunities to celebrate, it's almost Lent. Do you want to hold one last feast before it's time to begin fasting? Yes You convince your husband, and youYou convince your [masterTitle], and youYou convince your family, and youYou are planning a feast for a few friends. You're excited about all the things on the menu but especially your favorite dessert . Feasting costs money though, and things might be tight in the coming months, though your heart and stomach are full.
+
+Your parish priest hasn't returned yet, though, and his reputation plummets as the days tick over into [March 1666].
+
+| No You convince your husband to skip the feast.You convince your [masterTitle] to skip the feast.You convince your family to skip the feast.You decide against holding a feast. Do you instead go to the Queen's church for Ash Wednesday, the official beginning of Lent? Yes You instead go to the Queen's church for Ash Wednesday. Unfortunately your neighbors see you going into the Catholic Church and judge you harshly for abandoning your religious principles.
+
+Your parish priest hasn't returned yet, though, and his reputation plummets as the days tick over into [March 1666].
+
+| No You instead enjoy a quiet holiday inside, safe from the crowds and the plague.
+
+Your parish priest hasn't returned yet, though, and his reputation plummets as the days tick over into [March 1666].
+```
+
+---
+
+## Passage 25: March 1666
+
+**Tags:** storyline 1666
+
+```
+The Queen of Portugal, mother to England's beloved Queen Catherine, has died.
+
+Do you go to church and light a candle for the queen?Yes You go to church and light a candle for the late queen.
+
+| No You don't light a candle for the queen, but you do pray for her soul.
+```
+
+---
+
+## Passage 26: April 1666
+
+**Tags:** storyline 1666
+
+```
+There's no denying it now. Plague cases are definitely on the rise. Luckily, Sweden has declared itself on England's side in the war against the Dutch so at least things are looking more promising there. The Lenten fast is over it's time to celebrate Christ's resurrection on earth with Easter and the return of spring.
+
+Do you want to attend Easter services at your parish church, despite the risk of plague?
+
+Attend the service and take communion You gather with your neighbors to celebrate and unite in the glory of God. The last year has been terrible and the danger is not over, but for today at least you can set aside your troubles. | Attend the service but skip communion
+You gather with your neighbors to celebrate Easter but are too young to take communion.but can't bring yourself to join in their heretical communionbut you are too angry about the death around you to put aside your sins and take communion. Luckily, your churchwardens take mercy on you and don't fine you for skipping.Your reputation is so poor, you are reported for skipping communion and fined £20. | Skip church You can't bear to even set foot in a heretical church. Luckily, your churchwardens know that you only stay away because you fear contagion and don't fine you for non-attendance.Your reputation is so poor, you are reported for skipping communion and fined £20.
+```
+
+---
+
+## Passage 27: May 1666
+
+**Tags:** storyline 1666
+
+```
+Plague is increasing throughout the city, but that doesn't stop all of London from celebrating the king's birthday and the anniversary of the Restoration on May 29th with bonfires. Beggars throng the streets but, for once, no one seems to mind.
+
+While the king's return didn't lead to [religion] religious liberty, do you still want to celebrate?Yes You convince your husband that the king's birthday is an important holiday, and you take part in the toasting and feasting.You convince your [masterTitle] that the king's birthday is an important holiday, and you take part in the toasting and feasting.You convince your family that the king's birthday is an important holiday, and you take part in the toasting and feasting.You know that the king's birthday is an important holiday, and take part in the toasting and feasting.
+
+You are still recovering from the festivities when the days tip over into [June 1666]. | No You convince your husband not to celebrate, but yourYou convince your [masterTitle] not to celebrate, but yourYou convince your family not to celebrate, but yourYour neighbors notice when you don't join the revelers in the streets. While you claim you were afraid of plague, rumors fly about your religion and politics. It's not a great way to lead into [June 1666].
+
+You repeatedly toast the king and celebrate not just his return from exile, but also the restoration of a proper Church of England. You are still recovering from the festivities when the days tip over into [June 1666].
+```
+
+---
+
+## Passage 28: June 1666
+
+**Tags:** storyline 1666
+
+```
+The summer heat has hit London and everyone is feeling lethargic. Still, there are some things to do, like gossip with your neighbors. Do you listen to the gossip? Yes
+
+You hear rumors that the fleet has engaged the Dutch in battle again and the streets are full of people arguing over whether the four days of rumbling was cannon fire or thunder. Yes, the hot weather could have led to four days of distant thunder but the skies are clear and press gangs roam the street, grabbing any man they can.
+
+Do you want to join in the fight?
+
+Volunteer for the navy You have enlisted on [HMS Royal Sovereign] | Stay out of the fighting
+
+| No
+The sky has been rumbling for days and you wonder whether the sound was cannon fire or thunder. Yes, the hot weather could have led to four days of distant thunder but the skies are clear. You assume that this is why when you look out your window you can see press gangs roaming the street, grabbing any man they can.
+
+Do you want to volunteer to avoid being seized?
+
+Volunteer for the navy You have enlisted on [HMS Royal Sovereign] | Stay out of the fighting
+
+You avoid being pressed by keeping out of the way of the gangs. You don't know what future the city holds but at least it's better than being in the Navy.
+```
+
+---
+
+## Passage 29: July 1666
+
+**Tags:** storyline 1666
+
+```
+The heat of the city is oppressive but the worst is not the heat but the wails of women whose husbands have been impressed into the Fleet. Many of the men who have been impressed attempt to escape but are recaptured.
+
+Those who remain in the city hear the sounds of another battle in the distance--but any battle that is close enough for you can hear the cannon fire is too close.
+
+Do you want to join the Navy and defend the city where you were born and raised?
+
+Volunteer for the navy You have enlisted on [HMS Royal Sovereign] | Stay out of the fighting You wonder if you will make it to [August 1666].
+
+You wonder if you will make it to [August 1666].
+
+[image]
+By unknown Dutch artist, "Zee-Slag tussen de Engelse en Nederlandtse Vloot, op den 4 Aug. 1666." Engraving showing the St. James' Day Battle on August 4th, 1666 between English and Dutch ships
+```
+
+---
+
+## Passage 30: August 1666
+
+**Tags:** storyline 1666
+
+```
+As the summer heat engulfs the city, plague numbers continue to rise. But at least there's good news on the war front, as you hear that the fleet has burnt more Dutch ships.
+
+Do you want to join the victorious Navy and burn more Dutch ships?
+
+Volunteer for the navy You have enlisted on [HMS Royal Sovereign] | Stay out of the fighting
+You hope it will be enough to tide you through the last hot month of the year, as [September 1666] dawns.
+
+You hope it will be enough to tide you through the last hot month of the year, as [September 1666] dawns.
+```
+
+---
+
+## Passage 31: September 1666
+
+**Tags:** fire storyline 1666
+
+```
+Early one Sunday morning, you wake to the frantic ringing of church bells. This isn't the ordinary call to service—something you were looking forward to attending after you slept inas if you'd ever attend a service in the Church of England!—but rather a call to arms. When you stumble outside, you discover the city has caught fire around you.
+
+You immediately wake the nearest adult, who takes charge. You grab your favorite toysome of your clothes, then it's time to flee, with the fire nipping at your heels. You will have nightmares about this moment for weeks.
+
+You immediately alert your [masterTitle], who sends you out to find as many additional carts or boats as you can, to carry away their goods. Unfortunately, everyone is so busy saving their own households, they have little to spare for you. All you have is the single cart you already own. Luckily, you have friends and neighbors who hold you in high esteem and are willing to lend you carts. The household loads itthem up and you all flee with the fire nipping at your heels.
+
+You quickly organize your household to carry away all the most important things you own—agonizing over the tools of your trade that must be left behind—and flee with the fire nipping at your heels.
+
+You quickly organize your household to carry away all the most important things you own—sure, it isn't much, but you can't afford to replace any clothing you let burn much less your precious pots and pans—and flee with the fire nipping at your heels.
+
+You quickly organize your household to carry away all the most important things you own—sure, it isn't much, but you can't afford to replace any clothing you let burn—and flee with the fire nipping at your heels.
+
+You immediately send servants to find as many carts or boats as they can, to carry away your goods, and begin gathering your most important possessions—your money, your papers, your tally sticks. Unfortunately, everyone is so busy saving their own households, they have little to spare for your servants who return empty-handed. All you have is the single cart you already own, which will barely carry anything.Luckily, the servants soon return with several carts and you manage to send your most precious household goods out of the path of danger. After much agonizing, you task a servant to dig holes in the yard to bury your wine, Parmezan cheese, and most expensive books. Then you and the rest of your household gather all the things you can hold and flee with the fire nipping at your heels.
+
+You and your family take refuge in the open fields just outside the city and watch in horror as it burns for days.
+
+Your household takes refuge in a friend's house in Westminster and watch in horror as the city burns for days.
+
+One Sunday morning, you awaken and getting ready for church when you look out the window and realize there is a great fire in the distance. After dressing, you go out to find a neighbor who tells you that over 300 houses have burnt down in the night, by London Bridge.
+
+Curious, you walk down to the riversideto the Tower of London and climb up onto a high place, where you can see the houses on the end of the London Bridge all aflame. People are frantically flinging their belongings into the river and carrying the sick away in their beds as they run along the muddy riverbank.
+
+You ask around and discover the fire began in the King's Baker's house on Pudding Lane, but everyone believes the French were responsible and are looking for someone to blame. You quietly return home and bar the door, determined not to go out again until the streets are safe.
+
+A neighbor's cousin asks if you will help haul his belongings out of the path of the fire. Do you [[agree to help->October 1666][[reputation] to Math.clamp([reputation] + 1, 0, 10)]] or [[laugh him off and save your strength in case you need it to save your own things->October 1666][[reputation] to Math.clamp([reputation] - 1, 0, 10)]]?
+
+A neighbor's cousin asks if you will help haul his belongings out of the path of the fire. Do you [[agree to help->October 1666][[reputation] to Math.clamp([reputation] + 1, 0, 10)]] or [[laugh him off and save your strength in case you need it to save your own things->October 1666][[reputation] to Math.clamp([reputation] - 1, 0, 10)]]?
+
+A neighbor's cousin asks if he can borrow your cart. Do you [[agree to help->October 1666][[reputation] to Math.clamp([reputation] + 1, 0, 10)]] or [[laugh him off and keep your cart in case you need it to save your own things->October 1666][[reputation] to Math.clamp([reputation] - 1, 0, 10)]]?
+
+Everyone is still reeling from the shock of the Great Fire at the beginning of [October 1666].
+
+[image]
+Josepha Jane Battlehooke, The Great Fire of London, 1675
+```
+
+---
+
+## Passage 32: October 1666
+
+**Tags:** storyline 1666
+
+```
+You spend the next several weeks living in a field. The local parish church serves food three times a day to keep you and the others from starving, but winter is coming and you know that you'll freeze to death if you don't manage to find permanent shelter before then. Unfortunately, the first frost comes and you are still homeless because no one would take you in on account of your low reputation. Your only choices are to [return to your home in [origin]] or to You pray you don't [freeze].
+Luckily, just as the first frost hits the city, you manage to find a friend-of-a-friend who is willing to let you sleep on the floor until you can get more [permanent lodgings].
+
+You spend the next several weeks living in a field. Luckily, there is plenty of work clearing away the debris of the fire and you and your family manage to scrape together enough money to afford new lodgings in the eastern suburbs of the city. It's just a single room and you're a little worried that the building will fall down around you one night, but at least it's better than freezing to death in the fields. You're grateful to live long enough to see [November 1666].
+
+You and your family spend the next several weeks working to clear out the wreckage of your former home. Even though you work as fast as you can, you won't be able to rebuild before winter. Your poor reputation means that no one is willing to let you stay as a guest with them for long. Luckily, due to your young age, friends of the family allow you to stay with them through the [winter]. You end up having to leave the city for the winter You end up having to sleep in your office all winter You end up having to stay in crappy lodgings that are practically a hovel and well beneath your station and are [very unhappy about it].Because of your good reputation, friends allow you to stay with them through the [winter].
+
+Despite being afraid your home will burn, you find yourself in the enviable position of living in one of the few remaining parishes within the city walls.
+
+There's so many people homeless that there's money to be made for someone who's willing to rent out a few rooms of their house, especially with such rainy weather and the increasing cold. You instruct your man of business to make sure none of your tenants are illegally subletting.Not that you have room for such a thing, unfortunately.Not that it's your house to make such decisions about, of course.
+
+The weather may be miserable, but every disaster has a silver lining. Between the fires that still smolder in the city's cellars and the rainy weather, plague cases are plummeting and you've heard that the theatres are finally going to reopen!
+
+You greatly look forward to [November 1666]
+```
+
+---
+
+## Passage 33: November 1666
+
+**Tags:** storyline 1666
+
+```
+One November day, the church bells peal out in alarm again--not from the destroyed part of the city within its ancient walls, but from the king's palace at Whitehall, especially the area around Horse Guards. Everyone rushes to put out the fire at all costs, unwilling to have a repeat of September's disaster. Thankfully, no lives are lost.
+
+Even better, the king declares the official thanksgiving day for the end of the plague. Yes, some people are still dying, but the numbers are low enough and the epidemic has been going on long enough that most everyone is grateful for its official end.
+
+As Advent begins, you look forward to actually being able to properly [celebrate Christmas this year.]
+```
+
+---
+
+## Passage 34: December 1666
+
+**Tags:** storyline 1666
+
+```
+Fires still smolder in cellars throughout the city. Trouble is brewing in Scotland. The general bill of this year's deaths show many lamentable plague deaths. But you have made it through 1666 and you thank God you are still alive!
+
+Congratulations. You have [survived the Great Plague of London]
+```
+
+---
+
+## Passage 35: master-death widget
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+< b.agenum - a.agenum)>>
+
+Following the death of your [smdOldTitle], your 's father has taken over as head of the household.
+
+Following the death of your [smdOldTitle], your 's mother has taken over as head of the household.
+
+Following the death of your [smdOldTitle], your 's oldest son has become the new head of the household.
+
+Following the death of your [smdOldTitle] without any surviving relatives to take over the household, you have found a new position with a new employer.
+```
+
+---
+
+## Passage 36: widow widget
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+*(no user-facing text — code/logic only)*
+
+---
+
+## Passage 37: work-refusal
+
+```
+Because you refused to work, your parish's Overseers of the Poor have committed you to the gaol!
+
+Do you:
+[[beg for forgiveness and agree to work->ForgiveMe][[decisions.push]({text: "Begged for forgiveness and agreed to work", money: 0, repDelta: 0, repBefore: [reputation], infectPct: null})]]
+
+[[stand firm in your refusal to risk your life->transported][[decisions.push]({text: "Stood firm and was transported", money: 0, repDelta: 0, repBefore: [reputation], infectPct: null})]]
+
+[[stand firm in your refusal to risk your life->deported][[decisions.push]({text: "Stood firm and was deported", money: 0, repDelta: 0, repBefore: [reputation], infectPct: null})]]
+
+Because you are no longer working, you quickly run out of money and have to throw yourself on the mercy of your parish's Overseers of the Poor.
+
+They have decided it will be your job to
+look at the corpses and determine if they died of plague or some other cause of death
+
+[image]
+
+Nathaniel Parr, published by Thomas Astley, Plague in 1665, 1747
+stand guard outside quarantined houses to prevent anyone from escaping.
+
+nurse the sick and dying, despite the risk to your own life.
+remove the plague corpses of anyone who dies.
+
+[image]
+
+Printed by R. Price, A corpse bearer; reproduction of an engraving from a series of London Cries, 1655. Wellcome Images
+
+You have no choice but to .
+As you are not a member of the Church of England, the parish cannot assign you to plague work.The parish does not consider you old enough for plague work. You have no choice but to .
+```
+
+---
+
+## Passage 38: July 1665
+
+**Tags:** storyline 1665
+
+```
+Despite the English fleet's victory, the war grinds on and rumors begin to circulate that the French are considering siding with the Dutch. You make sure to talk loudly of your loyalty to the King and the superiority of the English fleet, whenever your neighbors mention the war.
+
+Do you volunteer to help fight the French?
+
+Volunteer for the navy You have enlisted on [HMS Royal Sovereign] | Stay out of the fighting
+Do you go looking for more information?
+Yes
+There aren't as many rumors as there might have been, given how many people have fled the city and how afraid the people who remain are of coming near each other.
+
+|
+No
+
+Do you go looking for more information?
+Yes
+There aren't as many rumors as there might have been, given how many people have fled the city and how afraid the people who remain are of coming near each other.
+
+|
+No
+```
+
+---
+
+## Passage 39: FamPesthouse
+
+**Tags:** infection-rates
+
+```
+It is a difficult decision, but with your among the sick, you decideyour family decidewith your fatherparent among the sick, you decideyour family decidewith your [masterTitle] among the sick, you decideyour [masterTitle] decideswith your husband among the sick, you decideyour family decideyou decide it's for the best to send your sick to the pesthouse.
+
+To your horror, rumors swirl that your family have actually murdered a member of your household and hidden the body! Remembering the rumors of murder that circulated last time your family sent someone to the household, you You send to the master of the pesthouse to produce a certificate for you that proves the rumor is a lie.
+
+Despite the pesthouse's care, your [NPCs[[idx]]].relationship [NPCs[[idx]]].name has died.[NPCs[[idx]]].relationship [NPCs[[idx]]].name, and [NPCs[[idx]]].relationship [NPCs[[idx]]].name have died.
+
+Your servant [NPCsServants[[idx]]].name has also died in the pesthouse.[NPCsServants[[idx]]].name, and [NPCsServants[[idx]]].name have also died in the pesthouse.
+
+Thankfully, your [NPCs[[idx]]].relationship [NPCs[[idx]]].name has survived.[NPCs[[idx]]].relationship [NPCs[[idx]]].name, and [NPCs[[idx]]].relationship [NPCs[[idx]]].name have survived.
+
+Your servant [NPCsServants[[idx]]].name has also survived.[NPCsServants[[idx]]].name, and [NPCsServants[[idx]]].name have also survived.
+
+[image]
+
+The pest house and plague pit, Moorfields, London. Wood engraving. Wellcome Images.
+```
+
+---
+
+## Passage 40: sick-fam-widget
+
+**Tags:** widget infection-rates
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+As morning dawns, a terrible realization settles over your household. Your
+
+[allInfected][0].rel [allInfected][0].name is infected with the plague.
+
+[inf].rel, [inf].name, and [inf].rel, [inf].name, are infected with the plague.
+
+As a good Christian, it is your duty to look after the poor, sick, and needy. But as a good Christian, you also know it is a sin to needlessly risk your life. With your too ill to make decisions, the responsibility falls to you. Do youDo you convince your household toWith your fatherparent too ill to make decisions, the responsibility falls to you. Do youDo you convince your family toWith your [masterTitle] too ill to give orders, the decision falls to you. Do youDo you convince your [masterTitle] toWith your husband too ill to make decisions, you must decide for yourself. Do youDo you convince your husband toDo you:
+
+- [[Quarantine with your household->Quarantine, Week 1][[reputation] to Math.clamp([reputation] + 3, 0, 10)]]
+- [[Send the sick to the pesthouse->FamPesthouse][[reputation] to Math.clamp([reputation] - 3, 0, 10)]]
+
+You prepare your household to flee the city. It takes some time to sort out the travel logistics, but finally everything is in order. They will leave tomorrow.
+
+Your servant [NPCsServants[[idx]]].name has died.servant [NPCsServants[[idx]]].name, and servant [NPCsServants[[idx]]].name have died.
+
+Your servant [NPCsServants[[idx]]].name has recovered.servant [NPCsServants[[idx]]].name, and servant [NPCsServants[[idx]]].name have recovered.
+
+In your [masterTitle]'s household, [NPCsMaster[[idx]]].relationship [NPCsMaster[[idx]]].name has died.[NPCsMaster[[idx]]].relationship [NPCsMaster[[idx]]].name, and [NPCsMaster[[idx]]].relationship [NPCsMaster[[idx]]].name have died.
+
+In your [masterTitle]'s household, [NPCsMaster[[idx]]].relationship [NPCsMaster[[idx]]].name has recovered.[NPCsMaster[[idx]]].relationship [NPCsMaster[[idx]]].name, and [NPCsMaster[[idx]]].relationship [NPCsMaster[[idx]]].name have recovered.
+
+Your [NPCsExtended[[idx]]].relationship [NPCsExtended[[idx]]].name has died.[NPCsExtended[[idx]]].relationship [NPCsExtended[[idx]]].name, and [NPCsExtended[[idx]]].relationship [NPCsExtended[[idx]]].name have died.
+
+Your [NPCsExtended[[idx]]].relationship [NPCsExtended[[idx]]].name has recovered.[NPCsExtended[[idx]]].relationship [NPCsExtended[[idx]]].name, and [NPCsExtended[[idx]]].relationship [NPCsExtended[[idx]]].name have recovered.
+
+Word reaches you that plague has struck your [masterTitle]'s household. Your
+
+[NPCsMaster[[idx]]].relationship [NPCsMaster[[idx]]].name is infected with the plague.
+
+[NPCsMaster[[idx]]].relationship, [NPCsMaster[[idx]]].name, and [NPCsMaster[[idx]]].relationship, [NPCsMaster[[idx]]].name are infected with the plague.
+
+Word reaches you that plague has struck your extended family. Your
+
+[NPCsExtended[[idx]]].relationship [NPCsExtended[[idx]]].name is infected with the plague.
+
+[NPCsExtended[[idx]]].relationship, [NPCsExtended[[idx]]].name, and [NPCsExtended[[idx]]].relationship, [NPCsExtended[[idx]]].name are infected with the plague.
+
+As a good Christian, it is your duty to look after the poor, sick, and needy. But as a good Christian, you also know it is a sin to needlessly risk your life. With your too ill to make decisions, the responsibility falls to you. Do youDo you convince your household toWith your fatherparent too ill to make decisions, the responsibility falls to you. Do youDo you convince your family toWith your [masterTitle] too ill to give orders, the decision falls to you. Do youDo you convince your [masterTitle] toWith your husband too ill to make decisions, you must decide for yourself. Do youDo you convince your husband toDo you:
+
+- Quarantine with the sick
+- Remain in your own household You decide to remain in your own household and pray for the sick. Despite your prayers, your [name] hasyour [name], and your [name] have died. Thankfully, your [name] hasyour [name], and your [name] have survived.
+```
+
+---
+
+## Passage 41: storyline-return widget
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+<= [timeline.length]>>
+```
+
+---
+
+## Passage 42: Hide
+
+**Tags:** infection-rates
+
+```
+You attempt to hide your illness from everyone, hoping that if you just ignore it then the lump will go away.
+
+Unfortunately, that's not how plague works. The lump gets bigger and is soon joined by even more lumps. They are now undeniably plague buboes.
+
+The King is furious at your deception and [banishes you to your country estate]. Your neighbors realize you attempted to hide your sickness and decide you can no longer be trusted. Not only do they shut up your household, they also conspire to have you [removed to the pesthouse] despite your high social status to keep the plague from spreading further.
+```
+
+---
+
+## Passage 43: banished
+
+```
+All but the most loyal—or desperate—servants flee from your country estate. The villagers refuse to receive your servants and even the local priest hesitates to come pray for you.
+
+Luckily, you will be too delirious to notice that the remainder of your servants all abandon you in the hours before your [death].
+Luckily, despite your disgrace, your final few servants stay by your side, praying for your life and administering every plague remedy known to mankind.
+
+You don't know which helps more, but after a few days you feel your fever break and your buboes begin to go down. Thanks be to God, you have survived the plague.
+
+Now you just have to figure out how to overcome your disgrace and find your way back into the King's good graces. Groveling will obviously have to be involved, but that won't be enough. Do you also:
+
+- [You hire an artist to paint portraits of the most beautiful women at court to present to the King and hope it will help restore you to favor.]
+- [You pour money into the war effort and hope it will help restor you to favor.]
+- [You write to the Queen and hope that her favor will help restore you to the King's favor.]
+- [You collect several poems composed in the King's honor and add a new one of your own, which you send to the King in hopes of regaining his favor.]
+```
+
+---
+
+## Passage 44: YouPesthouse
+
+**Tags:** infection-rates
+
+```
+The pesthouse is a terrible place to be confined, with countless sick people all crammed in close together so you can hear their every moan. They die terrifyingly fast and their cots refill just as quickly. You toss and turn in your dirty, sweat-soaked sheets, as your fever spikes and you fear for your life.
+
+It occurs to you that perhaps you ought to have written your will, but your reputation is so poor and the pesthouse is so terrifying that no one can be convinced to bring you the writing materials you need.
+
+It occurs to you that perhaps you ought to have written your will, but your reputation is so poor and the pesthouse is so terrifying that you can't convince a scrivener to come help you.
+
+Luckily, you will grow too delirious to notice how miserable you are in the hours before your [death].You spend all your remaining energy in prayer that God will spare you from death. Despite the neglect of the overworked pesthouse staff, after a few days you feel your fever break and your buboes begin to go down. Thanks be to God, you have survived the plague.
+
+[image]
+
+The pest house and plague pit, Moorfields, London. Wood engraving. Wellcome Images.
+
+Now you just have to figure out how to overcome your disgrace when you return home to your neighborhood. You decide to start by:
+
+[You pray your penance is enough to restore your good name.]
+
+[You pray your penance is enough to restore your good name.]
+```
+
+---
+
+## Passage 45: deported
+
+```
+Since you refuse to work in London, the local authorities decide to have you deported back to [origin].
+
+Do you:
+[try to escape and return to London]
+[go quietly]
+```
+
+---
+
+## Passage 46: escape
+
+```
+You try to escape
+but are immediately caught. The local authorities decide the safest course of action now is to have you [transported] to the New World.
+and manage to sneak back into London.
+Luckily, one of your neighbors takes pity on you and lets you stay with them while you seek work and a new place to stay. You .
+Unfortunately, now you are now homeless, no longer receiving alms from your parish's Overseers for the Poor, and cannot legally beg anymore. It doesn't take long before you are caught and thrown in gaol.
+
+Do you:
+beg for forgiveness and agree to work
+
+[stand firm in your refusal to risk your life]
+```
+
+---
+
+## Passage 47: go quietly
+
+```
+There's no plague in the New World, so you decide to take a chance and move to the colonies. It's a rough journey and difficult to start over again somewhere so different. You will always miss London.
+
+You return to [origin] and never see London again.
+
+But at least you didn't die of plague!
+
+[How typical was your experience of the Great Plague of London? Let's find out!]
+```
+
+---
+
+## Passage 48: stats
+
+```
+Your Story
+
+Player Stats
+
+- Name: [name]
+- Age: [age]
+- Gender: [gender]
+- Religion: [religion]
+- Social class: [socio]
+- Location: [location]
+- Pre-fire location: [preFireLocation]
+- Pre-fire parish: [preFireParish]
+- Origin: [origin]
+- Reputation: [reputation] — a worthy soulof good credit and qualitybad credit is better than nonea worthless and base rogue
+- Wealth:
+- Role: [role]
+
+Household
+
+- [NPCs[[i]]].name ([NPCs[[i]]].relationship) - [NPCs[[i]]].health
+
+You have no household members.
+
+Fled Family
+
+- [FledFamily[[i]]].name ([FledFamily[[i]]].relationship) - [FledFamily[[i]]].health
+
+Servants
+
+- [NPCsServants[[i]]].name - [NPCsServants[[i]]].health
+
+Decisions Made
+
+-
+- Cost: - Earned: - Reputation increased<= 9 ? "a worthy soul" : [d].repBefore >= 6 ? "of good credit and quality" : [d].repBefore >= 3 ? "bad credit is better than none" : "a worthless and base rogue")>><= 9 ? "a worthy soul" : [rA] >= 6 ? "of good credit and quality" : [rA] >= 3 ? "bad credit is better than none" : "a worthless and base rogue")>> from to - Reputation decreased<= 9 ? "a worthy soul" : [d].repBefore >= 6 ? "of good credit and quality" : [d].repBefore >= 3 ? "bad credit is better than none" : "a worthless and base rogue")>><= 9 ? "a worthy soul" : [rA] >= 6 ? "of good credit and quality" : [rA] >= 3 ? "bad credit is better than none" : "a worthless and base rogue")>> from to - % chance of plague infection- Reduced risk of plague infection
+
+No decisions recorded yet.
+
+Fumes and Remedies
+
+Fumigants
+Using fumigants during quarantine decreased the chance of plague spreading to each healthy member of your household by 50% (from a 1 in 2 chance to a 1 in 4 chance per person per week).
+ItemRemaining
+
+[key].name_key.quantity
+
+Remedies
+ItemRemainingGame Effect
+[remedies.Plaster.name][remedies.Plaster.quantityDecreased] the chance of death from plague from 1 in 2 (50%) to 1 in 3 (~33%) for you and your infected household members
+[remedies.Celestial.name][remedies.Celestial.quantityPreventative] medicine with no direct effect on survival rates
+[remedies.Treacle.name][remedies.Treacle.quantityNo] mechanical effect on survival rates
+[remedies.Cordial.name][remedies.Cordial.quantityNo] mechanical effect on survival rates
+[remedies.Suppository.name][remedies.Suppository.quantityNo] mechanical effect on survival rates
+[remedies.Immodium.name][remedies.Immodium.quantityNo] mechanical effect on survival rates
+
+How Representative Was Your Experience?
+The following sections place your experience in historical context, using data from the Bills of Mortality and other primary sources.
+```
+
+---
+
+## Passage 49: transported
+
+```
+The local authorities decide to have you bound into indentured servitude and shipped to the colony of Virginia.
+
+If you don't die during the perilous months' long journey across the Atlantic, you'll probably die of disease or violence within the first couple of years after your arrival.
+
+Though if by God's grace you do survive it all, at the end you will be given your freedom and enough land to start growing crops.
+
+Good luck! You'll need it...
+
+[How typical was your experience of the Great Plague of London? Let's find out!]
+```
+
+---
+
+## Passage 50: sickPC
+
+**Tags:** widget infection-rates
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+Lord have mercy! A strange lump has appeared on your
+
+neck and there's no hiding that you have caught the dreaded [plague].
+leg
+armpit.
+Do you:
+
+- warn people you have [plague]
+- [[try to hide it ->Hide][[reputation] to Math.clamp([reputation] - 3, 0, 10)]]
+```
+
+---
+
+## Passage 51: beggar-choice widgets
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+The alms you receive from your parish are just enough to pay for your housing and keep you from starvation, but you're always hungry and one unexpeced expense away from disaster. You know there has to be a better way, but you're not sure what that way is.
+
+It's illegal to beg on the highways, but you wonder if you would have better luck there.
+
+Do you:
+
+- [[beg on the highways, even though you know it's illegal|impressed][[impressed] += 1]][[beg on the highways, even though you know it's illegal->begging-success][[reputation] to Math.clamp([reputation] - 1, 0, 10)]]
+- [[put your trust in the charity of your neighbors->good-neighbors][[reputation] to Math.clamp([reputation] + 1, 0, 10)]]
+- take in extra laundry from your neighbors
+- offer to wash the church linens and sweep clean your church
+-
+```
+
+---
+
+## Passage 52: begging-success
+
+```
+Despite begging daily on the highway, you only earned an extra [beggarsluck] pence.
+
+While this is enough for a little extra bread, you are painfully aware that this came at a cost to your reputation with your neighbors.
+```
+
+---
+
+## Passage 53: good-neighbors
+
+```
+One of your neighbors provides you with leftovers from a feastgives you some moldy breadlets you have an old dress, which you sell for a bit of extra bread. Because you didn't have to spend as much money on food, you manage to save an extra [beggarsluck] pence.
+```
+
+---
+
+## Passage 54: beggar-roles
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+and the Overseers of the Poor have decided it will be your job to
+look at the corpses and determine if they died of plague or some other cause of death
+
+[image]
+Nathaniel Parr, published by Thomas Astley, Plague in 1665, 1747.
+stand guard outside quarantined houses to prevent anyone from escaping
+
+nurse the sick and dying, despite the risk to your own life
+remove the plague corpses if anyone dies
+
+[image]
+Printed by R. Price, A corpse bearer; reproduction of an engraving from a series of London Cries, 1655. Wellcome Images
+
+, but the Overseers of the Poor have refused to hire you for plague work, as only members of the Church of England may serve in such parish offices, as you are not old enough for such work
+.
+Many of your neighbors begin to flee the city and those who remain curse at you to leave when you try begging at their doors.
+
+You decide to:
+
+- [[Remain in the city->Stay][[fled] to 4; [decisions.push]({text: "Remained in the city", money: 0, repDelta: 0, repBefore: [reputation], infectPct: null})]]
+- [[Flee the city and return to [origin]->Fled][[fled] to 6; [decisions.push]({text: "Fled back to place of origin", money: 0, repDelta: 0, repBefore: [reputation], infectPct: null})]]
+```
+
+---
+
+## Passage 55: freeze
+
+```
+You quietly freeze to death, but at least it was a painless way to go.
+```
+
+---
+
+## Passage 56: StoryCaption
+
+*This is a system passage (engine infrastructure — not narrative content).*
+
+```
+Your reputation is good.Your reputation is bad.
+
+Income: [income]
+Monthly spending: [expenses]
+
+Total wealth: [money] ()
+
+Pre-fire location: [preFireLocation]
+
+Pre-fire parish: [preFireParish]
+
+Inventory
+```
+
+---
+
+## Passage 57: ForgiveMe
+
+```
+Forgiveness is a Christian virtue and you are lucky that your neighbors practice it. You publicly apologize and are officially forgiven, though it will take a while longer before your reputation is restored.
+```
+
+---
+
+## Passage 58: debtor widgets
+
+**Tags:** widget money
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+While nobles are expected to lead a lavish lifestyle, you've been spending so far beyond your income that it's finally caught up to you.
+
+You never have much money to spare, but things have gone more poorly than usual lately.
+
+Your [masterTitle] learns of your debts and, valuing your service, pays them off on your behalf. You are grateful, but your reputation has suffered for your inability to manage your own affairs.
+
+Your [masterTitle] learns of your debts and is furious. Due to your poor reputation, your [masterTitle] has dismissed you from service. You will have to hope you can survive as a day labourer.
+
+Your household has fallen so far into debt that creditors have demanded someone answer for it. To your distress, your [hohNPCRel], [hohNPCName], is thrown into debtor's prison. To your relief, your [hohNPCRel]'s creditors agree to due to your family's good reputation. [hohNPCName] is committed to the Fleet and forced to reside there until the debts are reduced.
+
+To your humiliation, you've fallen so far into debt that your creditors have demanded you be thrown in debtor's prison. To your relief, your creditors agree to due to your good reputation. You are committed to the Fleet and forced to reside there until you reduce your debts.
+
+You are in debt and can no longer afford your recurring expenses. The following have been cancelled: .
+
+You are running desperately low on money. With no income coming in, your debts are mounting. Do you risk breaking quarantine to earn some money?
+
+Attempt to break quarantine
+
+You are caught by the warder as you attempt to sneak out of the house and have been committed to the pesthouse.
+
+[You are dragged away.]
+
+You have successfully evaded the warder outside your house and managed to bring in a little income to stave off your creditors.
+
+| Endure the hardship You tighten your belt and pray your creditors will be patient.
+```
+
+---
+
+## Passage 59: Quarantine, Week 1
+
+**Tags:** quarantine
+
+```
+Your neighbors shut up the entrances to your house and paint a red cross with the words Lord Have Mercy on the front door.
+
+You have heard and read about different courses of treatment for the sick.
+You tend to the sick and suffering.
+
+The week is full of sorrows. Despite your care, your
+
+[NPCs[[d]]].relationship, [NPCs[[d]]].name has died.
+[NPCs[[d]]].relationship, [NPCs[[d]]].name,
+and [NPCs[[d]]].relationship, [NPCs[[d]]].name have died.
+
+There is some good news, though. The treatments seem to be helping, and your
+
+[NPCs[[d]]].relationship, [NPCs[[d]]].name has started to recover from their illness.
+
+[NPCs[[d]]].relationship, [NPCs[[d]]].name
+and [NPCs[[d]]].relationship, [NPCs[[d]]].name have started to recover from their illness.
+
+You must remain in quarantine for at least three more weeks, however, and only time will tell if the disease has spread.
+
+[You pray that God does have mercy on your household as you continue to nurse the sick.]
+[You pray that God does have mercy on your household as you continue to nurse the sick.]
+```
+
+---
+
+## Passage 60: Quarantine Continues
+
+**Tags:** quarantine
+
+```
+The first week was agony. The second is no better.
+
+As you enter the third week of quarantine, even the smallest glimmer of hope is a welcome relief.
+
+After nearly a month in quarantine, you begin to believe you might survive this.
+
+You have now been in quarantine for over a month, and there is no sign that the plague's spread is slowing. It seems a miracle that you have not fallen ill yourself.
+
+You have been in quarantine so long, you've lost track of time. The days are interminable.
+
+While the recovery process is slow for those who were ill, the infection does not seem to have spread any further. You must remain in quarantine, and [only time will tell if the disease has spread.]You must remain in quarantine for at least two more weeks, and [only time will tell if the disease has spread.]
+The infection seems to have burned itself out, and you can now focus on the recovery of those who survived.
+
+[You wonder what has happened while you were away from the world.][You wonder what has happened while you were away from the world.]
+
+Unfortunately, even more members of your household have fallen ill. Your The illness has spread through your household and your
+
+[NPCs[[y]]].relationship [NPCs[[y]]].name is now infected.
+
+[NPCs[[y]]].relationship [NPCs[[y]]].name, and [NPCs[[y]]].relationship [NPCs[[y]]].name are now infected.
+
+Despite your care, your
+
+[NPCs[[d]]].relationship [NPCs[[d]]].name has died. [NPCs[[d]]].relationship [NPCs[[d]]].name, and [NPCs[[d]]].relationship [NPCs[[d]]].name have died.
+
+There is some good news, though. The treatments seem to be helping, and your
+
+[NPCs[[d]]].relationship [NPCs[[d]]].name has started to recover from their illness. [NPCs[[d]]].relationship [NPCs[[d]]].name and [NPCs[[d]]].relationship [NPCs[[d]]].name have started to recover from their illness.
+
+You must remain in quarantine for at least two more weeks, however, and only time will tell if the disease has spread.
+You wonder what has been taking place in the outside world and hope for even a small bit of news as you enter the final weeks of quarantine.
+
+[You fear more of your family will die. You are even more afraid you will fall ill next.][The days continue to pass with agonizing slowness.][You wonder what has happened while you were away from the world.]
+[You fear more of your family will die. You are even more afraid you will fall ill next.][The days continue to pass with agonizing slowness.]
+[You wonder what has happened while you were away from the world.]
+[You wonder what has happened while you were away from the world.]
+```
+
+---
+
+## Passage 61: gating widgets
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+[contents]
+```
+
+---
+
+## Passage 62: death widget
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+You died with such a poor reputation that most of your neighbors didn't care. The rest of them probably cursed your name and hoped you were suffering in hell. Luckily,
+You died with a good enough reputation that your neighbors say prayers for your soul. Because of the plague ordinances, none of your neighbors could attend your funeral but
+
+as a member of the nobility, you were interred in a position of honor in a vault within your family's private chapel.
+you were rich enough to be buried within the walls of your parish churchyard. Your heirs, of course, paid extremely well for that privilege.
+your body was at least carefully wrapped in a burial shroud before being put into the communal plague pits, late at night with no one to witness your burial.
+your body was at least put into the communal plague pits, instead of being left out to rot.
+
+You died with a good enough reputation that your neighbors say prayers for your soul.
+As a member of the nobility, you were interred in a position of honor in a vault within your family's private chapel.
+You were rich enough to be buried within the walls of your parish churchyard. Your heirs, of course, paid extremely well for that privilege.
+Your body was carefully wrapped in a burial shroud and buried on the ground of your parish churchyard.
+Your body was buried in your parish churchyard.
+
+You died with such a poor reputation that most of your neighbors didn't care. The rest of them probably cursed your name and hoped you were suffering in hell.
+
+As a God-fearing Catholic, you know you are destined to spend time in purgatory before you can ascend to heaven but you hope that will not take too long, despite your poor reputation on earth.As a good Protestant, you know that Christ the Redeemer has died for you and your admittance to heaven is guaranteed.
+
+[How typical was your experience of the Great Plague of London? Let's find out!]
+```
+
+---
+
+## Passage 63: Fled
+
+**Tags:** fled
+
+```
+You have abandoned your parish and been removed from your position as [office].
+
+You convince your family to have decided to flee to your country estate.
+
+Your [masterTitle] flees London with you and the rest of herhis household. You have only a little time to prepare and say goodbye to your friends before you leave.
+
+You convince your family decide to flee the city to save yourself. Unfortunately, with no money and no reputation to speak of anymore, you only have the option of illegally begging along the road to survive.
+You decide to flee the city and return to [origin].
+
+Despite being safely out of harm's way, you closely follow the news of London's plague outbreak. As the death toll rises, you worry about the people you know back in the city but are relieved that you are out of harm's way.
+
+In fact, you and your family are determined to stay away:
+
+- [until the end of the summer, when plague death should start coming down again]
+- [until the winter, when plague typically goes away]
+- [until the King and his court decide it's safe to return to the city]
+- [[until the official Day of Thanksgiving for the end of the plague outbreak->official-end][[fledReturn] to "official"]]
+- [[until there are no more plague deaths in London->official-end][[fledReturn] to "no-plague"]]
+- [for good]
+```
+
+---
+
+## Passage 64: flight-choice
+
+**Tags:** widget fled
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+[You know that plague only grows worse as the weather warms, and you dread the coming of June and the first real heat of summer.]
+[Continue to August 1665]
+[Continue to July 1665]
+
+You begin to make preparations to leave the city, but as you do you notice a strange lump forming on your body. God's wounds &mdash; you have caught the plague! There will be no fleeing now.
+
+You prepare your household to flee the city. It takes some time to sort out the travel logistics, but finally everything is in order. They will leave tomorrow.
+
+You still have family back home in [origin] and have to consider whether or not to abandon your home and whatever possessions you cannot carry to take refuge with your family.
+
+You hear that the local parish officials want to hire you to look at plague corpses and determine if they died of plague or some other cause of deathstand guard outside quarantined houses to prevent anyone from escapingnurse the sick and dying, despite the risk to your own liferemove the plague corpses if anyone dies.
+
+As you are not a member of the Church of England, the parish cannot offer you plague work.The parish does not consider you old enough for plague work.
+
+You decide to:
+
+- accept the job
+- [[not accept the job->Stay][[repBefore] to [reputation]; [reputation] to Math.clamp([reputation] - 1, 0, 10); [fled] to 4; [decisions.push]({text: "Refused the plague work job", money: 0, repDelta: [reputation] - [repBefore], repBefore: [repBefore], infectPct: null})]]
+- [[Remain in the city->Stay][[fled] to 4; [decisions.push]({text: "Remained in the city", money: 0, repDelta: 0, repBefore: [reputation], infectPct: null})]]
+
+- [[flee the city and return to your place of origin->Fled][[fled] to 6; [money] -= [income]; [decisions.push]({text: "Fled back to place of origin", money: -[income], repDelta: 0, repBefore: [reputation], infectPct: null})]]
+- [[remain in the city yourself, but send your family back to your place of origin->Stay][[fled] to 5; [money] -= [income]; [decisions.push]({text: "Sent family home but stayed", money: -[income], repDelta: 0, repBefore: [reputation], infectPct: 0}); [plagueInfection] to 0; [infectedFamily] to 0]]
+- [[convince your husband to flee London and return to your place of origin->Fled][[fled] to 6; [money] -= [income]; [decisions.push]({text: "Convinced family to flee London", money: -[income], repDelta: 0, repBefore: [reputation], infectPct: null})]]
+- [[remain in the city with your husband, but send the rest of your family back to your place of origin->Stay][[fled] to 5; [money] -= [income]; [decisions.push]({text: "Sent family home but stayed", money: -[income], repDelta: 0, repBefore: [reputation], infectPct: 0}); [plagueInfection] to 0; [infectedFamily] to 0]]
+- [[try to convince your family to flee London and return to your place of origin->Fled][[fled] to 6; [money] -= [income]; [decisions.push]({text: "Convinced family to flee London", money: -[income], repDelta: 0, repBefore: [reputation], infectPct: null})]]
+- [[remain in the city with your , but send the rest of your family back to your place of origin->Stay][[fled] to 5; [money] -= [income]; [decisions.push]({text: "Sent family home but stayed", money: -[income], repDelta: 0, repBefore: [reputation], infectPct: 0}); [plagueInfection] to 0; [infectedFamily] to 0]]
+
+It's also not too late to
+convince your husband to try and convince your family to [[flee the city and join your family back in your home land.->Fled][[fled] to 6; [money] -= [income]; [decisions.push]({text: "Fled to join family", money: -[income], repDelta: 0, repBefore: [reputation], infectPct: null})]]
+convince your husband to try and convince your family to
+[[send your family back to your home land without you->Stay][[fled] to 5; [money] -= [income]; [decisions.push]({text: "Sent family home but stayed", money: -[income], repDelta: 0, repBefore: [reputation], infectPct: 0}); [plagueInfection] to 0; [infectedFamily] to 0]], or [[flee the city with your family.->Fled][[fled] to 6; [money] -= [income]; [decisions.push]({text: "Fled back to place of origin", money: -[income], repDelta: 0, repBefore: [reputation], infectPct: null})]]
+[[flee the city and return to your homeland.->Fled][[fled] to 6; [money] -= [income]; [decisions.push]({text: "Fled back to place of origin", money: -[income], repDelta: 0, repBefore: [reputation], infectPct: null})]]
+
+It's also not too late to
+convince your husband to try and convince your family to [[flee London and join your family.->Fled][[fled] to 6; [money] -= [income]; [decisions.push]({text: "Fled to join family", money: -[income], repDelta: 0, repBefore: [reputation], infectPct: null})]]
+convince your husband to try and convince your family to
+[[send your family to some other city where they can find work->Stay][[fled] to 5; [money] -= [income]; [decisions.push]({text: "Sent family away but stayed", money: -[income], repDelta: 0, repBefore: [reputation], infectPct: 0}); [plagueInfection] to 0; [infectedFamily] to 0]], or [[flee London with your family and find work in another city.->Fled][[fled] to 6; [money] -= [income]; [decisions.push]({text: "Fled to find work elsewhere", money: -[income], repDelta: 0, repBefore: [reputation], infectPct: null})]]
+[[flee London to some other city where you can find work.->Fled][[fled] to 6; [money] -= [income]; [decisions.push]({text: "Fled to find work elsewhere", money: -[income], repDelta: 0, repBefore: [reputation], infectPct: null})]]
+
+Your [masterTitle] decides to fleestay.
+
+As a member of your [masterTitle]'s household, your only choices are to follow herhis lead and remain in the city, or to run awayand flee the city, or to stay in the city and hope you are not caught for having broken your contract.
+
+You decide to:
+
+-
+- [[Break your contract and remain in the city->Stay][[fled] to 3; [socio] to "beggars"; [repBefore] to [reputation]; [reputation] to Math.clamp([reputation] - 2, 0, 10); [NPCsMaster] to []; [NPCs] to []; [decisions.push]({text: "Broke contract and stayed in the city", money: 0, repDelta: [reputation] - [repBefore], repBefore: [repBefore], infectPct: null})]]
+
+-
+- [[Break your contract and flee the city->Fled][[fled] to 2; [socio] to "beggars"; [repBefore] to [reputation]; [reputation] to Math.clamp([reputation] - 2, 0, 10); [money] -= [income]; [NPCsMaster] to []; [NPCs] to []; [decisions.push]({text: "Broke contract and fled the city", money: -[income], repDelta: [reputation] - [repBefore], repBefore: [repBefore], infectPct: null})]]
+
+It's also not too late to
+convince your [masterTitle] to convince your husband to try to convince your family to
+
+Your reputation is not high enough to be sure that anyone will take you in if you decide to leave London.
+
+You still have family back home in [origin]
+You have friends in the countryside
+who would take in you and your household if you decide to leave, too.
+
+You decide to:You convince your [masterTitle] toYou convince your husband toYou convince your family to
+
+- [[Remain in the city with your entire household->Stay][[fled] to 4; [decisions.push]({text: "Remained in the city with household", money: 0, repDelta: 0, repBefore: [reputation], infectPct: null})]]
+- [[Remain in the city, but send the rest of your household away.->Stay][[fled] to 5; [money] -= [income]; [decisions.push]({text: "Sent household away but stayed", money: -[income], repDelta: 0, repBefore: [reputation], infectPct: 0}); [plagueInfection] to 0; [infectedFamily] to 0]]- [[Remain in the city with your , but send the rest of your household away.->Stay][[fled] to 5; [money] -= [income]; [decisions.push]({text: "Sent household away but stayed", money: -[income], repDelta: 0, repBefore: [reputation], infectPct: 0}); [plagueInfection] to 0; [infectedFamily] to 0]]- [[Remain in the city with your [masterTitle], but send the rest of your household away.->Stay][[fled] to 5; [money] -= [income]; [decisions.push]({text: "Sent household away but stayed", money: -[income], repDelta: 0, repBefore: [reputation], infectPct: 0}); [plagueInfection] to 0; [infectedFamily] to 0]]- [[Remain in the city with your husband, but send the rest of your household away.->Stay][[fled] to 5; [money] -= [income]; [decisions.push]({text: "Sent household away but stayed", money: -[income], repDelta: 0, repBefore: [reputation], infectPct: 0}); [plagueInfection] to 0; [infectedFamily] to 0]]- [[Remain in the city, but send the rest of your household away.->Stay][[fled] to 5; [money] -= [income]; [decisions.push]({text: "Sent household away but stayed", money: -[income], repDelta: 0, repBefore: [reputation], infectPct: 0}); [plagueInfection] to 0; [infectedFamily] to 0]]
+- [[Flee the city with your entire household.->Fled][[repBefore] to [reputation]; [reputation] to Math.clamp([reputation] - 1, 0, 10); [fled] to 6; [money] -= [income]; [decisions.push]({text: "Fled the city with household", money: -[income], repDelta: [reputation] - [repBefore], repBefore: [repBefore], infectPct: null})]]
+
+[[Flee the city with your entire household.->Fled][[repBefore] to [reputation]; [reputation] to Math.clamp([reputation] - 1, 0, 10); [fled] to 6; [money] -= [income]; [decisions.push]({text: "Fled the city with household", money: -[income], repDelta: [reputation] - [repBefore], repBefore: [repBefore], infectPct: null})]][[Flee the city with your entire household.->Stay][[repBefore] to [reputation]; [reputation] to Math.clamp([reputation] - 1, 0, 10); [fled] to 7; [money] -= [income]; [decisions.push]({text: "Attempted to flee but was turned away", money: -[income], repDelta: [reputation] - [repBefore], repBefore: [repBefore], infectPct: null})]]
+
+It's also not too late to
+
+convince your [masterTitle] to convince your husband to try to convince your family to [[flee the city with your household and head to the countryside->Fled][[repBefore] to [reputation]; [fled] to 6; [reputation] to Math.clamp([reputation] - 1, 0, 10); [money] -= [income]; [decisions.push]({text: "Fled the city with household", money: -[income], repDelta: [reputation] - [repBefore], repBefore: [repBefore], infectPct: null})]], or [[send the rest of your household away while you remain behind.->Stay][[fled] to 5; [money] -= [income]; [decisions.push]({text: "Sent household away but stayed", money: -[income], repDelta: 0, repBefore: [reputation], infectPct: 0}); [plagueInfection] to 0; [infectedFamily] to 0]]
+[[join the rest of your household in the countryside->Fled][[repBefore] to [reputation]; [fled] to 6; [money] -= [income]; [reputation] to Math.clamp([reputation] - 1, 0, 10); [decisions.push]({text: "Fled to join household", money: -[income], repDelta: [reputation] - [repBefore], repBefore: [repBefore], infectPct: null})]]
+[[try to flee again, hoping your reputation has improved enough since your last attempt to seek help->Fled][[repBefore] to [reputation]; [fled] to 6; [money] -= [income]; [reputation] to Math.clamp([reputation] - 1, 0, 10); [decisions.push]({text: "Fled on second attempt", money: -[income], repDelta: [reputation] - [repBefore], repBefore: [repBefore], infectPct: null})]]
+
+[[flee the city with your entire household->Fled][[repBefore] to [reputation]; [reputation] to Math.clamp([reputation] - 1, 0, 10); [fled] to 6; [money] -= [income]; [decisions.push]({text: "Fled the city with household", money: -[income], repDelta: [reputation] - [repBefore], repBefore: [repBefore], infectPct: null})]][[Flee the city with your entire household.->Failed-Flight][[repBefore] to [reputation]; [reputation] to Math.clamp([reputation] - 1, 0, 10); [fled] to 7; [money] -= [income]; [decisions.push]({text: "Attempted to flee but was turned away", money: -[income], repDelta: [reputation] - [repBefore], repBefore: [repBefore], infectPct: null})]]
+
+your neighbors have begun to flee the city. Many are renting houses in the countryside and small towns surrounding London, either for themselves or for their households.
+
+You decide to:
+
+- [[Remain in the city with your entire household->Stay][[fled] to 4; [decisions.push]({text: "Remained in the city with household", money: 0, repDelta: 0, repBefore: [reputation], infectPct: null})]]
+- [[Remain in the city, but send the rest of your household away->Stay][[fled] to 5; [money] -= [income]; [decisions.push]({text: "Sent household away but stayed", money: -[income], repDelta: 0, repBefore: [reputation], infectPct: 0}); [plagueInfection] to 0; [infectedFamily] to 0]]
+- [[Flee the city with your entire household.->Fled][[repBefore] to [reputation]; [fled] to 6; [money] -= [income]; [reputation] to Math.clamp([reputation] - 1, 0, 10); [decisions.push]({text: "Fled the city with household", money: -[income], repDelta: [reputation] - [repBefore], repBefore: [repBefore], infectPct: null})]]
+
+It's also not too late to convince your [masterTitle] to convince your husband to try and convince your family to [[flee to the countryside with your household->Fled][[repBefore] to [reputation]; [fled] to 6; [money] -= [income]; [reputation] to Math.clamp([reputation] - 1, 0, 10); [decisions.push]({text: "Fled the city with household", money: -[income], repDelta: [reputation] - [repBefore], repBefore: [repBefore], infectPct: null})]]
+
+You decide to:
+
+- [[Remain in the city with your entire household->Stay][[fled] to 4; [decisions.push]({text: "Remained in the city with household", money: 0, repDelta: 0, repBefore: [reputation], infectPct: null})]]
+- [[Remain in the city, but send most of your household away to the countryside->Stay][[fled] to 5; [money] -= [income]; [decisions.push]({text: "Sent most of household to the countryside", money: -[income], repDelta: 0, repBefore: [reputation], infectPct: 0}); [plagueInfection] to 0; [infectedFamily] to 0]]
+- [[Flee the city with your entire household.->Fled][[repBefore] to [reputation]; [reputation] to Math.clamp([reputation] - 1, 0, 10); [fled] to 6; [money] -= [income]; [decisions.push]({text: "Fled the city with household", money: -[income], repDelta: [reputation] - [repBefore], repBefore: [repBefore], infectPct: null})]]
+
+It's also not too late to convince your [masterTitle] to convince your husband to try and convince your family to [[flee to the countryside with your household->Fled][[repBefore] to [reputation]; [fled] to 6; [money] -= [income]; [reputation] to Math.clamp([reputation] - 1, 0, 10); [decisions.push]({text: "Fled the city with household", money: -[income], repDelta: [reputation] - [repBefore], repBefore: [repBefore], infectPct: null})]]
+```
+
+---
+
+## Passage 65: Household-Fled
+
+**Tags:** fled
+
+```
+You help your household to pack up and leave the city for safety. You promise to meet them should the situation grow worse.
+```
+
+---
+
+## Passage 66: no-plague-yet
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+Luckily, there are no plague cases in your parish... yet.
+
+But your neighbors are no longer willing to give you food or money when you come begging to their doors.
+
+Many people are beginning to remove their goods to the countryside, though, which makes extra opportunities for you to earn money.
+
+You anxiously await your [masterTitle]'s decision about whether the household will flee or stay.
+
+You will soon need to decide if you want to flee or at least send the rest of your household away before things get worse.
+
+You will soon need to decide if you want to flee or at least send the rest of your household away before things get worse.
+
+You will soon need to decide if it is worth the risk of staying in London, near enough to visit the Court regularly, or if you or your household should flee before things get worse.
+```
+
+---
+
+## Passage 67: StoryInterface
+
+*This is a system passage (engine infrastructure — not narrative content).*
+
+```
+<!-- SIDEBAR -->
+
+<!-- EMPTY DIV -->
+
+<!-- NAME OF YOUR GAME -->
+
+<!-- MENU TOGGLE ICON -->
+
+<!-- HISTORY BUTTONS THAT ALLOW USER TO GO BACKWARDS AND FORWARDS -->
+<!-- COMMENT THESE OUT IF YOU DON'T WANT THEM IN YOUR GAME -->
+
+<!-- GAME LOGO IMAGE -->
+
+<!-- AUTHOR NAME -->
+
+-
+
+Restart
+
+-
+
+Saves
+
+-
+
+Settings
+
+<!-- placeholder in case we want social media later -->
+<!-- Social Media -->
+<!-- -->
+
+<!-- SIDEBAR-BODY END TAG -->
+<!-- SIDEBAR END TAG -->
+```
+
+---
+
+## Passage 68: plague-work
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+As a corpsebearer, every night, you and your fellow corpsebearers must go round to the locked up houses of your parish and call for them to bring out their dead, while praying to God that you remain safe.
+
+[image]
+Printed by R. Price, A corpse bearer; reproduction of an engraving from a series of London Cries, 1655. Wellcome Images
+
+As a searcher, every time you and your fellow searchers are called to someone's house to determine a cause of death, you pray to God to protect you. You are starting to have nightmares about seeing buboes and the tokens of plague on your neighbors.
+
+[image]
+Nathaniel Parr, published by Thomas Astley, Plague in 1665, 1747.
+
+The Overseers of the Poor assign you to your first plague patient to nurse. You must tend to the sick in their own homes, bringing them food, changing their linens, and applying what remedies you can. The work is grim and thankless, but someone must care for those whom God has afflicted.
+
+[image]
+A man consuming many antidotes to the plague during the Great Plague of London. Etching by J. Franklin, 1841. Wellcome Collection
+
+As a warder, you stand guard outside the locked up houses of your parish, making sure no one escapes their quarantine. A great red cross is painted on each door, with the words "Lord have mercy upon us" written above it. You must remain at your post day and night, listening to the pleas and cries of those locked within, and pray to God that the sickness does not reach you through the door.
+
+[image]
+A plague scene. Wellcome Collection
+
+Every night, you and your fellow corpsebearers go round to the locked up houses of your parish and call for them to bring out their dead, while praying to God that you remain safe.
+
+[image]
+Printed by R. Price, A corpse bearer; reproduction of an engraving from a series of London Cries, 1655. Wellcome Images
+
+Every time you and your fellow searchers are called to someone's house to determine a cause of death, you pray to God to protect you. You are starting to have nightmares about seeing buboes and the tokens of plague on your neighbors.
+
+[image]
+Nathaniel Parr, published by Thomas Astley, Plague in 1665, 1747.
+
+Parish officials tell you there is a patient for you to nurse. You must tend to the sick in their own homes, bringing them food, changing their linens, and applying what remedies you can. The work is grim and thankless, but someone must care for those whom God has afflicted.
+
+[image]
+A man consuming many antidotes to the plague during the Great Plague of London. Etching by J. Franklin, 1841. Wellcome Collection
+
+You stand guard outside the locked up houses of your parish. A great red cross is painted on each door, with the words "Lord have mercy upon us" written above it. You must remain at your post day and night, listening to the pleas and cries of those locked within, and pray to God that the sickness does not reach you through the door.
+
+[image]
+A plague scene. Wellcome Collection
+```
+
+---
+
+## Passage 69: storyLogo
+
+*This is a system passage (engine infrastructure — not narrative content).*
+
+```
+[image]
+```
+
+---
+
+## Passage 70: gameTitle
+
+*This is a system passage (engine infrastructure — not narrative content).*
+
+```
+Gaming the Great Plague
+```
+
+---
+
+## Passage 71: storyAuthor
+
+*This is a system passage (engine infrastructure — not narrative content).*
+
+```
+RRCHNM
+```
+
+---
+
+## Passage 72: storyMenu
+
+*This is a system passage (engine infrastructure — not narrative content).*
+
+```
+Reputation:
+a worthy soulReputation:
+of good credit and qualityReputation:
+bad credit is better than noneReputation:
+a worthless and base rogue
+
+Disposable Income:
+@@ #conversion; @@
+
+<!-- PLACE LINKS TO YOUR MENU BELOW, BUT REMEMBER TO WRAP IN - TAGS -->
+
+- Apothecary
+
+- Inventory
+
+- Household Status
+
+- Flight
+```
+
+---
+
+## Passage 73: data widgets
+
+**Tags:** widget infection-rates
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+*(no user-facing text — code/logic only)*
+
+---
+
+## Passage 74: Household Status
+
+```
+Player stats:
+
+- Name: [name]
+- Age: [age]
+- Social class: apprentice[socio]
+- Office: [office]
+- Location: [location]
+- Current plague status: [playerPlagueStatus]
+
+<!-- IMPORTANT! INCLUDE THE CODE BELOW ON ALL STAT PAGES TO MAKE SURE THE LINK RETURNS THE USER TO THE LAST PASSAGE. IF YOU USE A NORMAL RETURN LINK IT WILL SIMPLY LOOP -->
+```
+
+---
+
+## Passage 75: final stats widgets
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+Household Mortality
+
+CategoryCount
+Total household members
+Died of plague
+Died of other causes
+Survived
+Fled London
+
+Your household lost % of its members. Historically, households struck by plague often lost 30-50% of their members, and some were wiped out entirely.
+
+Your household suffered no deaths. This was fortunate but not unusual&mdash;many households, especially in less-affected parishes, escaped the plague entirely.
+
+You had no household members.
+
+London&rsquo;s Death Toll: The Numbers
+The Bills of Mortality&mdash;weekly tallies of deaths published by London&rsquo;s parish clerks&mdash;record the staggering scale of the Great Plague:
+YearTotal BurialsPlague Deaths
+1664 (normal year)18,2976
+1665 (plague year)97,30668,596
+166612,7381,998
+
+With an estimated population of 400,000&ndash;460,000, roughly 1 in 4 to 5 Londoners died in 1665 alone. Burials increased more than fivefold compared to a normal year.
+Plague accounted for about 70% of all recorded deaths in 1665. But the true toll was likely higher&mdash;historians estimate 20&ndash;30% of plague deaths were misattributed to other causes like &ldquo;spotted fever,&rdquo; &ldquo;surfeit,&rdquo; or simply &ldquo;fever&rdquo; due to bribery of searchers, fear of quarantine, or diagnostic uncertainty.
+
+Your Parish: [parish]
+
+Recorded plague deaths in your parish
+Cumulative chance of catching plague (per the game&rsquo;s model)%
+Most dangerous month
+Peak monthly infection chance1 in
+
+For comparison: St Mary Islington (a suburban parish) had only 58 plague deaths over the whole outbreak, while St Giles Cripplegate (a crowded northern suburb) had 1,353. The deadliest parish was St Dunstan Stepney with 1,392 recorded plague deaths. Parishes inside the City walls were generally safer than the poorer suburbs, where plague arrived earlier and spread faster due to crowded housing.
+
+How Your Character&rsquo;s Traits Affected Survival
+TraitEffect on Your Experience
+Age: [ageElderly] characters faced a 1-in-30 chance of dying from old age each month (~55% cumulative over the game). Historically, the elderly were especially vulnerable to plague and other diseases.As a child, you could not make your own decisions&mdash;your family decided whether to flee, quarantine, or stay. Historically, children and infants were extremely vulnerable; &ldquo;Chrisomes and Infants&rdquo; (infant deaths) was the second-largest cause of death after consumption in normal years.As a young or middle-aged adult, you had the best survival odds from non-plague causes. The game does not model the adult non-plague deaths (consumption, dropsy, fever) that were common in this period.
+Class: apprentice[socioAs] an apprentice, your fate was tied to your master&rsquo;s household. Your family invested in your future by securing you an apprenticeship with a London tradesmanmerchant, hoping it would lead to membership in a livery company and perhaps even Freedom of the City. Historically, apprentices lived and worked alongside their masters, sharing both the opportunities and the dangers of life in plague-stricken London.Nobles could afford to flee London and had the best chance of avoiding plague entirely. Historically, the nobility and gentry fled in large numbers, leaving the poor to bear the brunt of the epidemic.Merchants had resources to flee or send their families away, though leaving meant abandoning their businesses. Many merchants stayed to protect their trade.Artisans faced difficult choices about whether to flee (if their reputation allowed) or stay and risk infection. Their middling status meant plague hit them hard.As a servant, your fate was tied to your master&rsquo;s decisions. If your master fled, you went too; if they stayed, so did you. Breaking your contract meant destitution.Day labourers were among the most vulnerable. Many were recruited into dangerous plague work (corpse-bearing, searching, nursing) because they had no other income. Historically, the working poor suffered the highest plague mortality rates.Beggars were the most vulnerable class. With no money, no home security, and no ability to flee, they faced starvation, freezing, and constant plague exposure. Many were forcibly removed from the city.
+Location: [locationLiving] inside the City walls generally meant lower plague rates. The plague arrived later here (July 1665) and the wealthier, less crowded parishes fared better.The western suburbs, including St Giles in the Field, were where plague first appeared in London in late 1664. These areas were hit earliest and hardest.The eastern suburbs, including Stepney and Whitechapel, were densely populated and suffered heavily. St Dunstan Stepney recorded more plague deaths than any other parish.The northern suburbs included large parishes like St Giles Cripplegate (1,353 plague deaths) and Shoreditch, which were heavily affected.Southwark and the parishes south of the Thames were somewhat protected by the river barrier but still suffered significantly, especially St Olave Southwark (829 deaths) and St Saviour Southwark (605 deaths).Your location in the Westminster area placed you near the early epicenter of the outbreak.
+Status: [relationshipMarried] women of childbearing age (16&ndash;40) faced additional risks from pregnancy and childbirth. &ldquo;Childbed&rdquo; (maternal mortality) killed 625 women in 1665. Plague during pregnancy also caused miscarriages.Being unmarried meant a smaller household, which could mean fewer people to fall ill in quarantine&mdash;but also fewer people to provide care if you did.Your relationship status affected your household composition and therefore your exposure to plague during quarantine.
+
+Historically, roughly half of London&rsquo;s population fled the city during the plague. Those who stayed were disproportionately poor, unable to afford the costs of relocation. The King and his court left for Hampton Court in June 1665 and did not return until February 1666.
+
+What Else Killed Londoners in 1665
+Plague was not the only killer. The Bills of Mortality recorded these top non-plague causes of death in 1665:
+Cause of DeathDeathsIn Game?
+Fever5,257Yes
+Consumption and Tissick4,808No
+Teeth and Worms (infant deaths)2,614Yes
+Convulsions2,036Yes
+Spotted Fever and Purples1,929Yes
+Aged1,545Yes
+Dropsy and Tympany1,478No
+Griping in the Guts1,288Yes
+Chrisomes and Infants1,258Yes
+Surfeit (overeating/overdrinking)1,251No
+Smallpox655Yes
+Childbed (maternal death)625No
+Abortive and Stillborn617No
+Rickets557Yes
+
+Many of the recorded &ldquo;fever,&rdquo; &ldquo;spotted fever,&rdquo; and &ldquo;surfeit&rdquo; deaths were likely misattributed plague cases. Searchers of the dead (often elderly women) could be bribed to record a different cause of death, since a plague diagnosis meant the entire household would be quarantined.
+
+Your Plague Exposure
+
+Over the course of the game, your decisions exposed you to plague infection times, for a combined cumulative risk of approximately %.
+These exposure events included:
+
+- (% infection chance)
+
+None of your decisions directly exposed you to a measurable plague infection risk from decision-based events. Your primary risk came from simply living in your parish (see above).
+
+This risk is separate from and in addition to the monthly parish-based infection probability. In the game, your parish&rsquo;s infection rate was the primary determinant of whether you caught plague, but decisions like attending funerals, doing plague work, or visiting crowded places added to that risk.
+
+The Plague by the Month
+Approximate monthly plague deaths in London, based on the weekly Bills of Mortality:
+MonthPlague DeathsNotes
+Dec 1664 &ndash; Apr 1665&lt; 10Isolated cases
+May 1665~43Outbreak begins
+June 1665~590Rapid spread
+July 1665~4,129Crosses into the City
+August 1665~19,049Devastating peak begins
+September 1665~26,219Worst month
+October 1665~14,373Decline begins
+November 1665~3,219Cold weather helps
+December 1665~595Sharp decline
+Jan &ndash; Mar 1666~250 totalLingering cases
+Apr &ndash; Sep 1666~1,700 totalSummer resurgence
+Oct &ndash; Dec 1666~35 totalOutbreak ends
+
+At its worst, in the week of September 12&ndash;19, 1665, the Bills of Mortality recorded 7,165 plague deaths in a single week&mdash;more than 1,000 per day. In reality, the true number was almost certainly higher, as many deaths went unrecorded. The plague followed a seasonal pattern: it arrived in warm weather, peaked in late summer, and retreated with the cold. This pattern was well known to Londoners, which is why many chose to flee until winter.
+
+What This Game Does Not Include
+To keep the game playable, several historical realities are simplified or omitted:
+
+- Flat plague mortality rate: The game gives everyone the same 50% chance of dying from plague (33% with a plaster). In reality, mortality varied by age, overall health, and strain of plague. The elderly and very young were more vulnerable.
+- Limited non-plague adult deaths: Adults in the game can only die of plague, old age, fever, or accidents. Historically, consumption (4,808 deaths), dropsy (1,478), and many other diseases killed adults regularly.
+- No class-based plague rates: All social classes in the game face the same parish-based infection rates. Historically, the poor (living in crowded, unsanitary conditions) were infected at much higher rates than the wealthy.
+- Childbirth mortality: The game models pregnancy, miscarriage, and death in childbirth. Historically, childbirth killed 625 women in 1665.
+- Under-recording of deaths: The Bills of Mortality are known to undercount deaths, especially among the poor, dissenters, and those who bribed searchers. True plague mortality may have been 20&ndash;30% higher than official records.
+- Unusual causes of death: The Bills record deaths from &ldquo;Grief&rdquo; (46), &ldquo;Frighted&rdquo; (23&mdash;literally dying of fright), &ldquo;Hanged and made away themselves&rdquo; (7&mdash;suicide), and even &ldquo;Overlaid and Starved&rdquo; (45&mdash;mostly infants accidentally smothered).
+- Post-plague consequences: The Great Fire of London in September 1666 destroyed much of the City and dramatically reshaped the urban landscape. Many plague survivors faced poverty, displacement, and loss of livelihood in the years that followed.
+
+Source: Data from the General Bills of Mortality as transcribed by Millar et al.
+```
+
+---
+
+## Passage 76: infection-widgets
+
+**Tags:** widget infection-rates
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+*(no user-facing text — code/logic only)*
+
+---
+
+## Passage 77: money-widgets
+
+**Tags:** widget money
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+-£[pounds], [shillings] s., [pence] d.
+```
+
+---
+
+## Passage 78: Inventory
+
+```
+Fumigants:
+
+ItemQuantity
+[key].name [key].quantity
+
+Remedies
+ItemQuantity
+[key].name [key].quantity
+```
+
+---
+
+## Passage 79: Apothecary
+
+**Tags:** menu
+
+```
+The apothecary sells items that may help your family avoid illness. For the remedies to be effective, however, you must purchase enough for all members of your household. The effects are also limited and must be used constantly for prevention.
+
+ItemPriceHave (per person/month's supply)Purchase
+Preventative Medicines
+
+Celestial Water
+
+[remedies.Celestial.quantity]
+
+Buy
+
+You don't have enough to buy this.
+
+London Treacle[remedies.Treacle.quantity]
+
+Buy You don't have enough to buy this.
+
+Fumigants
+A purse of incense[fumes.Purse.quantityBuy] You don't have enough to buy this.
+
+St. Giles Powder[fumes.Fancy.quantityBuy] You don't have enough to buy this.
+
+Cheap Fumigants[fumes.Generic.quantityBuy] You don't have enough to buy this.
+
+Remaining money:
+
+Close
+
+[image]
+```
+
+---
+
+## Passage 80: preventatives-treatments
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+- Go to church and pray often You go to church and pray regularly through the month. Others admire your piety in the face of such a grave situation!
+- Avoid eating berries, cabbage, cucumbers, melon, and spinach. You avoid eating berries, cabbage, cucumbers, melons, and spinach. Your neighbors swear by it!
+
+A member of your household
+
+You pay
+
+Your parish's Overseers of the Poor pay
+
+an old woman to nurse you. She
+offers you some remedies to help ease your suffering and, hopefully, prevent your death. You:
+
+- You are offered a purgative drink, which induces vomiting. It's incredibly unpleasant.
+- Your plague buboes are covered with a blistering plaster, especially those around the ears, armpits, and groin. The plaster is left on half the day, which can break the buboes and draw out the malignity. Once broken open, your nurse applies another plaster to keep the buboes draining.Your plague buboes are covered with a blistering plaster, especially those around the ears, armpits, and groin. The plaster is left on half the day, which can break the buboes and draw out the malignity. Once broken open, your nurse applies another plaster to keep the buboes draining.
+- Twice a day, you are given a dose of tincture. After each dose, you are heavily covered for 3 hours to induce sweating, then wiped down with hot napkins.Twice a day, you are given a dose of tincture. After each dose, you are heavily covered for 3 hours to induce sweating, then wiped down with hot napkins.
+- You are given London Treacle dissolved in spoonfulls of warm vinegar, and drink 1/4 pint of this for the first few days of your illness.You are given London Treacle dissolved in spoonfulls of warm vinegar, and drink 1/4 pint of this for the first few days of your illness.
+- You use a homemade suppository of a fig filled with salt. It's unclear how this helps.
+- You drink some extra posset mixed with herbs like plantain, sorrel, or knot grass.
+
+You have some remedies on hand in your household, and may be able to purchase others from the apothecary, through the good charity of your neighbors.
+
+- You offer the sick a purgative drink, which induces vomiting. It's incredibly unpleasant.
+- You apply a blistering plaster to the plague buboes on the infected, especially those around the ears, armpits, and groin. If left on half the day, the plaster can break the buboes and draw out the malignity. Once broken open, you can apply another plaster to keep the buboe draining. If the buboes do not break, you may need to lance them.You apply a blistering plaster to the plague buboes on the infected, especially those around the ears, armpits, and groin. If left on half the day, the plaster can break the buboes and draw out the malignity. Once broken open, you can apply another plaster to keep the buboe draining. If the buboes do not break, you may need to lance them.
+- Twice a day, you give the sick a dose of tincture. After each dose, you heavily cover their bodies for 3 hours to induce sweating, then wipe them down with hot napkins.Twice a day, you give the sick a dose of tincture. After each dose, you heavily cover their bodies for 3 hours to induce sweating, then wipe them down with hot napkins.
+- You are given London Treacle dissolved in spoonfulls of warm vinegar, and drink 1/4 pint of this for the first few days of your illness.You dissolve a few spoonfuls of London Treacle in warm vinegar, and give the sick 1/4 pint of this for the first few days of their illness.
+- You give a homemade suppository of a fig filled with salt to the sick. It's unclear how this helps.
+- You mix extra posset mixed with herbs like plantain, sorrel, or knot grass and offer it to the sick.
+```
+
+---
+
+## Passage 81: glossary widgets
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+[args[0]]
+```
+
+---
+
+## Passage 82: First Plague Day
+
+```
+The first case of plague has appeared in your parish,
+
+and many of your neighbors have begun to flee the city.
+
+and many of your neighbors have begun to flee the city.
+
+and many of your neighbors have begun to flee the city.
+
+and
+
+and many members of the Court have begun to flee the city.
+```
+
+---
+
+## Passage 83: Reconnecting
+
+**Tags:** quarantine
+
+```
+You return to your household and begin reconnecting with the outside world.
+
+Unfortunately, you're going to be here a while longer. Your household is still infected.
+[You continue to tend to the sick]
+
+Lord be praised, your household has survived the plague. You still need to finish quarantine, but begin reconnecting with the outside world.
+```
+
+---
+
+## Passage 84: Summer 1665
+
+**Tags:** fled
+
+```
+When the death tolls top 7,000 a week in August and September, you're sure you made the right call. By the beginning of October, death tolls have fallen to half that and you decide to [return to the city].
+```
+
+---
+
+## Passage 85: Winter 1665
+
+**Tags:** fled
+
+```
+When the death tolls top 7,000 a week in August and September, you're sure you and your family made the right call.
+
+By the beginning of October, death tolls have fallen to half that but there are still a horrifying number of people dying every week.
+
+You anxiously watch the fall in the number of deaths each week, thanking God when only a thousand people a week are dying at the beginning of November.
+
+By the start of Advent, there are barely 200 or 300 odd people dying each week and you and your family decide it's finally safe to [return to the city] just in time for the Christmas feasting and merrymaking.
+```
+
+---
+
+## Passage 86: court-return
+
+**Tags:** fled
+
+```
+When the death tolls top 7,000 a week in August and September, you're sure you made the right call.
+
+By the beginning of October, death tolls have fallen to half that but there are still a horrifying number of people dying every week.
+
+You anxiously watch the fall in the number of deaths each week, thanking God when only a thousand people a week are dying at the beginning of November.
+
+At the start of Advent, there are still 200 or 300 odd people dying each week but unfortunately, you and your family have run out of money and are forced to [return to the city] to avoid starving.and you reconcile yourself with a Christmas spent away from the City.
+
+When the New Year dawns, you and your family are desperately homesick and renew your resolve to return to London as soon as the court does. You hear the King and court have returned to Hampton Court Palace, near to the city, and eagerly await news of his return. While you are waiting, you and your family realize you've run out of money and are forced to [return early to avoid starving].
+
+As soon as the first rumors fly of the king's entrance into London, you and your family hastily make your way [back to the city].
+```
+
+---
+
+## Passage 87: official-end
+
+**Tags:** fled
+
+```
+When the death tolls top 7,000 a week in August and September, you're sure you made the right call.
+
+By the beginning of October, death tolls have fallen to half that but there are still a horrifying number of people dying every week.
+
+You anxiously watch the fall in the number of deaths each week, thanking God when only a thousand people a week are dying at the beginning of November.
+
+At the start of Advent, there are still 200 or 300 odd people dying each week but unfortunately, you and your family have run out of money and are forced to [return to the city] to avoid starving.and you reconcile yourself with a Christmas spent away from the City.
+
+When the New Year dawns, you and your family are desperately homesick but renew your resolve not to return to London until the plague is officially over. You hear the King and court have returned to Hampton Court Palace, near to the city, and eagerly anticipate the end of the plague.While you and your family are waiting, you realize you've run out of money and are forced to return early to avoid starving.
+
+In February, you hear that the King has reentered the city and people begin asking you why you and your family have not returned when the danger has clearly passed. Your reputation plummets and people begin accusing you of cowardice. It is therefore a mixed blessing that you and your family realize you've run out of money and are forced to [return early to avoid starving].
+
+But by March, the bills of mortality show plague deaths creeping back up again and you and your family are terrified to realize you've run out of money and must [return early to the city]hold your course.
+
+As summer dawns over the city, plague deaths reach a height of over 1000 for the month of May. It's nothing compared to 1665, but the risk of death is still high and you are frustrated with all the people who demand your return.It is therefore a mixed blessing that you and your family realize you've run out of money and are forced to [return early to avoid starving].
+
+Then, in September, disaster strikes. Your first hint is a dark cloud rising into the air, just barely visible in the distance, but news soon arrives that the city is burning. You pray to God for the salvation of the city - and your home and everything you left behind in it - as the fire burns for days. Disaster heaps upon disaster as you and your family realize you've run out of money and are forced to [return to the ruined city to avoid starving].
+
+Finally, you receive word that your home was destroyed. It will cost you a significant amount of time and money to rebuild, and you resign yourself to searching for a new place to live.
+remains standing. You thank God for your close escape from disaster and look forward to your return to the city.
+
+With your home destroyed, you and your family are anxious about returning to a city where you have nowhere to live. There is still plague about and the thought of searching for new lodgings while the sickness lingers is terrifying. To make matters worse, you and your family are running out of money and realize you're going to have to [return to the city soon to avoid starving]
+
+The official Thanksgiving Day for the end of the plague is proclaimed in November, but there are still people dying each week. Unfortunately, you and your family are out of money and so are forced to [return to the city] so you and your family hold off returning and resign yourself to another winter in exile, dreading the search for a new home.
+
+Life may go on for the reckless, but it will not be until 1667 that you and your family finally make your way [back to the city].
+
+With your home destroyed, there is nothing to return to but rubble. Still, the official Thanksgiving Day for the end of the plague is proclaimed, and you and your family know you must make your way [back to the city] and begin rebuilding your life.
+
+While you and your family consider making a profit from renting out your residence to those who have been made homeless, you are uncomfortable doing so when you aren't around to make sure the tenant is taking proper care of your belongings. There is still plague about and who knows what other pestilence they could bring into your home? Besides, you and your family are running out of money and realize you're going to have to [return to the city soon to avoid starving]
+
+The official Thanksgiving Day for the end of the plague is proclaimed in November, but there are still people dying each week. Unfortunately, you and your family are out of money and so are forced to [return to the city] so you and your family hold off returning and resign yourself to another winter in exile.
+
+Life may go on for the reckless, but it will not be until 1667 that you and your family finally make your way [back to the city].
+
+While you and your family consider making a profit from renting out your residence to those who have been made homeless, you feel like your house being spared is God's way of encouraging you to return to the city. Luckily, the official Thanksgiving Day for the end of the plague is proclaimed, and so you and your family make your way [back to the city].
+```
+
+---
+
+## Passage 88: no-plague
+
+**Tags:** fled
+
+*(no user-facing text — code/logic only)*
+
+---
+
+## Passage 89: Stay
+
+```
+You prepare your household to flee the city. It takes some time to sort out the travel logistics, but finally everything is in order. They will leave tomorrow.
+
+You decide to break your contract with your [masterTitleYou] successfully convince your husband to break your contract with your [masterTitleYou] successfully convince your family to break their contract with your [masterTitle] and remain in the city, despite the danger to yourself and your family.
+
+Unfortunately, with no income and no reputation to speak of anymore, you and your family only have the option of begging to survive. You sell all your worldly goods and throw yourself on the mercy of your neighbors.
+You decide to remain in the city and fend for yourself. With so many people fleeing, surely there will be extra chances to earn some coin.
+
+You accept the job from the parish officials, which at least provides you with a little income while other work has dwindled.You decide not to accept the job from parish officials. Unfortunately, without any steady work, it may soon be difficult to survive as other work around the city dwindles.
+
+You convince your husbandconvince your familydecide to remain in the city with your [masterTitle] and herhis household, despite the danger.
+
+Despite your efforts to flee the city, your reputation is so poor that no one would take you in elsewhere. You have lost at least two months' of wages for your effort, and are considered in even lower esteem than before.
+
+You decide to remain in the city with your household, despite the dangerwith your , and send the rest of your family to the countryside away from the danger.with your [masterTitle], and send the rest of your household to the countryside away from the danger.with your husband, and send the rest of your household to the countryside away from the danger.by yourself, and send your family to the countryside away from the danger.
+
+You help your household to pack up and leave the city for safety in [hhlocation]. You send your family with most of the servants, keeping only [NPCsServants.length] for yourself. You promise to meet them should the situation grow worse.
+
+You send your family to safety in [hhlocation], along with your other servantyour other [FledServants.length] servants, keeping your servant[NPCsServants.length] servants with you. You promise to meet them should the situation grow worse.
+
+While you remain in the city, you can take measures to protect yourself and your household from the plague. You can:
+
+You can also visit the Apothecary, who sells remedies to prevent you from getting sick or to treat those who have fallen ill.
+```
+
+---
+
+## Passage 90: Failed-Flight
+
+```
+You have attempted to flee the city! Unfortunately, your reputation precedes you, and no one will take you in. You are forced to return to London, shamed, and many shillings poorer.
+```
+
+---
+
+## Passage 91: corpse-work widget
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+You and your fellow corpsebearers transported corpses this month and you were paid d. by the churchwardens for your service to the parish.
+of the dead had plague, may the Lord have mercy on their souls and protect you from sickness.
+
+You and your fellow searchers examined corpses this month and you were paid d. by the churchwardens for your service to the parish.
+You determined of the dead had plague, may the Lord have mercy on their souls and protect you from sickness.
+
+The parish officials bring you a new patient, sick with the plague. Do you nurse them?
+
+Do your Christian duty and nurse the sick
+
+You tend to your patient as best you can. You were paid 48d. by the churchwardens for your service and your Christian charity does not go unnoticed — but in the days that follow, you begin to feel unwell yourself.
+
+You tend to your patient as best you can. You were paid 48d. by the churchwardens for your service and your Christian charity does not go unnoticed. By the grace of God, you remain healthy.
+
+| Refuse to nurse the sick
+
+You refuse the assignment. The parish officials are displeased — your reputation suffers.
+
+The parish has no patient for you to nurse this month.
+
+A household in your parish has been shut up for the plague. The churchwardens ask you to stand guard outside the door. Do you take the assignment?
+
+Stand guard outside the door
+
+You stand guard outside the marked door, listening to the weeping and prayers within. You were paid 48d. by the churchwardens — but in the days that follow, you begin to feel unwell yourself.
+
+You stand guard outside the marked door, listening to the weeping and prayers within. You were paid 48d. by the churchwardens for your service. By the grace of God, you remain healthy.
+
+| Refuse the assignment
+
+You refuse the assignment. The churchwardens are displeased — your reputation suffers.
+
+To your relief, you are not called upon to guard any shut up houses this month.
+
+The Bills of Mortality report burials in [parish] this month, of plague.
+
+The Bills of Mortality report no burials in [parish] this month.
+```
+
+---
+
+## Passage 92: servant-rep widgets
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+Due to your poor reputation, your [masterTitle] has dismissed you and you have been unable to find a new position. You will have to hope you can survive as a day labourer.
+
+Your [masterTitle] is so impressed with your work that shehe is willing to take you on as an apprentice without paying the regular entrance fine. Do you accept?
+
+Yes, accept the apprenticeship
+
+Your [masterTitle] formally takes you on as herhis apprentice. You will continue to live in herhis household, but now you are learning a trade rather than merely serving. It is a remarkable opportunity, earned by your hard work and good reputation.
+
+| No, remain a servant
+
+You decline your [masterTitle]'s generous offer and continue in your current role as a servant.
+```
+
+---
+
+## Passage 93: steward
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+Zounds! The steward of you and your family's country estate has died and you must return home to manage affairs yourself.
+
+Were you fond of your steward? Yes You were fond of your steward so you and your family are sad he is now dead, and even sadder that he can no longer manage your estate. It will be hard to replace him. You decide to hold a funeral to honor his contributions to your family.
+
+How long do you spend putting your estate's affairs in order?
+
+-
+-
+-
+
+| No You weren't fond of your steward and are looking forward to the opportunity to replace him, but it will still require a great deal of work to find someone capable soon.
+
+How long do you spend putting your estate's affairs in order?
+
+-
+-
+-
+```
+
+---
+
+## Passage 94: march-1666-helper widget
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+The Court is plunged into mourning. After a month in London, the King moves on to one of his father's old houses of Audley End, in Essex. Once an enormous and grand palace, it is in bad shape after the Civil War and Interregnum. But the plague has proved the wisdom of the King having more royal palaces outside of London and the Court is happy to follow him... and the city quiets as well... because plague numbers are starting to go up again.
+
+So much for the city being safe again.
+
+[image]
+
+Peter Lely, Catherine of Braganza, 1663-5
+
+It's not a great lead up for [April 1666].
+```
+
+---
+
+## Passage 95: sep-1665-helper widget
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+The Lord Mayor has ordered fires to be lit throughout the city, to fill the air with smoke and sweep away any bad air that might be making the plague worse.
+
+You can continue to try and avoid the plague by visiting the Apothecary, or you can:
+
+[Continue to October 1665]
+```
+
+---
+
+## Passage 96: june-1666-helper widget
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+One thing is for certain, though. The weather is so hot that plague cases are on the rise again and you know it will only get worse in [July 1666].
+
+[image]
+Abraham Storck, The 'Royal Prince' and other Vessels at the Four Days Battle, 1–4 June 1666, c. 1670
+```
+
+---
+
+## Passage 97: accident
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+Send not to know for whom the church bells toll. They toll for you.
+
+Unfortunately you have suffered from a fatal accident while out on a job. You drowned in a brewer's masha well. You were bitten by a dog. You fell from scaffoldinga window. You were run over by a cart. You fell down a flight of stairs.
+
+At least you didn't die of the plague.
+
+You have suffered an accident whileout on a jobrunning errands, but thanks to God you are still alive. You fell from a window. You were kicked by a horse. You broke your arm. You were hit by a wagon wheel. You fell in the Thames and a cut on your arm was infected. Fortunately, this is something you can recover from with rest and care. Unfortunately your reputation is too low for anyone to offer you assistance so you must recover on your own and Your familyneighbors take good care of you, but you lose money every day you aren't working.
+
+Soon you are ready to rejoin the other day labourers in their search for work. your 's household.
+```
+
+---
+
+## Passage 98: empty
+
+*This is a system passage (engine infrastructure — not narrative content).*
+
+```
+retaining since has pid
+```
+
+---
+
+## Passage 99: elderly
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+Send not to know for whom the church bells toll. They toll for you. Unfortunately your old age has caught up with you. You have managed not to die of a wide range of diseases and other ailments, but at long last you have died of natural causes.
+
+At least you didn't die of plague.
+```
+
+---
+
+## Passage 100: runover
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+Send not to know for whom the church bells toll. They toll for you.
+
+Early one Sunday morning, you wake to the frantic ringing of church bells. This isn't the ordinary call to service—something you were looking forward to attending after you slept inas if you'd ever attend a service in the Church of England!—but rather a call to arms.
+
+Unfortunately, there are dangers other than the fire. As you stumble through the streets to flee the conflagration, you are run over by a cart, an accident from which you will not recover.
+
+One Sunday morning, you awaken and getting ready for church when you look out the window and realize there is a great fire in the distance. After dressing, you go out to find a neighbor who tells you that over 300 houses have burnt down in the night, by London Bridge.
+
+Unfortunately, there are dangers even outside the city walls. As you walk out to get a closer look at the conflagration, you are run over by a cart fleeing the flames, an accident from which you will not recover.
+
+Unfortunately, begging in the street comes with risks in a bustling city like London, and you have been run over by a cart, an accident from which you will not recover.
+
+At least you didn't die of plague.
+
+Early one Sunday morning, you wake to the frantic ringing of church bells. This isn't the ordinary call to service—something you were looking forward to attending after you slept inas if you'd ever attend a service in the Church of England!—but rather a call to arms.
+
+Unfortunately, there are dangers other than the fire. As you stumble through the streets to flee the conflagration, you are run over by a cart and suffer a serious injury.
+
+One Sunday morning, you awaken and getting ready for church when you look out the window and realize there is a great fire in the distance. After dressing, you go out to find a neighbor who tells you that over 300 houses have burnt down in the night, by London Bridge.
+
+Unfortunately, there are dangers even outside the city walls. As you walk out to get a closer look at the conflagration, you are run over by a cart fleeing the flames and suffer a serious injury.
+
+You thank God that you have survived his wrath! Unfortunately, your reputation is so low that your neighbors take no more pity on you and you earn very few spare coins while you recover. Fortunately, your reputation is so high among your neighbors that the sight of you after your injury invokes great pity (and a few extra coins). Nevertheless, you are glad that you will soon heal.
+
+Alack! Begging in the streets in a city as bustling as London comes with its dangers. You have been run over by a cart and suffered a serious injury. Unfortunately, your reputation is so low that your neighbors take no more pity on you and you earn very few spare coins while you recover. Fortunately, your reputation is so high among your neighbors that the sight of you after your injury invokes great pity (and a few extra coins). Nevertheless, you are glad that you will soon heal. You hear that in some areas of the city they are installing a new innovation–the sidewalk–which will help to keep people off the street and prevent more accidents like yours.
+```
+
+---
+
+## Passage 101: fever
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+Send not to know for whom the church bells toll. They toll for you. You have come down with a mysterious fever. Despite the care of your friends and family,Your reputation is so low that no one will lend you aid in your sickness and you die.
+
+At least you didn't die of plague.
+
+Alack! You have come down with a mysterious fever. Your reputation is high enough that your friends and family take diligent care of you in your sickness and Your reputation is so low that no one lends you aid in your sickness but you slowly recover.
+```
+
+---
+
+## Passage 102: navy-volunteer
+
+```
+When you show up to board your ship, the captain instantly realizes you are too young to volunteer. You are scolded and
+When you show up to board your ship, the captain instantly realizes you are too old to volunteer. He thanks you for volunteering but firmly refuses to let you board and
+When you show up to board your ship, the captain instantly realizes you are female and has you cast back onto the dock while everyone
+
+Send not for whom the bell tolls, it tolls for you. Unfortunately, you die in the fighting when you are knocked off deck and into the sea where you drowna cannon ball splinters the deck beneath your feet and the shrapnel cuts open your neckyour ship is boarded and a Dutch soldier stabs you in the stomacha keg of gunpowder explodes next to youa cannon splits the mast of your ship and the falling rigging crushes you.
+At your death, your crewmates discovered that you were a woman.
+You died with such a poor reputation that most of your fellow sailors didn't care. The rest of them probably cursed your name and hoped you were suffering in hell.
+You died with a good enough reputation that your fellow sailors say prayers for your soul.
+
+But regardless, your body meets the same fate of the hundreds of other soldiers who died in this battle. Your body is wrapped in your hammock and dropped over board.
+As a God-fearing Catholic, you know you are destined to spend time in purgatory before you can ascend to heaven but you hope that will not take too long, despite your poor reputation on earth.As a good Protestant, you know that Christ the Redeemer has died for you and your admittance to heaven is guaranteed.
+
+[At least you didn't die of plague].
+
+Unfortunately, you are taken prisoner and spend the rest of the war in a Dutch prison. It's not pleasant, but [at least you didn't die of plague].
+
+Unfortunately, your ship saw a lot of action and you are left with a disfiguring scar across your back which pains you occasionallywith a gangrenous leg that will later need to be amputatedwithout the use of your right eye, which was lost to a musket ballwithout your right arm, which was crushed by falling rigging and had to be amputatedwithout your left hand, which was cut off by a Dutch soldier in battle. Your injuries are severe enough that the Navy sends you back to London. Your disability will affect your ability to work, butyour disability might make your neighbors pity you and earn you more charity, butIt's not pleasant, but at least you didn't die of plague. After weeks of recovery, you are ready to
+
+You serve in the Navy through the war against the Dutch, leaving service in 1667. It was hard work, and not rewarding, but [at least you didn't die of plague].
+```
+
+---
+
+## Passage 103: parish-office widget
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+Because of your poor reputation, the vestry of [parish] decided to remove you from your position as [office].
+
+The vestry of [parish] has called you to serve as one of the parish's . Do you accept?
+
+Yes
+
+You accept the position of in [parish] and the responsibilities to your parish that come with it.
+
+| No
+You don't want the hassle of holding office in your parish and pay a fine to avoid serving.
+```
+
+---
+
+## Passage 104: orphan widget
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+Because your [masterTitle] died, you have found a new position in another household.
+
+Because you have been orphaned, your Parish Overseers of the Poor have found you a position as a servant in a local [MasterTrade]'s household.
+
+Because you have been orphaned, you have moved in with a family friendyour [newGuardian].
+```
+
+---
+
+## Passage 105: add-dependent widget
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+Despite everything, you keep finding opportunities for workknow you are lucky to be steadily employed as a servant. A friend from the countryside writes to your family and asks if you will take in their child so they can also seek work in London.
+
+Do you want to accept them into your home? Yes You convince your husband to accept them into your home.You convince your [masterTitle] to accept them into your home.You convince your family to accept them into your home.You accept them into your home. It's another mouth to feed, but you are glad to | No You convince your husband not to accept them into your home.You convince your [masterTitle] not to accept them into your home.You convince your family not to accept them into your home.You don't accept them into your home. Things are too hard right now. You can't afford another mouth to feed and you don't have the time to teach someone else the lay of the city.
+
+Despite everything, business continues. A friend from the countryside writes to your family and asks if you will take in their son as your apprentice.
+
+Do you want to accept him into your home? Yes You convince your husband to accept him into your home.You convince your [masterTitle] to accept him into your home.You convince your family to accept him into your home.You accept him into your home. It's another mouth to feed, but you could use the help and are glad to | No You convince your husband not to accept him into your home.You convince your [masterTitle] not to accept him into your home.You convince your family not to accept him into your home.You don't accept him into your home. Things are too hard right now. You can't afford another mouth to feed and you don't have the time to teach someone else your trade.
+
+Despite everything, court life proceeds as usual. A friend living the countryside writes to your family and asks if you will take in their child as your ward and help them get a place at court - and maybe even an advantageous marriage.
+
+Do you want to accept them into your home? Yes You convince your husband to accept them into your home.You convince your [masterTitle] to accept them into your home.You convince your family to accept them into your home.You accept them into your home. It will cost a small fortune to outfit a newcomer to court and provide the king the necessary gifts but you will control their purse strings and are glad to . | No You convince your husband not to accept them into your home.You convince your [masterTitle] not to accept them into your home.You convince your family not to accept them into your home.You don't accept them into your home. Your own affairs are not quite in order and you need to focus on setting them right before adding another person to the household. You don't have the time to teach someone else the ways of court.
+```
+
+---
+
+## Passage 106: catch-up widget
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+While you were away...
+
+:
+
+In [parish], were buried, of plague.
+```
+
+---
+
+## Passage 107: seeking widgets
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+As an unmarried adult, you may wish to get married. Marriage brings with it lots of advantages, including a life partner, social connections through their family, (probably) children, and wealth from your husband's incomewife's dowryadditional income that will help protect you from starvationpoverty. The downside is all your property will become your husband's and you will be legally dependent on him until he dies... or you do.
+
+You are
+
+- looking to be married soon You are looking to be married soon and will be seeking out a spouse.
+
+- are content to remain single for now You are content to remain single for now.
+
+As an unmarried young womanman from a merchantan artisan family, your family is considering securing you an apprenticeship with a London merchant or tradesman. An apprenticeship would teach you a trade, connect you to a livery company, and could eventually lead to gaining the Freedom of the City — the right to trade independently within London's walls. Female apprenticeships are unusual, but not unheard of, especially within family trade networks.
+
+Are you
+
+- seeking an apprenticeship You are seeking an apprenticeship and will be looking for a suitable master to take you on.
+
+- content to wait for now You are content to wait for now.
+```
+
+---
+
+## Passage 108: wedding
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+You have found a husbandwifespouse!
+
+Do you want to
+
+- be married in your parish church For the three weeks before the wedding, your parish priest reads the banns and then you are married in a nice ceremony in the church of [parish].
+After the dancing and feasting, you go home with your new spouse at your side.
+- pay for a private wedding license Rather than wait for three weeks ot have the banns read, you obtain a license to get married sooner at home.
+- elope at Fleet prison Rather than going through the fuss of a formal wedding, you go to the Fleet prison where you find a priest willing to marry you in a nearby tavern without asking too many questions.
+```
+
+---
+
+## Passage 109: NPC-death widget
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+Your [NPCs[[di]]].relationship [NPCs[[di]]].name has died of [cause].
+
+Your [NPCs[[di]]].relationship [NPCs[[di]]].name has died of [cause].
+
+Your [NPCs[[di]]].relationship [NPCs[[di]]].name has died of old age.
+
+The [NPCsMaster[[di]]].relationship [NPCsMaster[[di]]].name has died of [cause].
+
+The [NPCsMaster[[di]]].relationship [NPCsMaster[[di]]].name has died of [cause].
+
+The [NPCsMaster[[di]]].relationship [NPCsMaster[[di]]].name has died of old age.
+
+Your [NPCsExtended[[di]]].relationship [NPCsExtended[[di]]].name has died of [cause].
+
+Your [NPCsExtended[[di]]].relationship [NPCsExtended[[di]]].name has died of [cause].
+
+Your [NPCsExtended[[di]]].relationship [NPCsExtended[[di]]].name has died of old age.
+
+Your servant [NPCsServants[[di]]].name has died of [cause].
+
+Your servant [NPCsServants[[di]]].name has died of [cause].
+
+Your servant [NPCsServants[[di]]].name has died of old age.
+
+Tragically, and your [NPCs][[contagionDead][[gi]]].relationship [NPCs][[contagionDead][[gi]]].name hashave also died of [npcContagion].
+
+and your [NPCs][[contagionSurvived][[gi]]].relationship [NPCs][[contagionSurvived][[gi]]].name hashave contracted [npcContagion] but survived.
+
+Tragically, and the [NPCsMaster][[contagionDead][[gi]]].relationship [NPCsMaster][[contagionDead][[gi]]].name hashave also died of [masterContagion].
+
+and the [NPCsMaster][[contagionSurvived][[gi]]].relationship [NPCsMaster][[contagionSurvived][[gi]]].name hashave contracted [masterContagion] but survived.
+
+Tragically, and your [NPCsExtended][[contagionDead][[gi]]].relationship [NPCsExtended][[contagionDead][[gi]]].name hashave also died of [extendedContagion].
+
+and your [NPCsExtended][[contagionSurvived][[gi]]].relationship [NPCsExtended][[contagionSurvived][[gi]]].name hashave contracted [extendedContagion] but survived.
+
+Tragically, and your servant [NPCsServants][[contagionDead][[gi]]].name hashave also died of [servantsContagion].
+
+and your servant [NPCsServants][[contagionSurvived][[gi]]].name hashave contracted [servantsContagion] but survived.
+```
+
+---
+
+## Passage 110: pregnant
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+You have realized you are pregnant! You look forward to adding a new member to the family even if it means another mouth to feed. In a few months you'll have a new baby, but until then life continues as usual.
+```
+
+---
+
+## Passage 111: birth
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+Send not to know for whom the church bells toll. They toll for you. You died in childbirth.
+
+At least you didn't die of plague.
+
+After a long, hard labor you are devastated to find your baby was stillborn. You bury and attempt to move on.
+
+After a long, hard labor you are delighted to add a baby to your family.
+
+Do you
+host a celebration
+
+You have your new baby, [NPCs.last]().name, baptized then celebrate with all your family, friends, and neighbors. You know such a gathering might be dangerous, in such a time of plague, but there is a good chance that [NPCs.last]().name will not be one of the babies who survives their perilous first year of life and you want everyone to meet them.
+
+|
+have a quick baptism
+
+You quickly baptize them and pray to God that [NPCs.last]().name will be one of the babies who survives their perilous first year of life.
+```
+
+---
+
+## Passage 112: miscarriage
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+For a few weeks, you thought you might be pregnant, but it is now clear that you are not.
+
+Unfortunately, you have suffered a miscarriage and are no longer pregnant.
+```
+
+---
+
+## Passage 113: random events widget
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+*(no user-facing text — code/logic only)*
+
+---
+
+## Passage 114: Claude-widgets
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+*(no user-facing text — code/logic only)*
+
+---
+
+## Passage 115: june-1665-helper-widget
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+The plague grows worse and the streets are soon filled with coaches and wagons full of people fleeing with their goods to the countryside. The Queen Mother Henrietta Maria moves back to France, much to your dismay, and that of your fellow Catholics who flock to her chapel each week, much to your relief, and that of all your fellow God-fearing Protestants. On June 29th, the King packs up his entire household in 148 carriages and moves 12 miles away, to his palace at Hampton Court.
+
+[image]
+Runaways fleeing from the plague, a woodcut from 'A Looking-glasse for City and Countrey', printed by H. Gosson in 1630 and sold by E. Wright, c. 1630. Wellcome Images
+
+There are still no plague cases in your parish, but everyone knows that it is only a matter of time
+
+and your neighbors are growing increasingly reluctant to help when you come begging to their doors.
+
+. Your family will soon need to decide if you want to flee or at least send the rest of your household away before things get worse.
+
+. You anxiously await your [masterTitle]'s decision about whether the household will flee or stay.
+
+. Unfortunately, you are not important enough to merit lodgings at Hampton Court and the surrounding village is already full to bursting. Your family will soon need to decide if it's worth the risk of staying in London, near enough to visit the Court regularly, or if you or your household should flee before things get worse.
+
+[Continue to July 1665]
+
+Do you:
+
+- [swallow your fears and go to do your Christian duty.]
+- [[refuse to do as you've been tasked.->work-refusal][[reputation] to Math.clamp([reputation] - 1, 0, 10)]]
+
+No one has any charity right now for a healthy beggar, but somehow you manage to scrape together enough food to last you to [July 1665].
+
+Do you:
+
+- [swallow your fears and go to do your Christian duty.]
+- [[decide to quit and look for other work.->July 1665][[reputation] to Math.clamp([reputation] - 1, 0, 10)]]
+
+So many people are fleeing the city, there's plenty of work hauling their belongings to and fro... for now anyway. It's enough to get you through to [July 1665].
+
+Otherwise, you can [remain in the city with your entire household.]
+
+Otherwise, you can [remain in the city with your entire household.]
+
+Otherwise, you can [remain in the city with your entire household.]
+
+Do you:
+
+Otherwise, you can [remain in the city with your entire household.]
+
+You and your family lose money every day that you're away from the city, as no one wants to give charity to a beggar from the city
+You and your family lose money every day that you're away from the city and the people who normally would be willing to employ you for a day's labor
+You dislike being so far from the city
+You and your family lose money every day that you're away from the city and unable to practice your trade
+It's deeply irritating to have to pay rent on a country house as well as your home back in the city
+It's to your great disadvantage to be so far from Court and the centers of power
+, but luckily it's a price that you're able to pay for at least a little while to ensure your safety.
+
+Unfortunately, you and your family run out of money in [args[1]]have run out of money and are forced to return to the city to avoid starving.
+
+You return to the Church of England services this month. You cannot afford to pay the fine for skipping while in debt. Your previous commitment to always skip services no longer applies, but once you are no longer in debt, you can re-commit to always skipping Church of England services.
+
+As a [religion], do you want to attend services at your parish Church of England this month?
+
+Always avoid Church of England services
+
+You resolve to stop attending services at the Church of England. You are fined 48d. for non-attendance and your reputation suffers.
+
+| Skip Church of England services this month
+
+You skip services at your parish church this month and are fined 48d. for non-attendance. Your reputation suffers.
+
+| Attend services
+
+You attend services at your parish church, though it goes against your beliefs as a [religion].
+```
+
+---
+
+## Passage 116: Flight
+
+```
+Your household is currently safe and sheltering from the plague outbreak in [hhlocation]. Do you want to bring them back to London?
+
+Yes, bring them back
+
+No, not yet
+
+Your [NPCs[[ri]]].relationship [NPCs[[ri]]].name is[NPCs[[ri]]].relationship [NPCs[[ri]]].name, and [NPCs[[ri]]].relationship [NPCs[[ri]]].name are still safely sheltering in the countryside.
+
+Bring them home
+
+Leave them there for now
+
+Your [NPCs[[ri]]].relationship [NPCs[[ri]]].name is[NPCs[[ri]]].relationship [NPCs[[ri]]].name, and [NPCs[[ri]]].relationship [NPCs[[ri]]].name are still safely sheltering in the countryside. Do you want to bring themthem all home?
+
+Bring them home
+
+Leave them there for now
+```
+
+---
+
+## Passage 117: $args[0
+
+*This is a system passage (engine infrastructure — not narrative content).*
+
+*(empty passage)*
+
+---
+
+## Passage 118: bom widget
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+You hear that you can subscribe to the weekly Bills of Mortality, printed broadsides that record every death in every parish in London and whether the cause of death was plague. A subscription costs 4d. per month. Do you wish to subscribe?
+
+Yes You subscribe to the Bills of Mortality. Each month, you will receive a report on the deaths in your parish.
+
+| No You decide not to subscribe to the Bills of Mortality.
+```
+
+---
+
+## Passage 119: child-smuggling widgets
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+Your neighbors offer to help smuggle your [NPCs][[smuggleEligible][0]].relationship [NPCs][[smuggleEligible][0]].nameyour healthy children out of harm's way. Do you convince your husband to accept their offer?Do you accept their offer?
+
+Accept their offer
+
+Under cover of night, your neighbors manage to smuggle your [NPCs[[g]]].relationship [NPCs[[g]]].nameyour [NPCs[[g]]].relationship [NPCs[[g]]].name, and your [NPCs[[g]]].relationship [NPCs[[g]]].name out of the house and to a safer location.
+| Decline their offer You decide it is too risky to attempt smuggling your [NPCs][[smuggleEligible][0]].relationshipyour children out of the house.
+
+Your [NPCs[[ri]]].relationship [NPCs[[ri]]].name[NPCs[[ri]]].relationship [NPCs[[ri]]].name, and [NPCs[[ri]]].relationship [NPCs[[ri]]].name survived safely in the countryside. Do you want to bring themthem all home?
+
+Yes, bring them home
+
+Your [NPCs[[ri]]].relationship [NPCs[[ri]]].name returns[NPCs[[ri]]].relationship [NPCs[[ri]]].name, and [NPCs[[ri]]].relationship [NPCs[[ri]]].name return home safely.
+| Not yet
+Your [NPCs[[ri]]].relationship[NPCs[[ri]]].relationship, and [NPCs[[ri]]].relationship remainsremain safely in the countryside for now.
+```
+
+---
+
+## Passage 120: lodger widgets
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+Do you want to accept lodgers into your home?
+
+Yes, and charge extra rent [lodgerDesc] to your household. You welcome their rent money even though your reputation takes a hit for profiting off the disaster. | Yes, and charge a low rent [lodgerDesc] to your household. You welcome their rent money as even a little bit extra helps. | No any lodgers. Things are crowded enough without adding strangers to the household.
+```
+
+---
+
+## Passage 121: child-service widgets
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+Your family is struggling to make ends meet. Your [csSuggestor] suggests you might find a position as a servant in a nearby household.You wonder if you might find a position as a servant in a nearby household. Would you like to go into service?
+
+Go into service
+
+Your Parish Overseers of the Poor have found you a position as a servant in a local [MasterTrade]'s household.
+
+| Stay with your family You decide to stay with your family for now, even though times are hard.
+
+Your household is struggling. to put your [csRel], [csName], into service with a nearby household.
+
+Put them into service
+
+Your [csRel], [csName], has been placed into service with a local household. You hope [csHeshe] will be well cared for.
+
+| Keep your family together to send [csName] away. You'll find another way to manage.
+
+Your household's debts have grown so great that the parish Overseers of the Poor have stepped in.
+
+You and your [fsRemoved][0].relationship, [fsRemoved][0].name, have been removed from your family and bound into service.
+You and your [fsRemoved][[fn]].relationship [fsRemoved][[fn]].name, and [fsRemoved][[fn]].relationship [fsRemoved][[fn]].name have been removed from your family and bound into service.
+
+Your siblings have been placed in the same household as you. You have been separated from your siblings and placed in different households.
+You have been removed from your family and bound into service.
+
+Your remainsremain with your parents, too young to be put into service.
+You have been placed as a servant in a local [MasterTrade]'s household.
+
+The parish Overseers of the Poor have taken your [fsNames][0].relationship, [fsNames][0].name, and bound [fsNames][0].heshe into service with another family.
+The parish Overseers of the Poor have taken your [fsNames][[fn]].relationship [fsNames][[fn]].name, and [fsNames][[fn]].relationship [fsNames][[fn]].name and bound them into service.
+They have been placed together in the same household. They have been separated and placed in different households.
+
+Your remainsremain with you, too young to be put into service.
+```
+
+---
+
+## Passage 122: apprenticeship
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+```
+Word has spread that you are looking for an apprenticeship and your family has been making inquiries on your behalf. A contact at church has found several potential masters willing to take you on — for a fee.
+
+The following opportunities are available to you:
+
+- Apprentice to a Placeholder Trade A (£1 entry fee)
+
+Your family scrapes together the £1 entry fee and you are apprenticed to a local tradesman. It is humble work, but honest, and you move into your new [masterTitle]'s household to begin learning the trade.
+
+- Apprentice to a Placeholder Trade B (£5 entry fee)
+
+Your family pays the £5 entry fee and you are apprenticed to a respectable tradesman. You move into your new [masterTitle]'s household and begin learning a trade with decent prospects.
+
+- Apprentice to a Placeholder Trade C (£10 entry fee)
+
+Your family invests £10 in your future and you are apprenticed to a skilled merchant. You move into your new [masterTitle]'s fine household and begin learning a trade with good standing in the city.
+
+- Apprentice to a Placeholder Trade D (£25 entry fee)
+
+Your family makes a substantial investment of £25 and you are apprenticed to a prestigious merchant. You move into your new [masterTitle]'s impressive household and begin learning a trade that could lead to real influence in the city.
+
+- Apprentice to a Placeholder Trade E (£50 entry fee)
+
+Your family spends a fortune — £50 — to secure you a place with one of London's elite livery companies. You move into your new [masterTitle]'s grand household and begin your apprenticeship on the surest path to gaining Freedom of the City.
+
+- Unfortunately, your family cannot afford any of the available entry fees right now, or your reputation is not yet sufficient. You will need to save more money or build your standing before a master will take you on.
+
+- Decline for now You decide to wait for a better opportunity. Your search for an apprenticeship continues.
+```
+
+---
+
+## Passage 123: landlord widget
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+*(no user-facing text — code/logic only)*
+
+---
+
+## Passage 124: hoh caretaker
+
+**Tags:** widget
+
+*This is a widget passage (code/logic only — not directly displayed to players).*
+
+*(no user-facing text — code/logic only)*
+
+---


### PR DESCRIPTION
- extract-passage-text.js: Node script that reads decoded passage files, strips SugarCube macros/HTML/code, and outputs user-facing narrative text
- passage-data.md: Generated output with all 124 passages, including pid, name, tags, and extracted player-visible text

https://claude.ai/code/session_01PMoisq5wD8FisLKwETxh9e