### PR TITLE
Fix orderNPCs widget syntax error — bump to v3.14

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v3.13" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v3.14" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -6316,23 +6316,22 @@ You quickly baptize them&lt;&lt;set $money -=6&gt;&gt; and pray to God that $NPC
 &lt;&lt;widget &quot;orderNPCs&quot;&gt;&gt;&lt;&lt;silently&gt;&gt;
 &lt;&lt;set _arrName to _args[0]&gt;&gt;
 &lt;&lt;set _arr to State.getVar(_arrName)&gt;&gt;
+&lt;&lt;set _rankFn to function(npc) {
+  var r = (npc.relationship || &quot;&quot;).toLowerCase();
+  if (r === &quot;landlord&quot; || r === &quot;master&quot;) return 1;
+  if (r === &quot;landlord&#39;s wife&quot; || r === &quot;mistress&quot;) return 2;
+  if (r.indexOf(&quot;father&quot;) &gt;= 0) return 3;
+  if (r.indexOf(&quot;mother&quot;) &gt;= 0) return 4;
+  if (r.indexOf(&quot;uncle&quot;) &gt;= 0) return 5;
+  if (r.indexOf(&quot;aunt&quot;) &gt;= 0) return 6;
+  if (r === &quot;guardian&quot; || r === &quot;cousin&quot;) return 7;
+  if (r === &quot;guardian&#39;s wife&quot; || r === &quot;cousin&#39;s wife&quot;) return 8;
+  if (r.indexOf(&quot;servant&quot;) &gt;= 0) return 10;
+  if (r.indexOf(&quot;lodger&quot;) &gt;= 0) return 11;
+  return 9;
+}&gt;&gt;
 &lt;&lt;run _arr.sort(function(a, b) {
-  function _rel(npc) { return (npc.relationship || &quot;&quot;).toLowerCase(); }
-  function _rank(npc) {
-    var r = _rel(npc);
-    if (r === &quot;landlord&quot; || r === &quot;master&quot;) return 1;
-    if (r === &quot;landlord&#39;s wife&quot; || r === &quot;mistress&quot;) return 2;
-    if (r.indexOf(&quot;father&quot;) &gt;= 0) return 3;
-    if (r.indexOf(&quot;mother&quot;) &gt;= 0) return 4;
-    if (r.indexOf(&quot;uncle&quot;) &gt;= 0) return 5;
-    if (r.indexOf(&quot;aunt&quot;) &gt;= 0) return 6;
-    if (r === &quot;guardian&quot; || r === &quot;cousin&quot;) return 7;
-    if (r === &quot;guardian&#39;s wife&quot; || r === &quot;cousin&#39;s wife&quot;) return 8;
-    if (r.indexOf(&quot;servant&quot;) &gt;= 0) return 10;
-    if (r.indexOf(&quot;lodger&quot;) &gt;= 0) return 11;
-    return 9;
-  }
-  var ra = _rank(a), rb = _rank(b);
+  var ra = _rankFn(a), rb = _rankFn(b);
   if (ra !== rb) return ra - rb;
   return (b.agenum || 0) - (a.agenum || 0);
 })&gt;&gt;


### PR DESCRIPTION
SugarCube's <<run>> macro doesn't support named function declarations (function _rel, function _rank) inside expressions. Refactored to use a <<set>> with an anonymous function expression assigned to _rankFn, then reference _rankFn inside the sort callback.

https://claude.ai/code/session_01XRESTury3LHAGVMEHFKyrg