### PR TITLE
Remove gate widget and rename $seeking to $seekingMarriage — bump to …

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v3.15" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v3.16" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -1563,7 +1563,7 @@ The city has ordered public &lt;&lt;defFasts &quot;fasts&quot;&gt;&gt; and praye
 
 &lt;&lt;if $agenum gte 16 and $seekingDecision is 0&gt;&gt;
 &lt;&lt;marriage-market&gt;&gt;
-&lt;&lt;elseif ($socio is &quot;day labourers&quot; or $socio is &quot;artisans&quot; or $socio is &quot;merchants&quot;) and $agenum gte 14 and $agenum lte 21 and $relationship is &quot;single&quot; and $seeking is 0 and $seekingDecision isnot 2&gt;&gt;
+&lt;&lt;elseif ($socio is &quot;day labourers&quot; or $socio is &quot;artisans&quot; or $socio is &quot;merchants&quot;) and $agenum gte 14 and $agenum lte 21 and $relationship is &quot;single&quot; and $seekingMarriage is 0 and $seekingDecision isnot 2&gt;&gt;
 &lt;&lt;apprenticeship-market&gt;&gt;
 
 /* passage continues after decisions are made */
@@ -1756,31 +1756,7 @@ John: 1500, Thomas: 1300, William: 1300, Richard: 620, Robert: 600, Henry: 500, 
 &lt;&lt;set $timeline to [&quot;December 1664&quot;, &quot;January 1665&quot;, &quot;May 1665&quot;, &quot;June 1665&quot;, &quot;July 1665&quot;, &quot;August 1665&quot;, &quot;September 1665&quot;, &quot;October 1665&quot;, &quot;November 1665&quot;, &quot;December 1665&quot;, &quot;January 1666&quot;, &quot;February 1666&quot;, &quot;March 1666&quot;, &quot;April 1666&quot;, &quot;May 1666&quot;, &quot;June 1666&quot;, &quot;July 1666&quot;, &quot;August 1666&quot;, &quot;September 1666&quot;, &quot;October 1666&quot;, &quot;November 1666&quot;, &quot;December 1666&quot;
 ]&gt;&gt;
 &lt;&lt;initDeathData&gt;&gt;
-&lt;&lt;script&gt;&gt;
-/* Gate queue: sequential reveal of player-decision blocks.
-   Each widget that presents a choice registers a gate via setup.addGate().
-   All gate spans start hidden (inline style). The :passagerender handler
-   reveals the first gate before the page is shown. resolveGate() advances
-   the queue on the live DOM when a choice is made. */
-setup.gates = [];
-setup.addGate = function (id) {
-	setup.gates.push(id);
-};
-setup.resolveGate = function () {
-	setup.gates.shift();
-	if (setup.gates.length &gt; 0) {
-		$(&#39;#gate-&#39; + setup.gates[0]).show();
-	}
-};
-$(document).on(&#39;:passagestart&#39;, function () {
-	setup.gates = [];
-});
-$(document).on(&#39;:passagerender&#39;, function (ev) {
-	if (setup.gates.length &gt; 0) {
-		$(ev.content).find(&#39;#gate-&#39; + setup.gates[0]).show();
-	}
-});
-&lt;&lt;/script&gt;&gt;
+
 &lt;&lt;set $catchUpSummaries to [&quot;War with the Dutch looms on the horizon. Christmas is celebrated as usual across the city.&quot;, &quot;A great snowfall blankets London and the frost lasts two weeks. The Thames nearly freezes over.&quot;, &quot;The first plague cases appear. Houses are shut up with red crosses and the words &#39;Lord Have Mercy Upon Us&#39; painted on their doors.&quot;, &quot;The English fleet wins a great victory over the Dutch at the Battle of Lowestoft. The King and his court flee London for Hampton Court as plague spreads.&quot;, &quot;Plague deaths accelerate sharply. Burials now happen day and night, and the streets empty as those who can afford to flee do so.&quot;, &quot;Deaths outpace burials. The summer heat is oppressive and the city reeks of death. People strip clothing from corpses out of desperation.&quot;, &quot;Plague deaths reach their terrible peak at over 7,000 a week. The streets are nearly deserted.&quot;, &quot;Cold, rainy weather arrives at last. Plague numbers finally begin to decline, though thousands still die each week.&quot;, &quot;People begin trickling back into the city as deaths continue to fall. Shops cautiously reopen.&quot;, &quot;Despite two great frosts, plague numbers tick upward again. A grim Christmas settles over the city.&quot;, &quot;Plague recedes. Nobles return in their coaches, shops reopen, and the streets fill with life again.&quot;, &quot;The King returns to Whitehall, a sign the worst is over. A great snow covers the mass graves as if hiding a terrible dream.&quot;, &quot;The Queen of Portugal dies. London continues to mourn and rebuild.&quot;, &quot;Plague cases creep upward again with the spring warmth. Easter is celebrated cautiously.&quot;, &quot;The King\&#39;s birthday is celebrated with bonfires, though plague still lingers in the city.&quot;, &quot;The fleet engages the Dutch again. Four days of cannon fire are heard from London.&quot;, &quot;Press gangs roam the streets seizing men for the fleet. The summer heat returns.&quot;, &quot;Plague numbers climb again in the heat. The fleet burns Dutch ships in a bold raid.&quot;, &quot;A great fire breaks out and burns for days, destroying much of the City within the walls.&quot;, &quot;Thousands are left homeless by the fire. The city begins to clear rubble and rebuild amidst the ashes.&quot;, &quot;The King declares an official day of thanksgiving. The plague is declared over at last.&quot;, &quot;Fires still smolder in cellars beneath the ruins. London looks ahead to a long recovery.&quot;]&gt;&gt;</tw-passagedata><tw-passagedata pid="11" name="PassageHeader" tags="" position="525,25" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;silently&gt;&gt;
 &lt;&lt;fumigant-check&gt;&gt;
@@ -2220,7 +2196,7 @@ You&#39;ve been taken by a press gang&lt;&lt;if $impressed gte 2&gt;&gt; again&l
 &lt;&lt;corpse-work&gt;&gt;
 &lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;bill-subscribe&gt;&gt;
-&lt;&lt;gate &quot;monthly&quot;&gt;&gt;As if war wasn’t bad enough, you begin to hear rumors around the city that several houses have been shut up because their inhabitants have &lt;&lt;defPlague &quot;plague&quot;&gt;&gt;.
+As if war wasn’t bad enough, you begin to hear rumors around the city that several houses have been shut up because their inhabitants have &lt;&lt;defPlague &quot;plague&quot;&gt;&gt;.
 You &lt;span id=&quot;decision&quot;&gt;
 &lt;&lt;link &quot;decide to investigate&quot;&gt;&gt;&lt;&lt;replace &quot;#decision&quot;&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;May 1665: Investigated the plague rumors&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;investigate. After a few days, you decide to go see the truth of it for yourself and are horrified to find the rumors are true: several houses throughout the city had been locked up. Red crosses and the phrase //Lord Have Mercy Upon Us// have been painted on their front doors, to ensure that everyone knows this is a plague house.
 &lt;br&gt;
@@ -2240,13 +2216,13 @@ You &lt;span id=&quot;decision&quot;&gt;
     &lt;&lt;/if&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;
     &lt;/span&gt;
     &lt;&lt;fumigant&gt;&gt;
-&lt;&lt;/gate&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="17" name="June 1665" tags="storyline 1665" position="1325,475" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
 &lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;bill-subscribe&gt;&gt;
-&lt;&lt;gate &quot;monthly&quot;&gt;&gt;    On June 3rd, everyone throughout the city hears the sound of cannon fire—not the celebratory firing of cannons in ceremony but the sounds of battle. It is obvious that the English and Dutch &lt;&lt;defFleet &quot;fleets&quot;&gt;&gt; have engaged in battle, but where? How close are they to London? Who is winning? No one knows. &lt;&lt;if $origin is &quot;the Dutch Republic&quot;&gt;&gt;You keep your head down and hide from your neighbors as much as possible, for fear that they will turn on you.&lt;&lt;/if&gt;&gt;
+    On June 3rd, everyone throughout the city hears the sound of cannon fire—not the celebratory firing of cannons in ceremony but the sounds of battle. It is obvious that the English and Dutch &lt;&lt;defFleet &quot;fleets&quot;&gt;&gt; have engaged in battle, but where? How close are they to London? Who is winning? No one knows. &lt;&lt;if $origin is &quot;the Dutch Republic&quot;&gt;&gt;You keep your head down and hide from your neighbors as much as possible, for fear that they will turn on you.&lt;&lt;/if&gt;&gt;
     &lt;br&gt;&lt;br&gt;
    &lt;span id=&quot;decision&quot;&gt; Do you try to find out more?
     &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#decision&quot;&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jun 1665: Sought out war news&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;
@@ -2274,7 +2250,7 @@ You &lt;span id=&quot;decision&quot;&gt;
 &lt;br&gt;&lt;br&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 
-&lt;&lt;/gate&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 
 
 
@@ -2284,7 +2260,7 @@ You &lt;span id=&quot;decision&quot;&gt;
 &lt;&lt;corpse-work&gt;&gt;
 &lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;bill-subscribe&gt;&gt;
-&lt;&lt;gate &quot;monthly&quot;&gt;&gt; /* Beggar &amp; Day Labourer choices */
+ /* Beggar &amp; Day Labourer choices */
 /* nts: need text if day labourers don&#39;t have a job */
     &lt;&lt;if $role is &quot;corpsebearer&quot; or $role is &quot;searcher&quot; or $role is &quot;nurse&quot; or $role is &quot;warder&quot;&gt;&gt;
         &lt;&lt;if ndef $textGroup&gt;&gt;&lt;&lt;set $textGroup = 1&gt;&gt;&lt;&lt;/if&gt;&gt;
@@ -2317,14 +2293,14 @@ So many people are sick and shut up in their houses that the city has imposed a 
         &lt;&lt;august-1665-helper&gt;&gt; 
   &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
   &lt;&lt;/if&gt;&gt;
-&lt;&lt;/gate&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="19" name="September 1665" tags="storyline 1665" position="1200,625" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
 &lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;bill-subscribe&gt;&gt;
-&lt;&lt;gate &quot;monthly&quot;&gt;&gt;The deaths continue in such great numbers that you can hardly believe it.&lt;br&gt;&lt;br&gt;
+The deaths continue in such great numbers that you can hardly believe it.&lt;br&gt;&lt;br&gt;
 &lt;&lt;if $role is &quot;corpsebearer&quot;&gt;&gt;You are shocked to see that some bold people have begun attending &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; funerals, as if it were a child’s game or dare. &lt;br&gt;&lt;br&gt;
 &lt;&lt;sep-1665-helper&gt;&gt; 
     &lt;&lt;elseif $role is &quot;warder&quot;&gt;&gt;Some of those locked in their houses have grown desperate and you have had to physically restrain people trying to break out of quarantine.&lt;br&gt;&lt;br&gt;&lt;&lt;sep-1665-helper&gt;&gt; 
@@ -2339,13 +2315,13 @@ So many people are sick and shut up in their houses that the city has imposed a 
 &lt;&lt;sep-1665-helper&gt;&gt; 
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
     &lt;&lt;/if&gt;&gt;
-&lt;&lt;/gate&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="20" name="October 1665" tags="storyline 1665" position="1325,625" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
 &lt;&lt;if not _randomEventFired&gt;&gt;
-&lt;&lt;gate &quot;monthly&quot;&gt;&gt;October is miserably rainy and cold. &lt;&lt;defPlague &quot;Plague&quot;&gt;&gt; numbers are--thanks be to God--finally starting to come down, but are still terrifyingly high and you see sick people brazenly out and about on the streets.&lt;br&gt;&lt;br&gt;
+October is miserably rainy and cold. &lt;&lt;defPlague &quot;Plague&quot;&gt;&gt; numbers are--thanks be to God--finally starting to come down, but are still terrifyingly high and you see sick people brazenly out and about on the streets.&lt;br&gt;&lt;br&gt;
 &lt;span id=&quot;pesthouse&quot;&gt;Do you report the sick to the &lt;&lt;defPesthouse &quot;pesthouse&quot;&gt;&gt;? &lt;&lt;link &quot;Yes, I don&#39;t want them getting me sick&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Oct 1665: Reported the sick to the pesthouse&quot;, money: 0, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: _riskPct})&gt;&gt;&lt;&lt;replace &quot;#pesthouse&quot;&gt;&gt;You start reporting the sick people you see to the pesthouse, hoping to keep the streets free from their presence. You feel a bit bad about confining them to such an awful place, but your own safety is worth it.
 
 Rumors swirl about the Pope and the King of France dying, &lt;&lt;if $religion is &quot;Catholic&quot;&gt;&gt;much to your alarm as a good Catholic&lt;&lt;if $origin is &quot;France&quot;&gt;&gt; and subject of the French monarchy&lt;&lt;/if&gt;&gt;, but to your relief you discover&lt;&lt;else&gt;&gt;but alas&lt;&lt;/if&gt;&gt; they are only rumors.&lt;br&gt;&lt;br&gt;
@@ -2370,22 +2346,22 @@ You hope the cold will deepen--and plague numbers continue to fall--as you head 
 
 /* Noble text */
 
-&lt;&lt;/gate&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="21" name="November 1665" tags="storyline 1665" position="1450,625" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
 &lt;&lt;if not _randomEventFired&gt;&gt;
-&lt;&lt;gate &quot;monthly&quot;&gt;&gt;The weather is terrible but &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; numbers are coming down and people start to trickle back into town. 
+The weather is terrible but &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; numbers are coming down and people start to trickle back into town. 
 &lt;span id=&quot;visit&quot;&gt;Do you go out to visit your returning friends and neighbors? &lt;&lt;link &quot;Yes, I&#39;ve missed them greatly&quot;&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Nov 1665: Visited returning neighbors&quot;, money: 0, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: _riskPct})&gt;&gt;&lt;&lt;replace &quot;#visit&quot;&gt;&gt;You go out in the streets to greet your returning friends and neighbors, glad to be reunited after these long months.
 You don&#39;t expect great things this Christmas, but you are still looking forward to [[December 1665]].&lt;br&gt;&lt;br&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No, it&#39;s still not safe for socializing&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Nov 1665: Avoided socializing with returning neighbors&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;replace &quot;#visit&quot;&gt;&gt;You don&#39;t go out in the streets to welcome back your friends and neighbors, but you do shout your greetings down from your window. You are glad to see them back. You don&#39;t expect great things this Christmas, but you are still looking forward to [[December 1665]].&lt;br&gt;&lt;br&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
-&lt;&lt;/gate&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="22" name="December 1665" tags="storyline 1665" position="1075,775" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
 &lt;&lt;if not _randomEventFired&gt;&gt;
-&lt;&lt;gate &quot;monthly&quot;&gt;&gt;&lt;&lt;defPlague &quot;Plague&quot;&gt;&gt; numbers are up, despite two great frosts, and the Christmas festivities are all cancelled. You hope it&#39;s the last gasp of the outbreak, even as you reflect at how much different things are now than the were last year.&lt;br&gt;&lt;br&gt;
+&lt;&lt;defPlague &quot;Plague&quot;&gt;&gt; numbers are up, despite two great frosts, and the Christmas festivities are all cancelled. You hope it&#39;s the last gasp of the outbreak, even as you reflect at how much different things are now than the were last year.&lt;br&gt;&lt;br&gt;
 
 &lt;span id= &quot;decision&quot;&gt;Do you want to celebrate Christmas despite the risk? &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#decision&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;&lt;&lt;party-costs&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round((10000 / _rate) + 200) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if random(1, 50) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Dec 1665: Held a Christmas feast despite the plague&quot;, money: -_partyCost, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: _riskPct})&gt;&gt;&lt;&lt;if $hoh is 4&gt;&gt;You convince your husband, and you&lt;&lt;elseif $hoh is 3 or ($hoh is 0 and $socio is &quot;servants&quot;)&gt;&gt;You convince your $masterTitle, and you&lt;&lt;elseif $hoh isnot 1&gt;&gt;You convince your family, and you&lt;&lt;else&gt;&gt;You&lt;&lt;/if&gt;&gt; are planning a feast for a few friends to make up for the dour attitude across the city. You&#39;re looking forward to the opportunity to forget the plague for a few hours and feast on your favorite food &lt;&lt;set _food = [&quot;roasted herring&quot;, &quot;pigeon pie&quot;, &quot;lamprey pie&quot;, &quot;roasted veal&quot;, &quot;hogs pudding&quot;]&gt;&gt;&lt;&lt;listbox &quot;$food&quot;&gt;&gt;&lt;&lt;optionsfrom _food&gt;&gt;&lt;&lt;/listbox&gt;&gt;.&lt;br&gt;&lt;br&gt;&lt;&lt;if $socio is &quot;nobles&quot;&gt;&gt;
 The King decides to take the Court to &lt;&lt;defOxford &quot;Oxford&quot;&gt;&gt; to celebrate the Christmas festivities and settles into the &lt;&lt;defDeaneryAtChristChurchCollege &quot;Deanery at Christ Church College&quot;&gt;&gt;, the king&#39;s traditional lodgings when he is in residence. The rest of the Court is scattered in lodgings throughout the city.&lt;br&gt;&lt;br&gt;&lt;span id=&quot;gift2&quot;&gt;Do you wish to purchase a New Year&#39;s gift and send it to the King? &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#gift2&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;&lt;&lt;set $money -= 4800&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Dec 1665: Sent a New Year&#39;s gift to the King&quot;, money: -4800, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: null})&gt;&gt;You send a fine jeweled cup to the King as a New Year&#39;s gift. In return, you receive a present of gilt silver plate.&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#gift2&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Dec 1665: Did not send a New Year&#39;s gift to the King&quot;, money: 0, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: null})&gt;&gt;You decide not to send a gift this year.&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;&lt;&lt;/if&gt;&gt;
@@ -2395,13 +2371,13 @@ The King decides to take the Court to &lt;&lt;defOxford &quot;Oxford&quot;&gt;&g
 &lt;br&gt;&lt;br&gt;
 Maybe things will be better in [[1666-&gt;January 1666]].&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 
-&lt;&lt;/gate&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="23" name="January 1666" tags="storyline 1666" position="1200,775" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
 &lt;&lt;if not _randomEventFired&gt;&gt;
-&lt;&lt;gate &quot;monthly&quot;&gt;&gt;&lt;&lt;defPlague &quot;Plague&quot;&gt;&gt; numbers continue to come down. &lt;&lt;defNoble &quot;Noble&quot;&gt;&gt; coaches fill the streets, &lt;&lt;defPorter &quot;porters&quot;&gt;&gt; are everywhere hauling the belongings of those who are returning to the city, all the shops are reopening, and &lt;&lt;defBeggars &quot;beggars&quot;&gt;&gt; overflow the highways.&lt;br&gt;&lt;br&gt;
+&lt;&lt;defPlague &quot;Plague&quot;&gt;&gt; numbers continue to come down. &lt;&lt;defNoble &quot;Noble&quot;&gt;&gt; coaches fill the streets, &lt;&lt;defPorter &quot;porters&quot;&gt;&gt; are everywhere hauling the belongings of those who are returning to the city, all the shops are reopening, and &lt;&lt;defBeggars &quot;beggars&quot;&gt;&gt; overflow the highways.&lt;br&gt;&lt;br&gt;
 &lt;br&gt;
 &lt;&lt;if $socio is &quot;day labourers&quot; or $socio is &quot;beggars&quot;&gt;&gt;&lt;span id=&quot;help&quot;&gt;Do you offer your services as a porter? &lt;&lt;link &quot;Yes, I could use the extra money&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;&lt;&lt;set $money +=6&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jan 1666: Offered porter services&quot;, money: 6, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: _riskPct})&gt;&gt;&lt;&lt;replace &quot;#help&quot;&gt;&gt;You keep busy offering the returning families your services as a porter, earning a few coins as you do so. You are glad to see the city so lively again.
 
@@ -2415,13 +2391,13 @@ After six months of travel, the king finally returns the Court to &lt;&lt;defHam
 &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/c/ca/London_welcomes_home_runaways_Wellcome_L0002722.jpg&quot; width=&quot;100%&quot;&gt;
 //Henry Petowe and Frank Percy Wilson, &quot;London welcomes home her runaways&quot;. Taken from a woodcut in Henry Petowe&#39;s:The Countrie Ague, 1625. Wellcome Images//
 
-&lt;&lt;/gate&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="24" name="February 1666" tags="storyline 1666" position="1325,775" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
 &lt;&lt;if not _randomEventFired&gt;&gt;
-&lt;&lt;gate &quot;monthly&quot;&gt;&gt;The king has returned to London! People rejoice and return to their churches, knowing that if the king is willing to move back into his city palace of &lt;&lt;defWhitehall &quot;Whitehall&quot;&gt;&gt;, then the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; outbreak must be almost over. A great snow hides all the graves and it&#39;s as if the last year was all a terrible dream.&lt;br&gt;&lt;br&gt;
+The king has returned to London! People rejoice and return to their churches, knowing that if the king is willing to move back into his city palace of &lt;&lt;defWhitehall &quot;Whitehall&quot;&gt;&gt;, then the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; outbreak must be almost over. A great snow hides all the graves and it&#39;s as if the last year was all a terrible dream.&lt;br&gt;&lt;br&gt;
 
 And, as if you needed more opportunities to celebrate, it&#39;s almost &lt;&lt;defLent &quot;Lent.&quot;&gt;&gt; &lt;span id= &quot;decision&quot;&gt;Do you want to hold one last feast before it&#39;s time to begin fasting? &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#decision&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;&lt;&lt;party-costs&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round((10000 / _rate) + 200) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if random(1, 50) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Feb 1666: Held a pre-Lent feast&quot;, money: -_partyCost, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: _riskPct})&gt;&gt;&lt;&lt;if $hoh is 4&gt;&gt;You convince your husband, and you&lt;&lt;elseif $hoh is 3 or ($hoh is 0 and $socio is &quot;servants&quot;)&gt;&gt;You convince your $masterTitle, and you&lt;&lt;elseif $hoh isnot 1&gt;&gt;You convince your family, and you&lt;&lt;else&gt;&gt;You&lt;&lt;/if&gt;&gt; are planning a feast for a few friends. You&#39;re excited about all the things on the menu but especially your favorite dessert &lt;&lt;set _food = [&quot;minced pie&quot;, &quot;sweetmeats&quot;, &quot;currant cake&quot;, &quot;syllabub&quot;, &quot;tansy&quot;]&gt;&gt;&lt;&lt;listbox &quot;$food&quot;&gt;&gt;&lt;&lt;optionsfrom _food&gt;&gt;&lt;&lt;/listbox&gt;&gt;. Feasting costs money though, and things might be tight in the coming months, though your heart and stomach are full.&lt;br&gt;&lt;br&gt;
 
@@ -2429,38 +2405,38 @@ Your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; priest hasn&#39;t returned yet
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#decision&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Feb 1666: Skipped the pre-Lent feast&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;if $hoh is 4&gt;&gt;You convince your husband to skip the feast.&lt;&lt;elseif $hoh is 3 or ($hoh is 0 and $socio is &quot;servants&quot;)&gt;&gt;You convince your $masterTitle to skip the feast.&lt;&lt;elseif $hoh isnot 1&gt;&gt;You convince your family to skip the feast.&lt;&lt;else&gt;&gt;You decide against holding a feast.&lt;&lt;/if&gt;&gt; &lt;span id=&quot;church&quot;&gt;Do you instead go to the Queen&#39;s church for Ash Wednesday, the official beginning of Lent? &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#church&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;if $religion isnot &quot;Catholic&quot;&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Feb 1666: Attended the Queen&#39;s church&quot;, money: 0, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: null})&gt;&gt;You instead go to the Queen&#39;s church for Ash Wednesday. &lt;&lt;if $religion isnot &quot;Catholic&quot;&gt;&gt;Unfortunately your neighbors see you going into the Catholic Church and judge you harshly for abandoning your religious principles. &lt;&lt;/if&gt;&gt;&lt;br&gt;&lt;br&gt;Your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; priest hasn&#39;t returned yet, though, and his reputation plummets as the days tick over into [[March 1666]].&lt;br&gt;&lt;br&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#church&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Feb 1666: Stayed home for the holiday&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;You instead enjoy a quiet holiday inside, safe from the crowds and the plague. &lt;br&gt;&lt;br&gt;Your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; priest hasn&#39;t returned yet, though, and his reputation plummets as the days tick over into [[March 1666]].&lt;br&gt;&lt;br&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 
-&lt;&lt;/gate&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="25" name="March 1666" tags="storyline 1666" position="1450,775" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
 &lt;&lt;if not _randomEventFired&gt;&gt;
-&lt;&lt;gate &quot;monthly&quot;&gt;&gt;The Queen of Portugal, mother to England&#39;s beloved &lt;&lt;defQueenCatherine &quot;Queen Catherine&quot;&gt;&gt;, has died.
+The Queen of Portugal, mother to England&#39;s beloved &lt;&lt;defQueenCatherine &quot;Queen Catherine&quot;&gt;&gt;, has died.
 &lt;br&gt;
 &lt;br&gt;
 &lt;span id=&quot;pray&quot;&gt;Do you go to church and &lt;&lt;if $religion is &quot;Catholic&quot;&gt;&gt;light a candle&lt;&lt;else&gt;&gt;pray&lt;&lt;/if&gt;&gt; for the queen?&lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#pray&quot;&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Mar 1666: Went to church to pray for the Queen of Portugal&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;You go to church and &lt;&lt;if $religion is &quot;Catholic&quot;&gt;&gt;light a candle&lt;&lt;else&gt;&gt;pray&lt;&lt;/if&gt;&gt; for the late queen.&lt;&lt;march-1666-helper&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#pray&quot;&gt;&gt;You don&#39;t want to risk going to church, but you privately do pray that God shows mercy on her &lt;&lt;if $religion isnot &quot;Catholic&quot;&gt;&gt;&lt;&lt;defPapists &quot;papist&quot;&gt;&gt;&lt;&lt;/if&gt;&gt;soul. &lt;&lt;march-1666-helper&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Mar 1666: Prayed privately for the Queen of Portugal&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 &lt;&lt;/if&gt;&gt;
-&lt;&lt;/gate&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="26" name="April 1666" tags="storyline 1666" position="1075,925" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
 &lt;&lt;if not _randomEventFired&gt;&gt;
-&lt;&lt;gate &quot;monthly&quot;&gt;&gt;There&#39;s no denying it now. &lt;&lt;defPlague &quot;Plague&quot;&gt;&gt; cases are definitely on the rise. Luckily, Sweden has declared itself on England&#39;s side in the war against the Dutch so at least things are looking more promising there. The Lenten fast is over it&#39;s time to celebrate Christ&#39;s resurrection on earth with Easter and the return of spring.
+There&#39;s no denying it now. &lt;&lt;defPlague &quot;Plague&quot;&gt;&gt; cases are definitely on the rise. Luckily, Sweden has declared itself on England&#39;s side in the war against the Dutch so at least things are looking more promising there. The Lenten fast is over it&#39;s time to celebrate Christ&#39;s resurrection on earth with Easter and the return of spring.
 
 &lt;span id=&quot;Easter&quot;&gt;Do you want to attend Easter services at your parish church, despite the risk of plague?
 &lt;br&gt;&lt;br&gt;
 &lt;&lt;if $agenum gte 16&gt;&gt;
 &lt;&lt;link &quot;Attend the service and take communion&quot;&gt;&gt;&lt;&lt;replace &quot;#Easter&quot;&gt;&gt;You gather with your neighbors to celebrate and unite in the glory of God. The last year has been terrible and the danger is not over, but for today at least you can set aside your troubles.&lt;&lt;set $money to Math.clamp($money - 2, -1000000,1000000)&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Apr 1666: Attended Easter service and took communion&quot;, money: -2, repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;&lt;&lt;storyline-return&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;/if&gt;&gt;&lt;&lt;link &quot;Attend the service but skip communion&quot;&gt;&gt;&lt;&lt;replace &quot;#Easter&quot;&gt;&gt;
 You gather with your neighbors to celebrate Easter &lt;&lt;if $agenum lte 15&gt;&gt;but are too young to take communion.&lt;&lt;else&gt;&gt;&lt;&lt;if $religion isnot &quot;member of the Church of England&quot;&gt;&gt;but can&#39;t bring yourself to join in their heretical communion&lt;&lt;else&gt;&gt;but you are too angry about the death around you to put aside your sins and take communion&lt;&lt;/if&gt;&gt;. &lt;&lt;if $reputation gte 6&gt;&gt;Luckily, your churchwardens take mercy on you and don&#39;t fine you for skipping.&lt;&lt;else&gt;&gt;Your reputation is so poor, you are reported for skipping communion and fined £20.&lt;&lt;set $money to Math.clamp($money - 4800, -1000000,1000000)&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Apr 1666: Attended Easter service, skipped communion&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;&lt;&lt;storyline-return&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;Skip church&quot;&gt;&gt;&lt;&lt;replace &quot;#Easter&quot;&gt;&gt;&lt;&lt;if $religion isnot &quot;member of the Church of England&quot;&gt;&gt;You can&#39;t bear to even set foot in a heretical church. &lt;&lt;/if&gt;&gt;&lt;&lt;if $reputation gte 6&gt;&gt;Luckily, your churchwardens know that you only stay away because you fear contagion and don&#39;t fine you for non-attendance.&lt;&lt;else&gt;&gt;Your reputation is so poor, you are reported for skipping communion and fined £20.&lt;&lt;set $money to Math.clamp($money - 4800, -1000000,1000000)&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Apr 1666: Skipped Easter services&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;storyline-return&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
-&lt;&lt;/gate&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="27" name="May 1666" tags="storyline 1666" position="1200,925" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
 &lt;&lt;if not _randomEventFired&gt;&gt;
-&lt;&lt;gate &quot;monthly&quot;&gt;&gt;&lt;&lt;defPlague &quot;Plague&quot;&gt;&gt; is increasing throughout the city, but that doesn&#39;t stop all of London from celebrating the king&#39;s birthday and the anniversary of the &lt;&lt;defRestoration &quot;Restoration&quot;&gt;&gt; on May 29th with bonfires. &lt;&lt;defBeggars &quot;Beggars&quot;&gt;&gt; throng the streets but, for once, no one seems to mind. 
+&lt;&lt;defPlague &quot;Plague&quot;&gt;&gt; is increasing throughout the city, but that doesn&#39;t stop all of London from celebrating the king&#39;s birthday and the anniversary of the &lt;&lt;defRestoration &quot;Restoration&quot;&gt;&gt; on May 29th with bonfires. &lt;&lt;defBeggars &quot;Beggars&quot;&gt;&gt; throng the streets but, for once, no one seems to mind. 
 
 &lt;&lt;if $religion isnot &quot;member of the Church of England&quot;&gt;&gt;&lt;span id=&quot;celebrate&quot;&gt;While the king&#39;s return didn&#39;t lead to $religion religious liberty, do you still want to celebrate?&lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#celebrate&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;&lt;&lt;party-costs&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round((10000 / _rate) + 200) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if random(1, 50) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;May 1666: Celebrated the King&#39;s birthday&quot;, money: -_partyCost, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: _riskPct})&gt;&gt;You &lt;&lt;if $hoh is 4&gt;&gt;convince your husband&lt;&lt;elseif $hoh is 3 or ($hoh is 0 and $socio is &quot;servants&quot;)&gt;&gt;convince your $masterTitle&lt;&lt;elseif $hoh isnot 1&gt;&gt;convince your family&lt;&lt;else&gt;&gt;know&lt;&lt;/if&gt;&gt; that the king&#39;s birthday is an important holiday, and take part in the toasting and feasting.
 
@@ -2468,13 +2444,13 @@ You are still recovering from the festivities when the days tip over into [[June
 
 &lt;&lt;else&gt;&gt;
 The king&#39;s birthday is an important holiday and several of your neighbors are planning feasts. &lt;span id=&quot;celebrate&quot;&gt;Do you want to hold your own feast?&lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#celebrate&quot;&gt;&gt;&lt;&lt;party-costs&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round((10000 / _rate) + 200) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if random(1, 50) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;May 1666: Hosted a feast for the King&#39;s birthday&quot;, money: -_partyCost, repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;You host a feast at your house and repeatedly toast the king to celebrate not just his return from exile, but also the restoration of a proper Church of England. You are still recovering from the festivities when the days tip over into [[June 1666]].&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#celebrate&quot;&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round((10000 / _rate) + 200) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if random(1, 50) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;May 1666: Hosted a feast for the King&#39;s birthday&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;There are so many people reveling in the streets that you don&#39;t feel the need to host your own feast. You join them in repeatedly toasting the king to celebrate not just his return from exile, but also the restoration of a proper Church of England. You are still recovering from the festivities when the days tip over into [[June 1666]].&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
-&lt;&lt;/if&gt;&gt;&lt;&lt;/gate&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="28" name="June 1666" tags="storyline 1666" position="1325,925" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
 &lt;&lt;if not _randomEventFired&gt;&gt;
-&lt;&lt;gate &quot;monthly&quot;&gt;&gt;
+
 The summer heat has hit London and everyone is feeling lethargic. Still, there are some things to do, like gossip with your neighbors. &lt;span id=&quot;decision&quot;&gt;Do you listen to the gossip? &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#decision&quot;&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jun 1666: Listened to the war gossip&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;
 
 You hear rumors that the &lt;&lt;defFleet &quot;fleet&quot;&gt;&gt; has engaged the Dutch in battle again and the streets are full of people arguing over whether the four days of rumbling was cannon fire or thunder. Yes, the hot weather could have led to four days of distant thunder but the skies are clear and &lt;&lt;defPressGangs &quot;press gangs&quot;&gt;&gt; roam the street, grabbing any man they can.
@@ -2489,14 +2465,14 @@ The sky has been rumbling for days and you wonder whether the sound was cannon f
 &lt;&lt;june-1666-helper&gt;&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 
-&lt;&lt;/gate&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="29" name="July 1666" tags="storyline 1666" position="1450,925" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
 &lt;&lt;if not _randomEventFired&gt;&gt;
-&lt;&lt;gate &quot;monthly&quot;&gt;&gt;The heat of the city is oppressive but the worst is not the heat but the wails of women whose husbands have been &lt;&lt;defImpressed &quot;impressed&quot;&gt;&gt; into the &lt;&lt;defFleet &quot;Fleet&quot;&gt;&gt;. Many of the men who have been impressed attempt to escape but are recaptured.
+The heat of the city is oppressive but the worst is not the heat but the wails of women whose husbands have been &lt;&lt;defImpressed &quot;impressed&quot;&gt;&gt; into the &lt;&lt;defFleet &quot;Fleet&quot;&gt;&gt;. Many of the men who have been impressed attempt to escape but are recaptured.
 
 Those who remain in the city hear the sounds of another battle in the distance--but any battle that is close enough for you can hear the cannon fire is too close. 
 &lt;br&gt;&lt;br&gt;
@@ -2511,25 +2487,25 @@ Those who remain in the city hear the sounds of another battle in the distance--
 &lt;&lt;/if&gt;&gt;
 &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/3/34/St._James_Day_Fight%2C_Pic_1.jpg&quot; height=&quot;708px&quot; width=&quot;900px&quot;&gt;
 //By unknown Dutch artist, &quot;Zee-Slag tussen de Engelse en Nederlandtse Vloot, op den 4 Aug. 1666.&quot; Engraving showing the St. James&#39; Day Battle on August 4th, 1666 between English and Dutch ships//
-&lt;&lt;/gate&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="30" name="August 1666" tags="storyline 1666" position="1075,1075" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
 &lt;&lt;if not _randomEventFired&gt;&gt;
-&lt;&lt;gate &quot;monthly&quot;&gt;&gt;As the summer heat engulfs the city, &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; numbers continue to rise. But at least there&#39;s good news on the war front, as you hear that the &lt;&lt;defFleet &quot;fleet&quot;&gt;&gt; has burnt more Dutch ships.
+As the summer heat engulfs the city, &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; numbers continue to rise. But at least there&#39;s good news on the war front, as you hear that the &lt;&lt;defFleet &quot;fleet&quot;&gt;&gt; has burnt more Dutch ships.
 &lt;br&gt;&lt;br&gt;
 &lt;span id=&quot;bonfire&quot;&gt;Your neighbors are celebrating the burning of the Dutch fleet with bonfires in the street. &lt;&lt;if $origin is &quot;the Dutch Republic&quot;&gt;&gt;You eye the crowds warily—the mood is fiercely anti-Dutch and you worry what might happen if someone recognizes your origins. &lt;&lt;/if&gt;&gt;Do you join the celebrations?
 &lt;br&gt;&lt;br&gt;
 &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#bonfire&quot;&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Aug 1666: Celebrated the burning of the Dutch fleet&quot;, money: 0, repDelta: 1, repBefore: $reputation - 1, infectPct: _riskPct})&gt;&gt;You throw yourself into the celebrations, cheering and dancing around the bonfires with your neighbors. The cannons fired in celebration from the Tower of London echo across the city. You hope the good news will be enough to tide you through the last hot month of the year, as [[September 1666]] dawns.&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#bonfire&quot;&gt;&gt;&lt;&lt;if $origin is &quot;the Dutch Republic&quot;&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Aug 1666: Avoided the Dutch fleet celebrations&quot;, money: 0, repDelta: -1, repBefore: $reputation + 1, infectPct: null})&gt;&gt;You stay indoors, unwilling to risk being caught up in the anti-Dutch fervor. Your absence is noted by your neighbors, who mutter about your loyalties.&lt;&lt;else&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Aug 1666: Avoided the Dutch fleet celebrations&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;You stay indoors, keeping to yourself while the celebrations rage outside.&lt;&lt;/if&gt;&gt; The cannons fired in celebration from the Tower of London echo across the city. You hope the good news will be enough to tide you through the last hot month of the year, as [[September 1666]] dawns.&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 
-&lt;&lt;/gate&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="31" name="September 1666" tags="fire storyline 1666" position="1200,1075" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
 &lt;&lt;if not _randomEventFired&gt;&gt;
-&lt;&lt;gate &quot;monthly&quot;&gt;&gt;&lt;&lt;if $location is &quot;inside the City walls&quot; or $fireParishes.includes($parish)&gt;&gt;
+&lt;&lt;if $location is &quot;inside the City walls&quot; or $fireParishes.includes($parish)&gt;&gt;
 Early one Sunday morning, you wake to the frantic ringing of church bells.  This isn&#39;t the ordinary &lt;&lt;defCallToService &quot;call to service&quot;&gt;&gt;—&lt;&lt;if $religion is &quot;member of the Church of England&quot;&gt;&gt;something you were looking forward to attending after you slept in&lt;&lt;else&gt;&gt;as if you&#39;d ever attend a service in the Church of England!&lt;&lt;/if&gt;&gt;—but rather a call to arms.  When you stumble outside, you discover the city has caught fire around you.
 
 &lt;&lt;if $agenum lte 15&gt;&gt;You immediately wake the nearest adult, who takes charge. You grab &lt;&lt;if $age is &quot;child&quot;&gt;&gt;your favorite toy&lt;&lt;else&gt;&gt;some of your clothes&lt;&lt;/if&gt;&gt;, then it&#39;s time to flee, with the fire nipping at your heels.  You will have nightmares about this moment for weeks.
@@ -2568,7 +2544,7 @@ You ask around and discover the fire began in the King&#39;s Baker&#39;s house o
 
 &lt;&lt;if $preFireLocation neq &quot;&quot;&gt;&gt;Everyone is still reeling from the shock of the Great Fire at the beginning of [[October 1666]].&lt;&lt;/if&gt;&gt; 
 
-&lt;&lt;/gate&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/b/b6/Great_Fire_London.jpg&quot; width=&quot;100%&quot;&gt;
 //Josepha Jane Battlehooke, The Great Fire of London, 1675//
 &lt;&lt;fumigant&gt;&gt;
@@ -2576,7 +2552,7 @@ You ask around and discover the fire began in the King&#39;s Baker&#39;s house o
 &lt;&lt;random-events&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
 &lt;&lt;if not _randomEventFired&gt;&gt;
-&lt;&lt;gate &quot;monthly&quot;&gt;&gt;&lt;&lt;if $preFireLocation neq &quot;&quot;&gt;&gt;
+&lt;&lt;if $preFireLocation neq &quot;&quot;&gt;&gt;
 &lt;&lt;if $socio is &quot;beggars&quot;&gt;&gt;You spend the next several weeks living in a field. The local &lt;&lt;defParish &quot;parish&quot;&gt;&gt; church serves food three times a day to keep you and the others from starving, but winter is coming and you know that you&#39;ll freeze to death if you don&#39;t manage to find permanent shelter before then. &lt;&lt;if $reputation lte 2&gt;&gt;Unfortunately, the first frost comes and you are still homeless because no one would take you in on account of your low reputation.  &lt;&lt;if $origin is not &quot;London&quot;&gt;&gt; Your only choices are to [[return to your home in $origin-&gt;go quietly]] or to &lt;&lt;else&gt;&gt;You &lt;&lt;/if&gt;&gt;pray you don&#39;t [[freeze]].
 &lt;&lt;else&gt;&gt;Luckily, just as the first frost hits the city, you manage to find a friend-of-a-friend who is willing to let you sleep on the floor until you can get more [[permanent lodgings-&gt;November 1666]].
 &lt;&lt;set $location to &quot;in the eastern suburbs&quot;&gt;&gt;&lt;&lt;set $parish to weightedEither($eParishes)&gt;&gt;&lt;&lt;generate-landlord-household&gt;&gt;
@@ -2595,13 +2571,13 @@ The weather may be miserable, but every disaster has a silver lining. Between th
 &lt;&lt;lodger-choice&gt;&gt;
 &lt;&lt;else&gt;&gt;You greatly look forward to [[November 1666]]&lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
-&lt;&lt;/gate&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="33" name="November 1666" tags="storyline 1666" position="1450,1075" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
 &lt;&lt;corpse-work&gt;&gt;
 &lt;&lt;if not _randomEventFired&gt;&gt;
-&lt;&lt;gate &quot;monthly&quot;&gt;&gt;One November day, the church bells peal out in alarm again--not from the destroyed part of the city within its ancient walls, but from the king&#39;s palace at &lt;&lt;defWhitehall &quot;Whitehall&quot;&gt;&gt;, especially the area around &lt;&lt;defHorseGuards &quot;Horse Guards&quot;&gt;&gt;. Everyone rushes to put out the fire at all costs, unwilling to have a repeat of September&#39;s disaster. Thankfully, no lives are lost.
+One November day, the church bells peal out in alarm again--not from the destroyed part of the city within its ancient walls, but from the king&#39;s palace at &lt;&lt;defWhitehall &quot;Whitehall&quot;&gt;&gt;, especially the area around &lt;&lt;defHorseGuards &quot;Horse Guards&quot;&gt;&gt;. Everyone rushes to put out the fire at all costs, unwilling to have a repeat of September&#39;s disaster. Thankfully, no lives are lost.
 
 Even better, the king declares the official thanksgiving day for the end of the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt;. Yes, some people are still dying, but the numbers are low enough and the epidemic has been going on long enough that most everyone is grateful for its official end.
 
@@ -2612,18 +2588,18 @@ Even better, the king declares the official thanksgiving day for the end of the 
 &lt;li&gt;&lt;&lt;storyline-return &quot;taking a day to enjoy the reopened theatres&quot; 1 _cost -1&gt;&gt;&lt;/li&gt;
 &lt;/ul&gt;
 
-&lt;&lt;/gate&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="34" name="December 1666" tags="storyline 1666" position="1600,1075" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;random-events&gt;&gt;
 &lt;&lt;if not _randomEventFired&gt;&gt;
-&lt;&lt;gate &quot;monthly&quot;&gt;&gt;
+
 As Advent begins, you look forward to actually being able to properly [[celebrate Christmas this year.
 
 Fires still &lt;&lt;defSmolder &quot;smolder&quot;&gt;&gt; in cellars throughout the city. Trouble is brewing in Scotland. The &lt;&lt;defGeneralBill &quot;general bill of this year&#39;s deaths&quot;&gt;&gt; show many &lt;&lt;defLamentable &quot;lamentable&quot;&gt;&gt; &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; deaths. But you have made it through 1666 and you thank God you are still alive!
 
 Congratulations. You have [[survived the Great Plague of London-&gt;stats]]
-&lt;&lt;/gate&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="35" name="master-death widget" tags="widget" position="150,725" size="100,100">&lt;&lt;widget &quot;servant-master-death&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
 &lt;&lt;if $socio is &quot;servants&quot;&gt;&gt;
 &lt;&lt;set _smdSingle to ($relationship is &quot;single&quot; or $relationship is &quot;betrothed&quot;)&gt;&gt;
@@ -2848,7 +2824,7 @@ You have no choice but to &lt;&lt;storyline-return &quot;accept your new role&qu
 &lt;&lt;corpse-work&gt;&gt;
 &lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;bill-subscribe&gt;&gt;
-&lt;&lt;gate &quot;monthly&quot;&gt;&gt;&lt;span id=&quot;plague-day-replace&quot;&gt;
+&lt;span id=&quot;plague-day-replace&quot;&gt;
 Despite the English &lt;&lt;defFleet &quot;fleet&#39;s&quot;&gt;&gt; victory, the war grinds on and rumors begin to circulate that the French are considering siding with the Dutch. &lt;&lt;if $origin is &quot;France&quot; or $origin is &quot;the Dutch Republic&quot;&gt;&gt;You make sure to talk loudly of your loyalty to the King and the superiority of the English fleet, whenever your neighbors mention the war.&lt;&lt;/if&gt;&gt;
 &lt;br&gt;&lt;br&gt;
 &lt;span id=&quot;decision&quot;&gt;Do you go looking for more information?
@@ -2863,7 +2839,7 @@ There aren&#39;t as many rumors as there might have been, given how many people 
 
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 &lt;&lt;fumigant&gt;&gt;
-&lt;&lt;/gate&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="39" name="FamPesthouse" tags="infection-rates" position="25,450" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;silently&gt;&gt;
 /* Check whether the authority figure is among the infected being sent away */
@@ -3944,9 +3920,7 @@ You must remain in &lt;&lt;defQuarantine &quot;quarantine&quot;&gt;&gt; for at l
     &lt;&lt;health-update&gt;&gt;
 &lt;&lt;/linkappend&gt;&gt;
 &lt;&lt;/if&gt;&gt;
-&lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="61" name="gating widgets" tags="widget" position="650,275" size="100,100">&lt;&lt;widget &quot;gate&quot; container&gt;&gt;&lt;&lt;nobr&gt;&gt;&lt;&lt;run setup.addGate(_args[0])&gt;&gt;&lt;span @id=&quot;&#39;gate-&#39; + _args[0]&quot; style=&quot;display:none&quot;&gt;_contents&lt;/span&gt;&lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;
-
-&lt;&lt;widget &quot;resolve-gate&quot;&gt;&gt;&lt;&lt;run setup.resolveGate()&gt;&gt;&lt;&lt;/widget&gt;&gt;
+&lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="61" name="gating widgets" tags="widget" position="650,275" size="100,100">
 </tw-passagedata><tw-passagedata pid="62" name="death widget" tags="widget" position="2300,575" size="100,100">&lt;&lt;widget &quot;death-announcement&quot;&gt;&gt;
 &lt;&lt;nobr&gt;&gt;
 &lt;&lt;if hasVisited(&quot;May 1666&quot;)&gt;&gt;
@@ -5362,7 +5336,7 @@ You and your fellow searcher&lt;&lt;if _cwCrew gt 2&gt;&gt;s&lt;&lt;/if&gt;&gt; 
 &lt;&lt;if $role is &quot;nurse&quot; and $corpsePlague and $corpsePlague[$parish]&gt;&gt;
 &lt;&lt;set _nwPlague to $corpsePlague[$parish][$monthIndex]&gt;&gt;
 &lt;&lt;if _nwPlague gt 0 and $playerPlagueStatus is &quot;healthy&quot; and random(1, 100) lte _nwPlague&gt;&gt;
-&lt;&lt;gate &quot;corpse&quot;&gt;&gt;&lt;span id=&quot;nurse-choice&quot;&gt;The parish officials bring you a new patient, sick with the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt;. Do you nurse them?&lt;br&gt;&lt;br&gt;
+&lt;span id=&quot;nurse-choice&quot;&gt;The parish officials bring you a new patient, sick with the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt;. Do you nurse them?&lt;br&gt;&lt;br&gt;
 &lt;&lt;link &quot;Do your Christian duty and nurse the sick&quot;&gt;&gt;&lt;&lt;replace &quot;#nurse-choice&quot;&gt;&gt;
 &lt;&lt;set _repBefore to $reputation&gt;&gt;
 &lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;
@@ -5375,12 +5349,12 @@ You tend to your patient as best you can. You were paid 48d. by the churchwarden
 &lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Nursed a plague patient (survived)&quot;, money: 48, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: 50})&gt;&gt;
 You tend to your patient as best you can. You were paid 48d. by the churchwardens for your service and your Christian charity does not go unnoticed. By the grace of God, you remain healthy.
 &lt;&lt;/if&gt;&gt;
-&lt;&lt;resolve-gate&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;Refuse to nurse the sick&quot;&gt;&gt;&lt;&lt;replace &quot;#nurse-choice&quot;&gt;&gt;
+&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;Refuse to nurse the sick&quot;&gt;&gt;&lt;&lt;replace &quot;#nurse-choice&quot;&gt;&gt;
 &lt;&lt;set _repBefore to $reputation&gt;&gt;
 &lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;
 &lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Refused to nurse a plague patient&quot;, money: 0, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: 0})&gt;&gt;
 You refuse the assignment. The parish officials are displeased — your reputation suffers.
-&lt;&lt;resolve-gate&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;&lt;br&gt;&lt;br&gt;&lt;&lt;/gate&gt;&gt;
+&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;&lt;br&gt;&lt;br&gt;
 &lt;&lt;elseif _nwPlague gt 0&gt;&gt;
 The parish has no patient for you to nurse this month.&lt;br&gt;&lt;br&gt;
 &lt;&lt;/if&gt;&gt;
@@ -5391,7 +5365,7 @@ The parish has no patient for you to nurse this month.&lt;br&gt;&lt;br&gt;
 &lt;&lt;if _wwPlague gt 0 and $playerPlagueStatus is &quot;healthy&quot; and random(1, 100) lte _wwPlague&gt;&gt;
 &lt;&lt;set _wwRate to $parishRate[$parish][$monthIndex]&gt;&gt;
 &lt;&lt;set _wwInfectPct to Math.round(100 / _wwRate)&gt;&gt;
-&lt;&lt;gate &quot;corpse&quot;&gt;&gt;&lt;span id=&quot;warder-choice&quot;&gt;A household in your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; has been shut up for the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt;. The churchwardens ask you to stand guard outside the door. Do you take the assignment?&lt;br&gt;&lt;br&gt;
+&lt;span id=&quot;warder-choice&quot;&gt;A household in your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; has been shut up for the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt;. The churchwardens ask you to stand guard outside the door. Do you take the assignment?&lt;br&gt;&lt;br&gt;
 &lt;&lt;link &quot;Stand guard outside the door&quot;&gt;&gt;&lt;&lt;replace &quot;#warder-choice&quot;&gt;&gt;
 &lt;&lt;set _repBefore to $reputation&gt;&gt;
 &lt;&lt;set $money += 48&gt;&gt;
@@ -5403,12 +5377,12 @@ You stand guard outside the marked door, listening to the weeping and prayers wi
 &lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Guarded a plague house (survived)&quot;, money: 48, repDelta: 0, repBefore: _repBefore, infectPct: _wwInfectPct})&gt;&gt;
 You stand guard outside the marked door, listening to the weeping and prayers within. You were paid 48d. by the churchwardens for your service. By the grace of God, you remain healthy.
 &lt;&lt;/if&gt;&gt;
-&lt;&lt;resolve-gate&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;Refuse the assignment&quot;&gt;&gt;&lt;&lt;replace &quot;#warder-choice&quot;&gt;&gt;
+&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;Refuse the assignment&quot;&gt;&gt;&lt;&lt;replace &quot;#warder-choice&quot;&gt;&gt;
 &lt;&lt;set _repBefore to $reputation&gt;&gt;
 &lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;
 &lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Refused to guard a plague house&quot;, money: 0, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: 0})&gt;&gt;
 You refuse the assignment. The churchwardens are displeased — your reputation suffers.
-&lt;&lt;resolve-gate&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;&lt;br&gt;&lt;br&gt;&lt;&lt;/gate&gt;&gt;
+&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;&lt;br&gt;&lt;br&gt;
 &lt;&lt;elseif _wwPlague gt 0&gt;&gt;
 To your relief, you are not called upon to guard any shut up houses this month.&lt;br&gt;&lt;br&gt;
 &lt;&lt;/if&gt;&gt;
@@ -5835,7 +5809,7 @@ Despite everything, court life proceeds as usual. A friend living the countrysid
 As an unmarried adult, you may wish to get married. Marriage brings with it lots of advantages, including a life partner, social connections through their family, (probably) children, and &lt;&lt;if $socio is &quot;nobles&quot; or $socio is &quot;merchants&quot;&gt;&gt;wealth from your &lt;&lt;if $gender is &quot;female&quot;&gt;&gt;husband&#39;s income&lt;&lt;else&gt;&gt;wife&#39;s dowry&lt;&lt;/if&gt;&gt;&lt;&lt;else&gt;&gt;additional income that will help protect you from &lt;&lt;if $socio is &quot;beggars&quot;&gt;&gt;starvation&lt;&lt;else&gt;&gt;poverty&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;.&lt;&lt;if $gender is &quot;female&quot;&gt;&gt; The downside is all your property will become your husband&#39;s and you will be legally dependent on him until he dies... or you do.&lt;&lt;/if&gt;&gt;
 &lt;br&gt;&lt;br&gt;
 &lt;span id=&quot;marriage&quot;&gt;Do you wish to seek a &lt;&lt;if $gender is &quot;female&quot;&gt;&gt;husband&lt;&lt;else&gt;&gt;wife&lt;&lt;/if&gt;&gt;? 
-&lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#marriage&quot;&gt;&gt;&lt;&lt;set $seeking to 1&gt;&gt;&lt;&lt;set $seekingDecision to 1&gt;&gt;&lt;&lt;storyline-return &quot;You are looking to be married soon and will be seeking out a spouse.&quot; 0&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#marriage&quot;&gt;&gt;&lt;&lt;set $seeking to 0&gt;&gt;&lt;&lt;set $seekingDecision to 1&gt;&gt;&lt;&lt;storyline-return &quot;You are content to remain single for now.&quot; 0&gt;&gt;
+&lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#marriage&quot;&gt;&gt;&lt;&lt;set $seekingMarriage to 1&gt;&gt;&lt;&lt;set $seekingDecision to 1&gt;&gt;&lt;&lt;storyline-return &quot;You are looking to be married soon and will be seeking out a spouse.&quot; 0&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#marriage&quot;&gt;&gt;&lt;&lt;set $seekingMarriage to 0&gt;&gt;&lt;&lt;set $seekingDecision to 1&gt;&gt;&lt;&lt;storyline-return &quot;You are content to remain single for now.&quot; 0&gt;&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;
 &lt;/span&gt;
 
@@ -5854,7 +5828,7 @@ Young people between the ages of 14 and 21 are eligible to be bound as apprentic
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="108" name="wedding" tags="widget" position="2375,300" size="100,100">&lt;&lt;widget &quot;wedding&quot;&gt;&gt;
 &lt;&lt;nobr&gt;&gt;
-You have found a &lt;&lt;if $gender is &quot;female&quot;&gt;&gt;husband&lt;&lt;elseif $gender is &quot;male&quot;&gt;&gt;wife&lt;&lt;else&gt;&gt;spouse&lt;&lt;/if&gt;&gt;! &lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;unset $seeking&gt;&gt;&lt;&lt;unset $wedding&gt;&gt;
+You have found a &lt;&lt;if $gender is &quot;female&quot;&gt;&gt;husband&lt;&lt;elseif $gender is &quot;male&quot;&gt;&gt;wife&lt;&lt;else&gt;&gt;spouse&lt;&lt;/if&gt;&gt;! &lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;unset $seekingMarriage&gt;&gt;&lt;&lt;unset $wedding&gt;&gt;
 
 &lt;span id=&quot;format&quot;&gt;Do you want to 
 &lt;ul&gt;
@@ -6234,7 +6208,7 @@ You quickly baptize them&lt;&lt;set $money -=6&gt;&gt; and pray to God that $NPC
 		&lt;&lt;elderly&gt;&gt;
 	&lt;&lt;elseif $seekingApprenticeship is 1 and $apprenticeshipOffer is 1&gt;&gt;
 		&lt;&lt;apprenticeship-offer&gt;&gt;
-	&lt;&lt;elseif $seeking is 1 and $wedding is 1&gt;&gt;
+	&lt;&lt;elseif $seekingMarriage is 1 and $wedding is 1&gt;&gt;
 		&lt;&lt;wedding&gt;&gt;
 	&lt;&lt;elseif $pregnant is 4&gt;&gt; /* Pregnancy and Marriage */
 		&lt;&lt;pregnant&gt;&gt;
@@ -6832,22 +6806,22 @@ The &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; grows worse and the streets are
 You return to the Church of England services this month. You cannot afford to pay the fine for skipping while in debt. Your previous commitment to always skip services no longer applies, but once you are no longer in debt, you can re-commit to always skipping Church of England services.&lt;br&gt;&lt;br&gt;
 /* Offer choice if not in debt */
 &lt;&lt;elseif $money gte 0&gt;&gt;
-&lt;&lt;gate &quot;church&quot;&gt;&gt;&lt;span id=&quot;churchChoice&quot;&gt;As a $religion, do you want to attend services at your parish Church of England this month?&lt;br&gt;&lt;br&gt;
+&lt;span id=&quot;churchChoice&quot;&gt;As a $religion, do you want to attend services at your parish Church of England this month?&lt;br&gt;&lt;br&gt;
 &lt;&lt;link &quot;Always avoid Church of England services&quot;&gt;&gt;&lt;&lt;replace &quot;#churchChoice&quot;&gt;&gt;
 &lt;&lt;set _repLoss to 0&gt;&gt;&lt;&lt;if $churchSkipRepPenalty is 0&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;&lt;&lt;set $churchSkipRepPenalty to 1&gt;&gt;&lt;&lt;set _repLoss to -1&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Skipped Church of England services (fined 48d.)&quot;, money: -48, repDelta: _repLoss, repBefore: $reputation, infectPct: null})&gt;&gt;
 &lt;&lt;set $skipServices to 1&gt;&gt;
 &lt;&lt;set $money to Math.clamp($money - 48, -Infinity, Infinity)&gt;&gt;
 You resolve to stop attending services at the Church of England. You are fined 48d. for non-attendance&lt;&lt;if _repLoss is -1&gt;&gt; and your reputation suffers&lt;&lt;/if&gt;&gt;.&lt;&lt;if $role is &quot;searcher&quot; or $role is &quot;nurse&quot; or $role is &quot;corpsebearer&quot; or $role is &quot;warder&quot;&gt;&gt;&lt;&lt;set $role to &quot;0&quot;&gt;&gt; As you are no longer attending Church of England services, the parish has removed you from your plague work duties.&lt;&lt;/if&gt;&gt;&lt;br&gt;&lt;br&gt;
-&lt;&lt;resolve-gate&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;Skip Church of England services this month&quot;&gt;&gt;&lt;&lt;replace &quot;#churchChoice&quot;&gt;&gt;
+&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;Skip Church of England services this month&quot;&gt;&gt;&lt;&lt;replace &quot;#churchChoice&quot;&gt;&gt;
 &lt;&lt;set _repLoss to 0&gt;&gt;&lt;&lt;if $churchSkipRepPenalty is 0&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;&lt;&lt;set $churchSkipRepPenalty to 1&gt;&gt;&lt;&lt;set _repLoss to -1&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Skipped Church of England services (fined 48d.)&quot;, money: -48, repDelta: _repLoss, repBefore: $reputation, infectPct: null})&gt;&gt;
 &lt;&lt;set $money to Math.clamp($money - 48, -Infinity, Infinity)&gt;&gt;
 You skip services at your parish church this month and are fined 48d. for non-attendance.&lt;&lt;if _repLoss is -1&gt;&gt; Your reputation suffers.&lt;&lt;/if&gt;&gt;&lt;br&gt;&lt;br&gt;
-&lt;&lt;resolve-gate&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;Attend services&quot;&gt;&gt;&lt;&lt;replace &quot;#churchChoice&quot;&gt;&gt;
+&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;Attend services&quot;&gt;&gt;&lt;&lt;replace &quot;#churchChoice&quot;&gt;&gt;
 &lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Attended parish church services&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;
 You attend services at your parish church, though it goes against your beliefs as a $religion.&lt;br&gt;&lt;br&gt;
-&lt;&lt;resolve-gate&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;&lt;&lt;/gate&gt;&gt;
+&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="116" name="Flight" tags="" position="700,875" size="100,100">&lt;&lt;nobr&gt;&gt;
@@ -6899,9 +6873,9 @@ Your &lt;&lt;for _rc, _ri range _flightSafeKids&gt;&gt;&lt;&lt;if _flightSafeKid
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="117" name="$args[0" tags="" position="1625,275" size="100,100"></tw-passagedata><tw-passagedata pid="118" name="bom widget" tags="widget" position="150,1225" size="100,100">&lt;&lt;widget &quot;bill-subscribe&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
 &lt;&lt;if $billSubscribed is 0&gt;&gt;
-&lt;&lt;gate &quot;bill&quot;&gt;&gt;&lt;span id=&quot;billOffer&quot;&gt;With plague cases on the rise, you consider purchasing a subscription to the weekly &lt;&lt;defBillsOfMortality &quot;Bills of Mortality&quot;&gt;&gt;. It only costs 4d. per month and you will no longer be reliant upon rumor to know how many people are dying in your parish and in the city - of plague or anything else. Do you wish to subscribe?
+&lt;span id=&quot;billOffer&quot;&gt;With plague cases on the rise, you consider purchasing a subscription to the weekly &lt;&lt;defBillsOfMortality &quot;Bills of Mortality&quot;&gt;&gt;. It only costs 4d. per month and you will no longer be reliant upon rumor to know how many people are dying in your parish and in the city - of plague or anything else. Do you wish to subscribe?
 &lt;br&gt;&lt;br&gt;
-&lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#billOffer&quot;&gt;&gt;&lt;&lt;set $billSubscribed to 1&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;May 1665: Subscribed to the Bills of Mortality&quot;, money: -4, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;Each week you will receive a broadside report of the christenings, burials, and plague burials in $parish and across the city. You hope it will help you navigate the risks of the current oubreak.&lt;br&gt;&lt;br&gt;&lt;&lt;resolve-gate&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#billOffer&quot;&gt;&gt;&lt;&lt;set $billSubscribed to 2&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;May 1665: Declined Bills of Mortality subscription&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;Spending that much money doesn&#39;t make sense to you, when you can ask your parish clerk for the numbers or simply look around see how many houses have been shut up on your street to know the current risks.&lt;br&gt;&lt;br&gt;&lt;&lt;resolve-gate&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;&lt;&lt;/gate&gt;&gt;
+&lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#billOffer&quot;&gt;&gt;&lt;&lt;set $billSubscribed to 1&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;May 1665: Subscribed to the Bills of Mortality&quot;, money: -4, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;Each week you will receive a broadside report of the christenings, burials, and plague burials in $parish and across the city. You hope it will help you navigate the risks of the current oubreak.&lt;br&gt;&lt;br&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#billOffer&quot;&gt;&gt;&lt;&lt;set $billSubscribed to 2&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;May 1665: Declined Bills of Mortality subscription&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;Spending that much money doesn&#39;t make sense to you, when you can ask your parish clerk for the numbers or simply look around see how many houses have been shut up on your street to know the current risks.&lt;br&gt;&lt;br&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="119" name="child-smuggling widgets" tags="widget" position="150,575" size="100,100">&lt;&lt;widget &quot;smuggle-children&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
 /* Offer to smuggle healthy children/infants out of a shut-up house. Requires reputation gte 6 and player must be a parent (hoh 1 or 4). */

--- a/variables.md
+++ b/variables.md
@@ -475,17 +475,25 @@ This document lists all global (story) variables used in **Gaming the Great Plag
 - **Used for:** Holds a small random pence amount that is immediately added to `$money` and then `<<unset>>`. It is a display variable only (shown in the passage text as the amount earned/saved) and is never checked in a conditional.
 - **Dependency:** Only set when `$socio is "beggars"` and the player takes a begging or charity action.
 
-### `$seeking`
+### `$seekingMarriage`
 - **Type:** Integer (boolean-like)
 - **Possible values:** `0` (not seeking), `1` (seeking a spouse)
+- **Set by:** Set to `1` or `0` by `marriage-market` widget (pid 107) when the player chooses whether to seek a spouse; `<<unset>>` by `wedding` widget (pid 108) when the player marries
 - **Used for:** Whether the player is actively looking for a marriage partner
-- **Dependency:** Interacts with `$wedding`
+- **Dependency:** Interacts with `$wedding` and `$seekingDecision`
+
+### `$seekingDecision`
+- **Type:** Integer
+- **Possible values:** `0` (no decision yet), `1` (marriage decision made), `2` (apprenticeship decision made)
+- **Set by:** `0` in StoryInit; set to `1` by `marriage-market` widget (pid 107) when the player makes a marriage decision; set to `2` by `apprenticeship-market` widget (pid 107) when the player makes an apprenticeship decision
+- **Used for:** Tracks whether the player has already been presented with the marriage or apprenticeship choice, preventing the question from being asked again. Value `2` also gates out the marriage-market widget for characters who chose the apprenticeship path.
+- **Dependency:** Checked in January 1665 (pid 9) to determine which widget to show
 
 ### `$seekingApprenticeship`
 - **Type:** Integer (boolean-like)
 - **Possible values:** `0` (not seeking), `1` (seeking an apprenticeship)
 - **Set by:** `0` in StoryInit; set to `1` by `apprenticeship-market` widget when the player chooses to seek an apprenticeship; set to `0` when an apprenticeship is accepted via `apprenticeship-offer`
-- **Used for:** Whether the player is actively looking for an apprenticeship. Mutually exclusive with `$seeking` — characters eligible for apprenticeship (single, artisan/merchant, agenum 14–21) are routed to `apprenticeship-market` instead of `marriage-market`.
+- **Used for:** Whether the player is actively looking for an apprenticeship. Mutually exclusive with `$seekingMarriage` — characters eligible for apprenticeship (single, artisan/merchant, agenum 14–21) are routed to `apprenticeship-market` instead of `marriage-market`.
 - **Dependency:** Interacts with `$apprenticeshipOffer`
 
 ### `$apprenticeship`
@@ -529,7 +537,7 @@ This document lists all global (story) variables used in **Gaming the Great Plag
 - **Type:** Integer (random event roll)
 - **Set by:** `random(1, 10)`
 - **Trigger:** `$wedding is 1` (10% chance) triggers a wedding event
-- **Dependency:** Interacts with `$seeking`
+- **Dependency:** Interacts with `$seekingMarriage`
 
 ### `$elderly`
 - **Type:** Integer (random event roll)


### PR DESCRIPTION
…v3.16

- Remove gate/resolve-gate widget definitions (pid 061) and gate queue JavaScript from StoryInit (pid 010)
- Strip <<gate>>, <</gate>>, and <<resolve-gate>> calls from all 29 passages that used them (monthly passages, corpse-work, church attendance, and Bills of Mortality widgets)
- Rename $seeking to $seekingMarriage in pids 009, 107, 108, 113
- Add $seekingDecision documentation to variables.md and update all references from $seeking to $seekingMarriage

https://claude.ai/code/session_016MATFN9ZtR74uz4b4LsszJ