### PR TITLE
Fix orderNPCs widget syntax error — bump to v3.6

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v3.5" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v3.6" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -6248,9 +6248,9 @@ You quickly baptize them&lt;&lt;set $money -=6&gt;&gt; and pray to God that $NPC
 &lt;&lt;widget &quot;orderNPCs&quot;&gt;&gt;&lt;&lt;silently&gt;&gt;
 &lt;&lt;set _arrName to _args[0]&gt;&gt;
 &lt;&lt;set _arr to State.getVar(_arrName)&gt;&gt;
-&lt;&lt;set _arr to _arr.sort(function(a, b) {
-  var _rel = function(npc) { return (npc.relationship || &quot;&quot;).toLowerCase(); };
-  var _rank = function(npc) {
+&lt;&lt;run _arr.sort(function(a, b) {
+  function _rel(npc) { return (npc.relationship || &quot;&quot;).toLowerCase(); }
+  function _rank(npc) {
     var r = _rel(npc);
     if (r === &quot;landlord&quot; || r === &quot;master&quot;) return 1;
     if (r === &quot;landlord&#39;s wife&quot; || r === &quot;mistress&quot;) return 2;
@@ -6259,11 +6259,11 @@ You quickly baptize them&lt;&lt;set $money -=6&gt;&gt; and pray to God that $NPC
     if (r.indexOf(&quot;uncle&quot;) &gt;= 0) return 5;
     if (r.indexOf(&quot;aunt&quot;) &gt;= 0) return 6;
     if (r === &quot;guardian&quot; || r === &quot;cousin&quot;) return 7;
-	if (r === &quot;guardian&#39;s wife&quot; || r === &quot;cousin&#39;s&#39;s wife&quot;) return 8;
+    if (r === &quot;guardian&#39;s wife&quot; || r === &quot;cousin&#39;s wife&quot;) return 8;
     if (r.indexOf(&quot;servant&quot;) &gt;= 0) return 10;
     if (r.indexOf(&quot;lodger&quot;) &gt;= 0) return 11;
     return 9;
-  };
+  }
   var ra = _rank(a), rb = _rank(b);
   if (ra !== rb) return ra - rb;
   return (b.agenum || 0) - (a.agenum || 0);


### PR DESCRIPTION
Replace <<set>> with <<run>> for the sort callback in orderNPCs widget. SugarCube's <<set>> parser misinterprets `var` declarations inside the expression, causing "Unexpected token '.'" errors. Using <<run>> avoids the parser issue since .sort() mutates in place. Also fixed a typo ("cousin's's wife" → "cousin's wife").

https://claude.ai/code/session_01TSmGcyKSsjYUGzX6eLcUxz