### PR TITLE
Update navy recruitment restrictions across multiple months — bump to…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v3.6" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v3.7" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -2242,7 +2242,7 @@ You &lt;span id=&quot;decision&quot;&gt;
 &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/9/99/James_II_by_Peter_Lely.jpg&quot; width=&quot;100%&quot;&gt;
 &lt;br&gt;
 //Peter Lely, James II, c. 1650-1675//&lt;br&gt;&lt;br&gt;
-&lt;&lt;if $gender isnot &quot;female&quot;&gt;&gt;&lt;span id=&quot;volunteer&quot;&gt;Do you want to be there for the next battle?
+&lt;&lt;if $agenum gte 16 and $gender isnot &quot;female&quot;&gt;&gt;&lt;span id=&quot;volunteer&quot;&gt;Do you want to be there for the next battle?
 &lt;br&gt;&lt;br&gt;
 &lt;&lt;link &quot;Volunteer for the navy&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jun 1665: Volunteered for the navy&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;replace &quot;#volunteer&quot;&gt;&gt;You have enlisted on [[HMS Royal Sovereign-&gt;navy-volunteer]]&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;Stay out of the fighting&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jun 1665: Stayed out of the fighting&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;replace &quot;#volunteer&quot;&gt;&gt;
    &lt;br&gt;&lt;br&gt;&lt;&lt;linkappend &quot;That is the last good day of the month, though.&quot;&gt;&gt;&lt;&lt;june-1665-helper&gt;&gt;
@@ -2256,18 +2256,9 @@ You &lt;span id=&quot;decision&quot;&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;
  | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#decision&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jun 1665: Ignored the war gossip&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt; You don&#39;t listen to the gossip, but it&#39;s hard to ignore the shouts when news finally arrives of a great battle that killed many important men.
    &lt;br&gt;&lt;br&gt;
-   
- &lt;&lt;if $gender isnot &quot;female&quot;&gt;&gt;&lt;span id=&quot;volunteer&quot;&gt;Do you want to be there for the next battle?
-&lt;br&gt;&lt;br&gt;
-&lt;&lt;link &quot;Volunteer for the navy&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jun 1665: Volunteered for the navy&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;replace &quot;#volunteer&quot;&gt;&gt;You have enlisted on [[HMS Royal Sovereign-&gt;navy-volunteer]]&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;Stay out of the fighting&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jun 1665: Stayed out of the fighting&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;replace &quot;#volunteer&quot;&gt;&gt;
-   &lt;&lt;linkappend &quot;That is the last good day of the month, though.&quot;&gt;&gt;&lt;&lt;june-1665-helper&gt;&gt;&lt;&lt;/linkappend&gt;&gt;
-&lt;br&gt;&lt;br&gt;
-&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
-&lt;&lt;else&gt;&gt;
- &lt;&lt;linkappend &quot;That is the last good day of the month, though.&quot;&gt;&gt;&lt;&lt;june-1665-helper&gt;&gt;
+&lt;&lt;linkappend &quot;That is the last good day of the month, though.&quot;&gt;&gt;&lt;&lt;june-1665-helper&gt;&gt;
 &lt;&lt;/linkappend&gt;&gt;
 &lt;br&gt;&lt;br&gt;
-&lt;&lt;/if&gt;&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 
 &lt;&lt;/gate&gt;&gt;&lt;&lt;/if&gt;&gt;
@@ -2475,27 +2466,14 @@ The summer heat has hit London and everyone is feeling lethargic. Still, there a
 
 You hear rumors that the &lt;&lt;defFleet &quot;fleet&quot;&gt;&gt; has engaged the Dutch in battle again and the streets are full of people arguing over whether the four days of rumbling was cannon fire or thunder. Yes, the hot weather could have led to four days of distant thunder but the skies are clear and &lt;&lt;defPressGangs &quot;press gangs&quot;&gt;&gt; roam the street, grabbing any man they can.
 
-&lt;&lt;if $agenum gte 16 and $religion isnot &quot;Quaker&quot; and $gender isnot &quot;female&quot;&gt;&gt;&lt;span id=&quot;volunteer&quot;&gt;Do you want to join in the fight?
-&lt;br&gt;&lt;br&gt;
-&lt;&lt;link &quot;Volunteer for the navy&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jun 1666: Volunteered for the navy&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;replace &quot;#volunteer&quot;&gt;&gt;You have enlisted on [[HMS Royal Sovereign-&gt;navy-volunteer]]&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;Stay out of the fighting&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jun 1666: Stayed out of the fighting&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;replace &quot;#volunteer&quot;&gt;&gt;
-
-&lt;&lt;june-1666-helper&gt;&gt;
-&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
+&lt;&lt;if $agenum gte 16 and $gender isnot &quot;female&quot; and $socio isnot &quot;nobles&quot; and $socio isnot &quot;merchants&quot;&gt;&gt;&lt;&lt;if random(1,2) eq 1&gt;&gt;&lt;&lt;set $impressed += 1&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jun 1666: Impressed by a press gang&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;Unfortunately, while you are out listening to the gossip, a &lt;&lt;defPressGangs &quot;press gang&quot;&gt;&gt; seizes you! You are [[dragged away-&gt;impressed]].&lt;&lt;else&gt;&gt;You keep a wary eye on the &lt;&lt;defPressGangs &quot;press gangs&quot;&gt;&gt; as you listen to the gossip, and manage to avoid being seized. &lt;&lt;june-1666-helper&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;else&gt;&gt;
 &lt;&lt;june-1666-helper&gt;&gt;
 &lt;&lt;/if&gt;&gt;
  &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#decision&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jun 1666: Ignored the gossip&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;
 The sky has been rumbling for days and you wonder whether the sound was cannon fire or thunder. Yes, the hot weather could have led to four days of distant thunder but the skies are clear. You assume that this is why when you look out your window you can see &lt;&lt;defPressGangs &quot;press gangs&quot;&gt;&gt; roaming the street, grabbing any man they can.
 
-&lt;&lt;if $agenum gte 16 and $religion isnot &quot;Quaker&quot; and $gender isnot &quot;female&quot;&gt;&gt;&lt;span id=&quot;volunteer&quot;&gt;Do you want to volunteer to avoid being seized?
-&lt;br&gt;&lt;br&gt;
-&lt;&lt;link &quot;Volunteer for the navy&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jun 1666: Volunteered for the navy&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;replace &quot;#volunteer&quot;&gt;&gt;You have enlisted on [[HMS Royal Sovereign-&gt;navy-volunteer]]&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;Stay out of the fighting&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jun 1666: Stayed out of the fighting&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;replace &quot;#volunteer&quot;&gt;&gt;
-
-You avoid being pressed by keeping out of the way of the gangs. You don&#39;t know what future the city holds but at least it&#39;s better than being in the Navy. &lt;&lt;june-1666-helper&gt;&gt;
-&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
-&lt;&lt;else&gt;&gt;
 &lt;&lt;june-1666-helper&gt;&gt;
-&lt;&lt;/if&gt;&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 
 &lt;&lt;/gate&gt;&gt;&lt;&lt;/if&gt;&gt;
@@ -2513,8 +2491,9 @@ Those who remain in the city hear the sounds of another battle in the distance--
 &lt;br&gt;&lt;br&gt;
 &lt;&lt;link &quot;Volunteer for the navy&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jul 1666: Volunteered for the navy&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;replace &quot;#volunteer&quot;&gt;&gt;You have enlisted on [[HMS Royal Sovereign-&gt;navy-volunteer]]&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;Stay out of the fighting&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jul 1666: Stayed out of the fighting&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;replace &quot;#volunteer&quot;&gt;&gt;You wonder if you will make it to [[August 1666]].
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
-&lt;&lt;else&gt;&gt;
-You wonder if you will make it to [[August 1666]].
+&lt;&lt;else&gt;&gt;&lt;span id=&quot;pray&quot;&gt;With the sounds of battle so close to home, do you pray for London&#39;s safety?
+&lt;br&gt;&lt;br&gt;
+&lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#pray&quot;&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jul 1666: Prayed for London&#39;s safety&quot;, money: 0, repDelta: 1, repBefore: $reputation - 1, infectPct: _riskPct})&gt;&gt;You join your neighbors in prayer for the city&#39;s deliverance, finding comfort in shared devotion during these dark times. You wonder if you will make it to [[August 1666]].&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#pray&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jul 1666: Did not pray for London&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;You keep to yourself and hope for the best. You wonder if you will make it to [[August 1666]].&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 
 &lt;&lt;/if&gt;&gt;
 &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/3/34/St._James_Day_Fight%2C_Pic_1.jpg&quot; height=&quot;708px&quot; width=&quot;900px&quot;&gt;
@@ -2527,14 +2506,9 @@ You wonder if you will make it to [[August 1666]].
 &lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;gate &quot;monthly&quot;&gt;&gt;As the summer heat engulfs the city, &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; numbers continue to rise. But at least there&#39;s good news on the war front, as you hear that the &lt;&lt;defFleet &quot;fleet&quot;&gt;&gt; has burnt more Dutch ships.
 &lt;br&gt;&lt;br&gt;
-&lt;&lt;if $agenum gte 16 and $gender isnot &quot;female&quot;&gt;&gt;&lt;span id=&quot;volunteer&quot;&gt;Do you want to join the victorious Navy and burn more Dutch ships?
+&lt;span id=&quot;bonfire&quot;&gt;Your neighbors are celebrating the burning of the Dutch fleet with bonfires in the street. &lt;&lt;if $origin is &quot;the Dutch Republic&quot;&gt;&gt;You eye the crowds warily—the mood is fiercely anti-Dutch and you worry what might happen if someone recognizes your origins. &lt;&lt;/if&gt;&gt;Do you join the celebrations?
 &lt;br&gt;&lt;br&gt;
-&lt;&lt;link &quot;Volunteer for the navy&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Aug 1666: Volunteered for the navy&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;replace &quot;#volunteer&quot;&gt;&gt;You have enlisted on [[HMS Royal Sovereign-&gt;navy-volunteer]]&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;Stay out of the fighting&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Aug 1666: Stayed out of the fighting&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;replace &quot;#volunteer&quot;&gt;&gt;
-You hope it will be enough to tide you through the last hot month of the year, as [[September 1666]] dawns.
-&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
-&lt;&lt;else&gt;&gt;
-You hope it will be enough to tide you through the last hot month of the year, as [[September 1666]] dawns.
-&lt;&lt;/if&gt;&gt;
+&lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#bonfire&quot;&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Aug 1666: Celebrated the burning of the Dutch fleet&quot;, money: 0, repDelta: 1, repBefore: $reputation - 1, infectPct: _riskPct})&gt;&gt;You throw yourself into the celebrations, cheering and dancing around the bonfires with your neighbors. The cannons fired in celebration from the Tower of London echo across the city. You hope the good news will be enough to tide you through the last hot month of the year, as [[September 1666]] dawns.&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#bonfire&quot;&gt;&gt;&lt;&lt;if $origin is &quot;the Dutch Republic&quot;&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Aug 1666: Avoided the Dutch fleet celebrations&quot;, money: 0, repDelta: -1, repBefore: $reputation + 1, infectPct: null})&gt;&gt;You stay indoors, unwilling to risk being caught up in the anti-Dutch fervor. Your absence is noted by your neighbors, who mutter about your loyalties.&lt;&lt;else&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Aug 1666: Avoided the Dutch fleet celebrations&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;You stay indoors, keeping to yourself while the celebrations rage outside.&lt;&lt;/if&gt;&gt; The cannons fired in celebration from the Tower of London echo across the city. You hope the good news will be enough to tide you through the last hot month of the year, as [[September 1666]] dawns.&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 
 &lt;&lt;/gate&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;fumigant&gt;&gt;
@@ -2862,23 +2836,6 @@ You have no choice but to &lt;&lt;storyline-return &quot;accept your new role&qu
 &lt;&lt;gate &quot;monthly&quot;&gt;&gt;&lt;span id=&quot;plague-day-replace&quot;&gt;
 Despite the English &lt;&lt;defFleet &quot;fleet&#39;s&quot;&gt;&gt; victory, the war grinds on and rumors begin to circulate that the French are considering siding with the Dutch. &lt;&lt;if $origin is &quot;France&quot; or $origin is &quot;the Dutch Republic&quot;&gt;&gt;You make sure to talk loudly of your loyalty to the King and the superiority of the English fleet, whenever your neighbors mention the war.&lt;&lt;/if&gt;&gt;
 &lt;br&gt;&lt;br&gt;
-&lt;&lt;if $agenum gte 16 and $gender isnot &quot;female&quot;&gt;&gt;&lt;span id=&quot;volunteer&quot;&gt;Do you volunteer to help fight the French?
-&lt;br&gt;&lt;br&gt;
-&lt;&lt;link &quot;Volunteer for the navy&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jul 1665: Volunteered for the navy&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;replace &quot;#volunteer&quot;&gt;&gt;You have enlisted on [[HMS Royal Sovereign-&gt;navy-volunteer]]&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;Stay out of the fighting&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jul 1665: Stayed out of the fighting&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;replace &quot;#volunteer&quot;&gt;&gt;
-&lt;span id=&quot;decision&quot;&gt;Do you go looking for more information?
-&lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#decision&quot;&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jul 1665: Sought out war news&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;
-There aren&#39;t as many rumors as there might have been, given how many people have fled the city and how afraid the people who remain are of coming near each other. 
-&lt;br&gt;&lt;br&gt;
-&lt;&lt;july-1665-helper&gt;&gt;
-
-&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | 
-&lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#decision&quot;&gt;&gt;
-&lt;br&gt;&lt;br&gt;
-&lt;&lt;july-1665-helper&gt;&gt;
-
-&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;
-&lt;/span&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
-&lt;&lt;else&gt;&gt;
 &lt;span id=&quot;decision&quot;&gt;Do you go looking for more information?
 &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#decision&quot;&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jul 1665: Sought out war news&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;
 There aren&#39;t as many rumors as there might have been, given how many people have fled the city and how afraid the people who remain are of coming near each other.
@@ -2890,7 +2847,6 @@ There aren&#39;t as many rumors as there might have been, given how many people 
 &lt;&lt;july-1665-helper&gt;&gt;
 
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
-&lt;&lt;/if&gt;&gt;
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/gate&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="39" name="FamPesthouse" tags="infection-rates" position="25,450" size="100,100">&lt;&lt;nobr&gt;&gt;


### PR DESCRIPTION
… v3.7

- Jun 1665: Restrict volunteer to men 16+ who answered Yes to "find out more"
- Jul 1665: Remove volunteer choice entirely
- Jun 1666: Remove volunteer, add 50% impressment for eligible men who listened to gossip
- Jul 1666: Add prayer choice (+1 rep, double plague risk) for non-volunteer-eligible players
- Aug 1666: Replace volunteer with bonfire celebration choice with Dutch Republic flavor text

https://claude.ai/code/session_01Gu2XksEbjxUuPn6RJS8EgB