### PR TITLE
Return players to storyline after random events; combine funeral choi…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v3.16" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v3.17" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -1707,6 +1707,7 @@ When you go to church on Easter Sunday, you are reminded of how lucky you are as
 &lt;&lt;set $SavedNPCs to []&gt;&gt;
 &lt;&lt;set $SavedServants to []&gt;&gt;
 &lt;&lt;set $seekingDecision to 0&gt;&gt;
+&lt;&lt;set $randomEventCompleted to false&gt;&gt;
 &lt;&lt;set $FledFamily = []&gt;&gt;
 &lt;&lt;set $fled to 0&gt;&gt;
 &lt;&lt;set $getaway = []&gt;&gt;
@@ -1807,8 +1808,43 @@ On Christmas Eve, you see a comet in the sky and you wonder if it is [[a sign of
 //Great Comet of 1665//
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;&lt;&lt;/linkappend&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="13" name="NPC-funeral widget" tags="widget" position="275,725" size="100,100">&lt;&lt;widget &quot;funeral-choice&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
-&lt;&lt;set _funeralId to (_funeralId || 0) + 1&gt;&gt;&lt;&lt;set _fNPC to $args[0]&gt;&gt;&lt;&lt;set _fName to _fNPC.name&gt;&gt;&lt;&lt;set _npcDeathOccurred to true&gt;&gt;&lt;&lt;set _fNPC.funeralDone to true&gt;&gt;Do you give _fName &lt;span @id=&quot;&#39;funeral-&#39; + _funeralId&quot;&gt;&lt;&lt;capture _funeralId, _fNPC, _fName&gt;&gt;&lt;&lt;link &quot;a quick burial&quot;&gt;&gt;&lt;&lt;replace `&#39;#funeral-&#39; + _funeralId`&gt;&gt;&lt;&lt;set $money -= 9&gt;&gt;&lt;&lt;set _fNPC.funeralDone to true&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Quick burial for &quot; + _fName, money: -9, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;a quick burial.&lt;&lt;storyline-return&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;a proper funeral&quot;&gt;&gt;&lt;&lt;replace `&#39;#funeral-&#39; + _funeralId`&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round((10000 / _rate) + 200) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if random(1, 50) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set _fNPC.funeralDone to true&gt;&gt;&lt;&lt;if $socio is &quot;nobles&quot;&gt;&gt;&lt;&lt;set $money -= 4800&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Proper funeral for &quot; + _fName, money: -4800, repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;&lt;&lt;elseif $socio is &quot;merchants&quot;&gt;&gt;&lt;&lt;set $money -= 960&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Proper funeral for &quot; + _fName, money: -960, repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;&lt;&lt;elseif $socio is &quot;artisans&quot;&gt;&gt;&lt;&lt;set $money -= 240&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Proper funeral for &quot; + _fName, money: -240, repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $money -= 12&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Proper funeral for &quot; + _fName, money: -12, repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;&lt;&lt;/if&gt;&gt;a proper funeral.&lt;&lt;storyline-return&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;&lt;/capture&gt;&gt;&lt;/span&gt;&lt;br&gt;
-&lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="14" name="char-gen-widgets" tags="widget" position="1075,25" size="100,100">&lt;&lt;widget &quot;setAge&quot;&gt;&gt;
+/* Expects _deadNPCs: array of {npc, label} objects where label is e.g. &quot;your daughter&quot; or &quot;your servant&quot; */
+&lt;&lt;if _deadNPCs.length gt 0&gt;&gt;
+&lt;&lt;set _npcDeathOccurred to true&gt;&gt;
+
+/* Build a readable list of the dead */
+&lt;&lt;set _deathList to &quot;&quot;&gt;&gt;
+&lt;&lt;for _fi = 0; _fi lt _deadNPCs.length; _fi++&gt;&gt;
+	&lt;&lt;if _fi gt 0 and _deadNPCs.length gt 2&gt;&gt;, &lt;&lt;/if&gt;&gt;
+	&lt;&lt;if _fi gt 0 and _fi is _deadNPCs.length - 1&gt;&gt; and &lt;&lt;/if&gt;&gt;
+	&lt;&lt;set _deathList to _deathList + _deadNPCs[_fi].label + &quot; &quot; + _deadNPCs[_fi].npc.name&gt;&gt;
+&lt;&lt;/for&gt;&gt;
+
+/* Calculate proper funeral cost based on socio */
+&lt;&lt;if $socio is &quot;nobles&quot;&gt;&gt;&lt;&lt;set _funeralCost to 4800&gt;&gt;
+&lt;&lt;elseif $socio is &quot;merchants&quot;&gt;&gt;&lt;&lt;set _funeralCost to 960&gt;&gt;
+&lt;&lt;elseif $socio is &quot;artisans&quot;&gt;&gt;&lt;&lt;set _funeralCost to 240&gt;&gt;
+&lt;&lt;else&gt;&gt;&lt;&lt;set _funeralCost to 12&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;set _funeralCost to _funeralCost * _deadNPCs.length&gt;&gt;
+&lt;&lt;set _burialCost to 9 * _deadNPCs.length&gt;&gt;
+
+&lt;span id=&quot;funeral-combined&quot;&gt;Do you give &lt;&lt;print _deathList&gt;&gt;
+&lt;&lt;link &quot;a quick burial&quot;&gt;&gt;&lt;&lt;replace &quot;#funeral-combined&quot;&gt;&gt;
+&lt;&lt;set $money -= _burialCost&gt;&gt;
+&lt;&lt;for _fi = 0; _fi lt _deadNPCs.length; _fi++&gt;&gt;&lt;&lt;set _deadNPCs[_fi].npc.funeralDone to true&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Quick burial for &quot; + _deadNPCs[_fi].npc.name, money: -9, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;/for&gt;&gt;
+a quick burial.&lt;&lt;storyline-return &quot;Continue.&quot; 0&gt;&gt;
+&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;a proper funeral&quot;&gt;&gt;&lt;&lt;replace &quot;#funeral-combined&quot;&gt;&gt;
+&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round((10000 / _rate) + 200) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if random(1, 50) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;set $money -= _funeralCost&gt;&gt;
+&lt;&lt;set _perCost to Math.round(_funeralCost / _deadNPCs.length)&gt;&gt;
+&lt;&lt;for _fi = 0; _fi lt _deadNPCs.length; _fi++&gt;&gt;&lt;&lt;set _deadNPCs[_fi].npc.funeralDone to true&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Proper funeral for &quot; + _deadNPCs[_fi].npc.name, money: -_perCost, repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;&lt;&lt;/for&gt;&gt;
+a proper funeral.&lt;&lt;storyline-return &quot;Continue.&quot; 0&gt;&gt;
+&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;
+&lt;/span&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;
+</tw-passagedata><tw-passagedata pid="14" name="char-gen-widgets" tags="widget" position="1075,25" size="100,100">&lt;&lt;widget &quot;setAge&quot;&gt;&gt;
 &lt;&lt;nobr&gt;&gt;
     &lt;&lt;if $minAge lte 0&gt;&gt;
         &lt;&lt;set $minAge to 0&gt;&gt;
@@ -3283,6 +3319,9 @@ As morning dawns, a terrible realization settles over your &lt;&lt;defHousehold 
 		&lt;&lt;if random(1, 100) lte _plagueRisk&gt;&gt;
 			&lt;&lt;set $plagueInfection to 1&gt;&gt;
 		&lt;&lt;/if&gt;&gt;
+	&lt;&lt;/if&gt;&gt;
+	&lt;&lt;if _timeOffset is 0&gt;&gt;
+		&lt;&lt;set $randomEventCompleted to true&gt;&gt;
 	&lt;&lt;/if&gt;&gt;
     &lt;&lt;/link&gt;&gt;
     &lt;&lt;/nobr&gt;&gt;
@@ -5422,11 +5461,11 @@ The Bills of Mortality report no burials in $parish this month.
 &lt;&lt;set _repBefore to $reputation&gt;&gt;
 &lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Promoted from servant to apprentice by &quot; + $masterTitle, money: 0, repDelta: 0, repBefore: _repBefore, infectPct: null})&gt;&gt;
 Your $masterTitle formally takes you on as &lt;&lt;if $masterGender is &quot;female&quot;&gt;&gt;her&lt;&lt;else&gt;&gt;his&lt;&lt;/if&gt;&gt; apprentice. You will continue to live in &lt;&lt;if $masterGender is &quot;female&quot;&gt;&gt;her&lt;&lt;else&gt;&gt;his&lt;&lt;/if&gt;&gt; household, but now you are learning a trade rather than merely serving. It is a remarkable opportunity, earned by your hard work and good reputation.&lt;br&gt;&lt;br&gt;
-&lt;&lt;storyline-return&gt;&gt;
+&lt;&lt;storyline-return &quot;Continue.&quot; 0&gt;&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No, remain a servant&quot;&gt;&gt;&lt;&lt;replace &quot;#promoteServant&quot;&gt;&gt;
 &lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Declined apprenticeship offer from &quot; + $masterTitle, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;
 You decline your $masterTitle&#39;s generous offer and continue in your current role as a servant.&lt;br&gt;&lt;br&gt;
-&lt;&lt;storyline-return&gt;&gt;
+&lt;&lt;storyline-return &quot;Continue.&quot; 0&gt;&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;
 &lt;/span&gt;
 &lt;&lt;/if&gt;&gt;
@@ -5480,7 +5519,7 @@ One thing is for certain, though. The weather is so hot that &lt;&lt;defPlague &
 &lt;br&gt;&lt;br&gt;Unfortunately you have suffered from a fatal accident &lt;&lt;if $socio is &quot;day labourers&quot;&gt;&gt;while out on a job&lt;&lt;/if&gt;&gt;. &lt;&lt;set $death to random(1,5)&gt;&gt;&lt;&lt;if $death is 1&gt;&gt;You drowned in &lt;&lt;if $socio is &quot;day labourers&quot;&gt;&gt;a brewer&#39;s mash&lt;&lt;else&gt;&gt;a well&lt;&lt;/if&gt;&gt;. &lt;&lt;elseif $death is 2&gt;&gt;You were bitten by a dog. &lt;&lt;elseif $death is 3&gt;&gt;You fell from &lt;&lt;if $socio is &quot;day labourers&quot;&gt;&gt;scaffolding&lt;&lt;else&gt;&gt;a window&lt;&lt;/if&gt;&gt;. &lt;&lt;elseif $death is 4&gt;&gt;You were run over by a cart. &lt;&lt;else&gt;&gt;You fell down a flight of stairs.&lt;&lt;/if&gt;&gt;&lt;br&gt;&lt;br&gt;At least you didn&#39;t die of the plague.&lt;br&gt;&lt;br&gt;
 &lt;&lt;death-announcement&gt;&gt;
 &lt;&lt;else&gt;&gt;
-You have suffered an accident while&lt;&lt;if $socio is &quot;day labourers&quot;&gt;&gt;out on a job&lt;&lt;else&gt;&gt;running errands&lt;&lt;/if&gt;&gt;, but thanks to God you are still alive. &lt;&lt;set $accident to random (1,5)&gt;&gt;&lt;&lt;if $accident is 1&gt;&gt;You fell from a window. &lt;&lt;elseif $accident is 2&gt;&gt;You were kicked by a horse. &lt;&lt;elseif $accident is 3&gt;&gt;You broke your arm. &lt;&lt;elseif $accident is 4&gt;&gt;You were hit by a wagon wheel. &lt;&lt;else&gt;&gt;You fell in the Thames and a cut on your arm was infected. &lt;&lt;/if&gt;&gt; Fortunately, this is something you can recover from with rest and care. &lt;&lt;if $reputation lte 2&gt;&gt;Unfortunately your reputation is too low for anyone to offer you assistance so you must recover on your own and &lt;&lt;else&gt;&gt;Your &lt;&lt;if $NPCs.length gt 0&gt;&gt;family&lt;&lt;else&gt;&gt;neighbors&lt;&lt;/if&gt;&gt; take good care of you, but &lt;&lt;/if&gt;&gt;you lose money every day you aren&#39;t working.&lt;&lt;set $money -=3&gt;&gt;&lt;br&gt;&lt;br&gt;Soon you are ready to rejoin &lt;&lt;if $socio is &quot;day labourers&quot;&gt;&gt;the other &lt;&lt;defDayLabourer &quot;day labourers&quot;&gt;&gt; in their search for work. &lt;&lt;storyline-return&gt;&gt;&lt;&lt;else&gt;&gt;your &lt;&lt;print $masterTitle || &quot;master&quot;&gt;&gt;&#39;s household. &lt;&lt;storyline-return&gt;&gt;&lt;&lt;/if&gt;&gt;
+You have suffered an accident while&lt;&lt;if $socio is &quot;day labourers&quot;&gt;&gt;out on a job&lt;&lt;else&gt;&gt;running errands&lt;&lt;/if&gt;&gt;, but thanks to God you are still alive. &lt;&lt;set $accident to random (1,5)&gt;&gt;&lt;&lt;if $accident is 1&gt;&gt;You fell from a window. &lt;&lt;elseif $accident is 2&gt;&gt;You were kicked by a horse. &lt;&lt;elseif $accident is 3&gt;&gt;You broke your arm. &lt;&lt;elseif $accident is 4&gt;&gt;You were hit by a wagon wheel. &lt;&lt;else&gt;&gt;You fell in the Thames and a cut on your arm was infected. &lt;&lt;/if&gt;&gt; Fortunately, this is something you can recover from with rest and care. &lt;&lt;if $reputation lte 2&gt;&gt;Unfortunately your reputation is too low for anyone to offer you assistance so you must recover on your own and &lt;&lt;else&gt;&gt;Your &lt;&lt;if $NPCs.length gt 0&gt;&gt;family&lt;&lt;else&gt;&gt;neighbors&lt;&lt;/if&gt;&gt; take good care of you, but &lt;&lt;/if&gt;&gt;you lose money every day you aren&#39;t working.&lt;&lt;set $money -=3&gt;&gt;&lt;br&gt;&lt;br&gt;Soon you are ready to rejoin &lt;&lt;if $socio is &quot;day labourers&quot;&gt;&gt;the other &lt;&lt;defDayLabourer &quot;day labourers&quot;&gt;&gt; in their search for work. &lt;&lt;storyline-return &quot;Continue.&quot; 0&gt;&gt;&lt;&lt;else&gt;&gt;your &lt;&lt;print $masterTitle || &quot;master&quot;&gt;&gt;&#39;s household. &lt;&lt;storyline-return &quot;Continue.&quot; 0&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="98" name="legacy non-binary code" tags="" position="2150,1350" size="100,100">/* from bio but have changed how names are assigned since then */
@@ -5534,9 +5573,9 @@ At least you didn&#39;t die of plague.&lt;br&gt;&lt;br&gt;
         Unfortunately, there are dangers even outside the city walls. As you walk out to get a closer look at the conflagration, you are run over by a cart fleeing the flames and suffer a serious injury.
         &lt;&lt;/if&gt;&gt;
 &lt;br&gt;&lt;br&gt;
- You thank God that you have survived his wrath! &lt;&lt;if $reputation lte 2&gt;&gt;&lt;&lt;set $money -=1&gt;&gt; Unfortunately, your reputation is so low that your neighbors take no more pity on you and you earn very few spare coins while you recover. &lt;&lt;storyline-return&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $money +=2&gt;&gt;Fortunately, your reputation is so high among your neighbors that the sight of you after your injury invokes great pity (and a few extra coins). Nevertheless, you are glad that you will soon heal. &lt;&lt;storyline-return&gt;&gt;&lt;&lt;/if&gt;&gt;
+ You thank God that you have survived his wrath! &lt;&lt;if $reputation lte 2&gt;&gt;&lt;&lt;set $money -=1&gt;&gt; Unfortunately, your reputation is so low that your neighbors take no more pity on you and you earn very few spare coins while you recover. &lt;&lt;storyline-return &quot;Continue.&quot; 0&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $money +=2&gt;&gt;Fortunately, your reputation is so high among your neighbors that the sight of you after your injury invokes great pity (and a few extra coins). Nevertheless, you are glad that you will soon heal. &lt;&lt;storyline-return &quot;Continue.&quot; 0&gt;&gt;&lt;&lt;/if&gt;&gt;
     &lt;&lt;else&gt;&gt;
-    Alack! Begging in the streets in a city as bustling as London comes with its dangers. You have been run over by a cart and suffered a serious injury. &lt;&lt;if $reputation lte 2&gt;&gt;Unfortunately, your reputation is so low that your neighbors take no more pity on you and you earn very few spare coins while you recover. &lt;&lt;set $money -=1&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $money +=2&gt;&gt;Fortunately, your reputation is so high among your neighbors that the sight of you after your injury invokes great pity (and a few extra coins). Nevertheless, you are glad that you will soon heal.&lt;&lt;/if&gt;&gt; You hear that in some areas of the city they are installing a new innovation–the sidewalk–which will help to keep people off the street and prevent more accidents like yours. &lt;&lt;storyline-return&gt;&gt;   
+    Alack! Begging in the streets in a city as bustling as London comes with its dangers. You have been run over by a cart and suffered a serious injury. &lt;&lt;if $reputation lte 2&gt;&gt;Unfortunately, your reputation is so low that your neighbors take no more pity on you and you earn very few spare coins while you recover. &lt;&lt;set $money -=1&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $money +=2&gt;&gt;Fortunately, your reputation is so high among your neighbors that the sight of you after your injury invokes great pity (and a few extra coins). Nevertheless, you are glad that you will soon heal.&lt;&lt;/if&gt;&gt; You hear that in some areas of the city they are installing a new innovation–the sidewalk–which will help to keep people off the street and prevent more accidents like yours. &lt;&lt;storyline-return &quot;Continue.&quot; 0&gt;&gt;   
     &lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;
@@ -5547,7 +5586,7 @@ At least you didn&#39;t die of plague.&lt;br&gt;&lt;br&gt;
 &lt;&lt;else&gt;&gt;
 &lt;&lt;set $money -=2&gt;&gt;Alack! You have come down with a mysterious fever.&lt;&lt;if $reputation gte 3&gt;&gt; Your reputation is high enough that your friends and family take diligent care of you in your sickness and&lt;&lt;else&gt;&gt; Your reputation is so low that no one lends you aid in your sickness but&lt;&lt;/if&gt;&gt; you slowly recover.
 &lt;br&gt;&lt;br&gt;
-&lt;&lt;storyline-return&gt;&gt;
+&lt;&lt;storyline-return &quot;Continue.&quot; 0&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="102" name="navy-volunteer" tags="" position="2250,1125" size="100,100">&lt;&lt;nobr&gt;&gt;
@@ -5596,10 +5635,10 @@ Because of your poor reputation, the vestry of $parish decided to remove you fro
 &lt;&lt;set $office to _officeType&gt;&gt;
 &lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;
 You accept the position of &lt;&lt;print _officeType&gt;&gt; in $parish and the responsibilities to your parish that come with it.&lt;br&gt;&lt;br&gt;
-&lt;&lt;storyline-return&gt;&gt;
+&lt;&lt;storyline-return &quot;Continue.&quot; 0&gt;&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#officeChoice&quot;&gt;&gt;
 You don&#39;t want the hassle of holding office in your parish and pay a fine to avoid serving.&lt;&lt;set $money -=24&gt;&gt;&lt;br&gt;&lt;br&gt;
-&lt;&lt;storyline-return&gt;&gt;
+&lt;&lt;storyline-return &quot;Continue.&quot; 0&gt;&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
@@ -5766,7 +5805,7 @@ You don&#39;t want the hassle of holding office in your parish and pay a fine to
 &lt;&lt;nobr&gt;&gt;
 Despite everything, you &lt;&lt;if $socio is &quot;day labourers&quot;&gt;&gt;keep finding opportunities for work&lt;&lt;else&gt;&gt;know you are lucky to be steadily employed as a servant&lt;&lt;/if&gt;&gt;. A friend from the countryside writes to you&lt;&lt;if $agenum lte 15&gt;&gt;r family&lt;&lt;/if&gt;&gt; and asks if you will take in their child so they can also seek work in London. 
 &lt;br&gt;&lt;br&gt;
-&lt;span id=&quot;worker&quot;&gt;Do you want to accept them into your home? &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#worker&quot;&gt;&gt;&lt;&lt;addWorkerKidNPC&gt;&gt;&lt;&lt;set $worker to 0&gt;&gt;&lt;&lt;if $hoh is 4&gt;&gt;You convince your husband to accept them into your home.&lt;&lt;elseif $hoh is 3 or ($hoh is 0 and $socio is &quot;servants&quot;)&gt;&gt;You convince your $masterTitle to accept them into your home.&lt;&lt;elseif $hoh isnot 1&gt;&gt;You convince your family to accept them into your home.&lt;&lt;else&gt;&gt;You accept them into your home.&lt;&lt;/if&gt;&gt; It&#39;s another mouth to feed, but you are glad to &lt;&lt;storyline-return &quot;do a friend a favor.&quot; 1 -48 1&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#worker&quot;&gt;&gt;&lt;&lt;if $hoh is 4&gt;&gt;You convince your husband not to accept them into your home.&lt;&lt;elseif $hoh is 3 or ($hoh is 0 and $socio is &quot;servants&quot;)&gt;&gt;You convince your $masterTitle not to accept them into your home.&lt;&lt;elseif $hoh isnot 1&gt;&gt;You convince your family not to accept them into your home.&lt;&lt;else&gt;&gt;You don&#39;t accept them into your home.&lt;&lt;/if&gt;&gt; Things are too hard right now. You can&#39;t afford another mouth to feed and you don&#39;t have the time to teach someone else the lay of the city.&lt;&lt;storyline-return&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
+&lt;span id=&quot;worker&quot;&gt;Do you want to accept them into your home? &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#worker&quot;&gt;&gt;&lt;&lt;addWorkerKidNPC&gt;&gt;&lt;&lt;set $worker to 0&gt;&gt;&lt;&lt;if $hoh is 4&gt;&gt;You convince your husband to accept them into your home.&lt;&lt;elseif $hoh is 3 or ($hoh is 0 and $socio is &quot;servants&quot;)&gt;&gt;You convince your $masterTitle to accept them into your home.&lt;&lt;elseif $hoh isnot 1&gt;&gt;You convince your family to accept them into your home.&lt;&lt;else&gt;&gt;You accept them into your home.&lt;&lt;/if&gt;&gt; It&#39;s another mouth to feed, but you are glad to &lt;&lt;storyline-return &quot;do a friend a favor.&quot; 0 -48 1&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#worker&quot;&gt;&gt;&lt;&lt;if $hoh is 4&gt;&gt;You convince your husband not to accept them into your home.&lt;&lt;elseif $hoh is 3 or ($hoh is 0 and $socio is &quot;servants&quot;)&gt;&gt;You convince your $masterTitle not to accept them into your home.&lt;&lt;elseif $hoh isnot 1&gt;&gt;You convince your family not to accept them into your home.&lt;&lt;else&gt;&gt;You don&#39;t accept them into your home.&lt;&lt;/if&gt;&gt; Things are too hard right now. You can&#39;t afford another mouth to feed and you don&#39;t have the time to teach someone else the lay of the city.&lt;&lt;storyline-return &quot;Continue.&quot; 0&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;
 
@@ -5774,7 +5813,7 @@ Despite everything, you &lt;&lt;if $socio is &quot;day labourers&quot;&gt;&gt;ke
 &lt;&lt;nobr&gt;&gt;
 Despite everything, business continues. A friend from the countryside writes to you&lt;&lt;if $agenum lte 15&gt;&gt;r family&lt;&lt;/if&gt;&gt; and asks if you will take in their son as your apprentice.
 &lt;br&gt;&lt;br&gt;
-&lt;span id=&quot;apprentice&quot;&gt;Do you want to accept him into your home? &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#apprentice&quot;&gt;&gt;&lt;&lt;addApprenticeNPC&gt;&gt;&lt;&lt;set $apprentice to 0&gt;&gt;&lt;&lt;if $hoh is 4&gt;&gt;You convince your husband to accept him into your home.&lt;&lt;elseif $hoh is 3 or ($hoh is 0 and $socio is &quot;servants&quot;)&gt;&gt;You convince your $masterTitle to accept him into your home.&lt;&lt;elseif $hoh isnot 1&gt;&gt;You convince your family to accept him into your home.&lt;&lt;else&gt;&gt;You accept him into your home.&lt;&lt;/if&gt;&gt; It&#39;s another mouth to feed, but you could use the help and are glad to &lt;&lt;storyline-return &quot;do a friend a favor.&quot; 1 -48 1&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#apprentice&quot;&gt;&gt;&lt;&lt;if $hoh is 4&gt;&gt;You convince your husband not to accept him into your home.&lt;&lt;elseif $hoh is 3 or ($hoh is 0 and $socio is &quot;servants&quot;)&gt;&gt;You convince your $masterTitle not to accept him into your home.&lt;&lt;elseif $hoh isnot 1&gt;&gt;You convince your family not to accept him into your home.&lt;&lt;else&gt;&gt;You don&#39;t accept him into your home.&lt;&lt;/if&gt;&gt; Things are too hard right now. You can&#39;t afford another mouth to feed and you don&#39;t have the time to teach someone else your trade.&lt;&lt;storyline-return&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
+&lt;span id=&quot;apprentice&quot;&gt;Do you want to accept him into your home? &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#apprentice&quot;&gt;&gt;&lt;&lt;addApprenticeNPC&gt;&gt;&lt;&lt;set $apprentice to 0&gt;&gt;&lt;&lt;if $hoh is 4&gt;&gt;You convince your husband to accept him into your home.&lt;&lt;elseif $hoh is 3 or ($hoh is 0 and $socio is &quot;servants&quot;)&gt;&gt;You convince your $masterTitle to accept him into your home.&lt;&lt;elseif $hoh isnot 1&gt;&gt;You convince your family to accept him into your home.&lt;&lt;else&gt;&gt;You accept him into your home.&lt;&lt;/if&gt;&gt; It&#39;s another mouth to feed, but you could use the help and are glad to &lt;&lt;storyline-return &quot;do a friend a favor.&quot; 0 -48 1&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#apprentice&quot;&gt;&gt;&lt;&lt;if $hoh is 4&gt;&gt;You convince your husband not to accept him into your home.&lt;&lt;elseif $hoh is 3 or ($hoh is 0 and $socio is &quot;servants&quot;)&gt;&gt;You convince your $masterTitle not to accept him into your home.&lt;&lt;elseif $hoh isnot 1&gt;&gt;You convince your family not to accept him into your home.&lt;&lt;else&gt;&gt;You don&#39;t accept him into your home.&lt;&lt;/if&gt;&gt; Things are too hard right now. You can&#39;t afford another mouth to feed and you don&#39;t have the time to teach someone else your trade.&lt;&lt;storyline-return &quot;Continue.&quot; 0&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;
 
@@ -5782,7 +5821,7 @@ Despite everything, business continues. A friend from the countryside writes to 
 &lt;&lt;nobr&gt;&gt;
 Despite everything, court life proceeds as usual. A friend living the countryside writes to you&lt;&lt;if $agenum lte 15&gt;&gt;r family&lt;&lt;/if&gt;&gt; and asks if you will take in their child as your ward and help them get a place at court - and maybe even an advantageous marriage.
 &lt;br&gt;&lt;br&gt;
-&lt;span id=&quot;ward&quot;&gt;Do you want to accept them into your home? &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#ward&quot;&gt;&gt;&lt;&lt;addWardNPC&gt;&gt;&lt;&lt;set $ward to 0&gt;&gt;&lt;&lt;if $hoh is 4&gt;&gt;You convince your husband to accept them into your home.&lt;&lt;elseif $hoh is 3 or ($hoh is 0 and $socio is &quot;servants&quot;)&gt;&gt;You convince your $masterTitle to accept them into your home.&lt;&lt;elseif $hoh isnot 1&gt;&gt;You convince your family to accept them into your home.&lt;&lt;else&gt;&gt;You accept them into your home.&lt;&lt;/if&gt;&gt; It will cost a small fortune to outfit a newcomer to court and provide the king the necessary gifts but you will control their purse strings and are glad to &lt;&lt;storyline-return &quot;do a friend a favor.&quot; 1 -12000 1&gt;&gt;.&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#ward&quot;&gt;&gt;&lt;&lt;if $hoh is 4&gt;&gt;You convince your husband not to accept them into your home.&lt;&lt;elseif $hoh is 3 or ($hoh is 0 and $socio is &quot;servants&quot;)&gt;&gt;You convince your $masterTitle not to accept them into your home.&lt;&lt;elseif $hoh isnot 1&gt;&gt;You convince your family not to accept them into your home.&lt;&lt;else&gt;&gt;You don&#39;t accept them into your home.&lt;&lt;/if&gt;&gt; Your own affairs are not quite in order and you need to focus on setting them right before adding another person to the household. You don&#39;t have the time to teach someone else the ways of court.&lt;&lt;storyline-return&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
+&lt;span id=&quot;ward&quot;&gt;Do you want to accept them into your home? &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#ward&quot;&gt;&gt;&lt;&lt;addWardNPC&gt;&gt;&lt;&lt;set $ward to 0&gt;&gt;&lt;&lt;if $hoh is 4&gt;&gt;You convince your husband to accept them into your home.&lt;&lt;elseif $hoh is 3 or ($hoh is 0 and $socio is &quot;servants&quot;)&gt;&gt;You convince your $masterTitle to accept them into your home.&lt;&lt;elseif $hoh isnot 1&gt;&gt;You convince your family to accept them into your home.&lt;&lt;else&gt;&gt;You accept them into your home.&lt;&lt;/if&gt;&gt; It will cost a small fortune to outfit a newcomer to court and provide the king the necessary gifts but you will control their purse strings and are glad to &lt;&lt;storyline-return &quot;do a friend a favor.&quot; 0 -12000 1&gt;&gt;.&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#ward&quot;&gt;&gt;&lt;&lt;if $hoh is 4&gt;&gt;You convince your husband not to accept them into your home.&lt;&lt;elseif $hoh is 3 or ($hoh is 0 and $socio is &quot;servants&quot;)&gt;&gt;You convince your $masterTitle not to accept them into your home.&lt;&lt;elseif $hoh isnot 1&gt;&gt;You convince your family not to accept them into your home.&lt;&lt;else&gt;&gt;You don&#39;t accept them into your home.&lt;&lt;/if&gt;&gt; Your own affairs are not quite in order and you need to focus on setting them right before adding another person to the household. You don&#39;t have the time to teach someone else the ways of court.&lt;&lt;storyline-return &quot;Continue.&quot; 0&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;
 </tw-passagedata><tw-passagedata pid="106" name="catch-up widget" tags="widget" position="150,1350" size="100,100">&lt;&lt;widget &quot;catch-up&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
@@ -5832,9 +5871,9 @@ You have found a &lt;&lt;if $gender is &quot;female&quot;&gt;&gt;husband&lt;&lt;
 
 &lt;span id=&quot;format&quot;&gt;Do you want to 
 &lt;ul&gt;
-&lt;li&gt;&lt;&lt;link &quot;be married in your parish church&quot;&gt;&gt;&lt;&lt;party-costs&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round((10000 / _rate) + 200) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if random(1, 50) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Married in parish church&quot;, money: -48, repDelta: 2, repBefore: _repBefore, infectPct: _riskPct})&gt;&gt;&lt;&lt;set $relationship to &quot;married&quot;&gt;&gt;&lt;&lt;addPartnerNPC&gt;&gt;&lt;&lt;set-hoh&gt;&gt;&lt;&lt;replace &quot;#format&quot;&gt;&gt;For the three weeks before the wedding, your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; priest reads the banns and then you are married in a nice ceremony in the church of $parish. After the dancing and feasting, you &lt;&lt;storyline-return &quot;go home&quot; 1 -48 2&gt;&gt; with your new &lt;&lt;if $gender is &quot;female&quot;&gt;&gt;husband&lt;&lt;elseif $gender is &quot;male&quot;&gt;&gt;wife&lt;&lt;else&gt;&gt;spouse&lt;&lt;/if&gt;&gt;.&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
-&lt;li&gt;&lt;&lt;link &quot;pay for a private wedding license&quot;&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Paid for a private wedding license&quot;, money: -96, repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;&lt;&lt;set $relationship to &quot;married&quot;&gt;&gt;&lt;&lt;addPartnerNPC&gt;&gt;&lt;&lt;set-hoh&gt;&gt;&lt;&lt;replace &quot;#format&quot;&gt;&gt;You don&#39;t want to have to wait three weeks to have the banns read, or to celebrate in your possibly &lt;&lt;defPlague &quot;plague&quot;&gt;&gt;-stricken &lt;&lt;defParish &quot;parish&quot;&gt;&gt; church. You pay 8s. to obtain a special license and have &lt;&lt;storyline-return &quot;a small ceremony at home.&quot; 1 -96&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
-&lt;li&gt;&lt;&lt;link &quot;elope at Fleet prison&quot;&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Eloped at Fleet prison&quot;, money: -72, repDelta: -1, repBefore: _repBefore, infectPct: _riskPct})&gt;&gt;&lt;&lt;set $relationship to &quot;married&quot;&gt;&gt;&lt;&lt;addPartnerNPC&gt;&gt;&lt;&lt;set-hoh&gt;&gt;&lt;&lt;replace &quot;#format&quot;&gt;&gt;Rather than going through the fuss of a formal wedding, you go to the Fleet prison where you find a priest willing to marry you in a nearby tavern without &lt;&lt;storyline-return &quot;asking too many questions.&quot; 1 -72 -1&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/span&gt;
+&lt;li&gt;&lt;&lt;link &quot;be married in your parish church&quot;&gt;&gt;&lt;&lt;party-costs&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round((10000 / _rate) + 200) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if random(1, 50) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Married in parish church&quot;, money: -48, repDelta: 2, repBefore: _repBefore, infectPct: _riskPct})&gt;&gt;&lt;&lt;set $relationship to &quot;married&quot;&gt;&gt;&lt;&lt;addPartnerNPC&gt;&gt;&lt;&lt;set-hoh&gt;&gt;&lt;&lt;replace &quot;#format&quot;&gt;&gt;For the three weeks before the wedding, your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; priest reads the banns and then you are married in a nice ceremony in the church of $parish. After the dancing and feasting, you &lt;&lt;storyline-return &quot;go home&quot; 0 -48 2&gt;&gt; with your new &lt;&lt;if $gender is &quot;female&quot;&gt;&gt;husband&lt;&lt;elseif $gender is &quot;male&quot;&gt;&gt;wife&lt;&lt;else&gt;&gt;spouse&lt;&lt;/if&gt;&gt;.&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
+&lt;li&gt;&lt;&lt;link &quot;pay for a private wedding license&quot;&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Paid for a private wedding license&quot;, money: -96, repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;&lt;&lt;set $relationship to &quot;married&quot;&gt;&gt;&lt;&lt;addPartnerNPC&gt;&gt;&lt;&lt;set-hoh&gt;&gt;&lt;&lt;replace &quot;#format&quot;&gt;&gt;You don&#39;t want to have to wait three weeks to have the banns read, or to celebrate in your possibly &lt;&lt;defPlague &quot;plague&quot;&gt;&gt;-stricken &lt;&lt;defParish &quot;parish&quot;&gt;&gt; church. You pay 8s. to obtain a special license and have &lt;&lt;storyline-return &quot;a small ceremony at home.&quot; 0 -96&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
+&lt;li&gt;&lt;&lt;link &quot;elope at Fleet prison&quot;&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Eloped at Fleet prison&quot;, money: -72, repDelta: -1, repBefore: _repBefore, infectPct: _riskPct})&gt;&gt;&lt;&lt;set $relationship to &quot;married&quot;&gt;&gt;&lt;&lt;addPartnerNPC&gt;&gt;&lt;&lt;set-hoh&gt;&gt;&lt;&lt;replace &quot;#format&quot;&gt;&gt;Rather than going through the fuss of a formal wedding, you go to the Fleet prison where you find a priest willing to marry you in a nearby tavern without &lt;&lt;storyline-return &quot;asking too many questions.&quot; 0 -72 -1&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/span&gt;
 
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="109" name="NPC-death widget" tags="widget" position="25,725" size="100,100">&lt;&lt;widget &quot;NPC-death&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
@@ -5855,58 +5894,77 @@ You have found a &lt;&lt;if $gender is &quot;female&quot;&gt;&gt;husband&lt;&lt;
 /* Track contagion per array (empty string = none triggered yet) */
 &lt;&lt;set _npcContagion to &quot;&quot;&gt;&gt;&lt;&lt;set _masterContagion to &quot;&quot;&gt;&gt;&lt;&lt;set _extendedContagion to &quot;&quot;&gt;&gt;&lt;&lt;set _servantsContagion to &quot;&quot;&gt;&gt;
 
+/* Collect all dead NPCs for a single funeral choice */
+&lt;&lt;set _deadNPCs to []&gt;&gt;
+
 /* === $NPCs (household) === */
 &lt;&lt;for _di = 0; _di lt $NPCs.length; _di++&gt;&gt;&lt;&lt;if $NPCs[_di].health is &quot;healthy&quot;&gt;&gt;&lt;&lt;if $NPCs[_di].age is &quot;infant&quot;&gt;&gt;
 &lt;&lt;if random(1,1000) lte 56&gt;&gt;
-&lt;&lt;set _cause to weightedEither(_causeWeights)&gt;&gt;&lt;&lt;set $NPCs[_di].health to &quot;deceased&quot;&gt;&gt;Your $NPCs[_di].relationship $NPCs[_di].name has died of _cause.&lt;br&gt;&lt;br&gt;&lt;&lt;funeral-choice $NPCs[_di]&gt;&gt;
+&lt;&lt;set _cause to weightedEither(_causeWeights)&gt;&gt;&lt;&lt;set $NPCs[_di].health to &quot;deceased&quot;&gt;&gt;Your $NPCs[_di].relationship $NPCs[_di].name has died of _cause.&lt;br&gt;
+&lt;&lt;set _deadNPCs.push({npc: $NPCs[_di], label: &quot;your &quot; + $NPCs[_di].relationship})&gt;&gt;
 &lt;&lt;if (_cause is &quot;smallpox&quot; or _cause is &quot;measles&quot;) and _npcContagion is &quot;&quot;&gt;&gt;&lt;&lt;set _npcContagion to _cause&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;elseif $NPCs[_di].age is &quot;child&quot;&gt;&gt;
 &lt;&lt;if random(1,1000) is 1&gt;&gt;
-&lt;&lt;set _cause to weightedEither(_causeWeights)&gt;&gt;&lt;&lt;set $NPCs[_di].health to &quot;deceased&quot;&gt;&gt;Your $NPCs[_di].relationship $NPCs[_di].name has died of _cause.&lt;br&gt;&lt;&lt;funeral-choice $NPCs[_di]&gt;&gt;
+&lt;&lt;set _cause to weightedEither(_causeWeights)&gt;&gt;&lt;&lt;set $NPCs[_di].health to &quot;deceased&quot;&gt;&gt;Your $NPCs[_di].relationship $NPCs[_di].name has died of _cause.&lt;br&gt;
+&lt;&lt;set _deadNPCs.push({npc: $NPCs[_di], label: &quot;your &quot; + $NPCs[_di].relationship})&gt;&gt;
 &lt;&lt;if (_cause is &quot;smallpox&quot; or _cause is &quot;measles&quot;) and _npcContagion is &quot;&quot;&gt;&gt;&lt;&lt;set _npcContagion to _cause&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;elseif $NPCs[_di].age is &quot;elderly adult&quot;&gt;&gt;
-&lt;&lt;if random(1,100) is 1&gt;&gt;&lt;&lt;set $NPCs[_di].health to &quot;deceased&quot;&gt;&gt;Your $NPCs[_di].relationship $NPCs[_di].name has died of old age.&lt;br&gt;&lt;&lt;funeral-choice $NPCs[_di]&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
+&lt;&lt;if random(1,100) is 1&gt;&gt;&lt;&lt;set $NPCs[_di].health to &quot;deceased&quot;&gt;&gt;Your $NPCs[_di].relationship $NPCs[_di].name has died of old age.&lt;br&gt;
+&lt;&lt;set _deadNPCs.push({npc: $NPCs[_di], label: &quot;your &quot; + $NPCs[_di].relationship})&gt;&gt;
+&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
 
 /* === $NPCsMaster (master&#39;s household) === */
 &lt;&lt;for _di = 0; _di lt $NPCsMaster.length; _di++&gt;&gt;
 &lt;&lt;if $NPCsMaster[_di].health is &quot;healthy&quot;&gt;&gt;&lt;&lt;if $NPCsMaster[_di].age is &quot;infant&quot;&gt;&gt;
 &lt;&lt;if random(1,1000) lte 56&gt;&gt;
-&lt;&lt;set _cause to weightedEither(_causeWeights)&gt;&gt;&lt;&lt;set $NPCsMaster[_di].health to &quot;deceased&quot;&gt;&gt;The $NPCsMaster[_di].relationship $NPCsMaster[_di].name has died of _cause.&lt;br&gt;&lt;&lt;funeral-choice $NPCsMaster[_di]&gt;&gt;
+&lt;&lt;set _cause to weightedEither(_causeWeights)&gt;&gt;&lt;&lt;set $NPCsMaster[_di].health to &quot;deceased&quot;&gt;&gt;The $NPCsMaster[_di].relationship $NPCsMaster[_di].name has died of _cause.&lt;br&gt;
+&lt;&lt;set _deadNPCs.push({npc: $NPCsMaster[_di], label: &quot;the &quot; + $NPCsMaster[_di].relationship})&gt;&gt;
 &lt;&lt;if (_cause is &quot;smallpox&quot; or _cause is &quot;measles&quot;) and _masterContagion is &quot;&quot;&gt;&gt;&lt;&lt;set _masterContagion to _cause&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;elseif $NPCsMaster[_di].age is &quot;child&quot;&gt;&gt;
 &lt;&lt;if random(1,1000) is 1&gt;&gt;
-&lt;&lt;set _cause to weightedEither(_causeWeights)&gt;&gt;&lt;&lt;set $NPCsMaster[_di].health to &quot;deceased&quot;&gt;&gt;The $NPCsMaster[_di].relationship $NPCsMaster[_di].name has died of _cause.&lt;br&gt;&lt;&lt;funeral-choice $NPCsMaster[_di]&gt;&gt;
+&lt;&lt;set _cause to weightedEither(_causeWeights)&gt;&gt;&lt;&lt;set $NPCsMaster[_di].health to &quot;deceased&quot;&gt;&gt;The $NPCsMaster[_di].relationship $NPCsMaster[_di].name has died of _cause.&lt;br&gt;
+&lt;&lt;set _deadNPCs.push({npc: $NPCsMaster[_di], label: &quot;the &quot; + $NPCsMaster[_di].relationship})&gt;&gt;
 &lt;&lt;if (_cause is &quot;smallpox&quot; or _cause is &quot;measles&quot;) and _masterContagion is &quot;&quot;&gt;&gt;&lt;&lt;set _masterContagion to _cause&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;elseif $NPCsMaster[_di].age is &quot;elderly adult&quot;&gt;&gt;
-&lt;&lt;if random(1,100) is 1&gt;&gt;&lt;&lt;set $NPCsMaster[_di].health to &quot;deceased&quot;&gt;&gt;The $NPCsMaster[_di].relationship $NPCsMaster[_di].name has died of old age.&lt;br&gt;&lt;&lt;funeral-choice $NPCsMaster[_di]&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if random(1,100) is 1&gt;&gt;&lt;&lt;set $NPCsMaster[_di].health to &quot;deceased&quot;&gt;&gt;The $NPCsMaster[_di].relationship $NPCsMaster[_di].name has died of old age.&lt;br&gt;
+&lt;&lt;set _deadNPCs.push({npc: $NPCsMaster[_di], label: &quot;the &quot; + $NPCsMaster[_di].relationship})&gt;&gt;
+&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;/for&gt;&gt;
 
 /* === $NPCsExtended (extended household) === */
 &lt;&lt;for _di = 0; _di lt $NPCsExtended.length; _di++&gt;&gt;&lt;&lt;if $NPCsExtended[_di].health is &quot;healthy&quot;&gt;&gt;
 &lt;&lt;if $NPCsExtended[_di].age is &quot;infant&quot;&gt;&gt;
 &lt;&lt;if random(1,1000) lte 56&gt;&gt;
-&lt;&lt;set _cause to weightedEither(_causeWeights)&gt;&gt;&lt;&lt;set $NPCsExtended[_di].health to &quot;deceased&quot;&gt;&gt;Your $NPCsExtended[_di].relationship $NPCsExtended[_di].name has died of _cause.&lt;br&gt;&lt;&lt;funeral-choice $NPCsExtended[_di]&gt;&gt;
+&lt;&lt;set _cause to weightedEither(_causeWeights)&gt;&gt;&lt;&lt;set $NPCsExtended[_di].health to &quot;deceased&quot;&gt;&gt;Your $NPCsExtended[_di].relationship $NPCsExtended[_di].name has died of _cause.&lt;br&gt;
+&lt;&lt;set _deadNPCs.push({npc: $NPCsExtended[_di], label: &quot;your &quot; + $NPCsExtended[_di].relationship})&gt;&gt;
 &lt;&lt;if (_cause is &quot;smallpox&quot; or _cause is &quot;measles&quot;) and _extendedContagion is &quot;&quot;&gt;&gt;&lt;&lt;set _extendedContagion to _cause&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;elseif $NPCsExtended[_di].age is &quot;child&quot;&gt;&gt;
 &lt;&lt;if random(1,1000) is 1&gt;&gt;
-&lt;&lt;set _cause to weightedEither(_causeWeights)&gt;&gt;&lt;&lt;set $NPCsExtended[_di].health to &quot;deceased&quot;&gt;&gt;Your $NPCsExtended[_di].relationship $NPCsExtended[_di].name has died of _cause.&lt;br&gt;&lt;&lt;funeral-choice $NPCsExtended[_di]&gt;&gt;
+&lt;&lt;set _cause to weightedEither(_causeWeights)&gt;&gt;&lt;&lt;set $NPCsExtended[_di].health to &quot;deceased&quot;&gt;&gt;Your $NPCsExtended[_di].relationship $NPCsExtended[_di].name has died of _cause.&lt;br&gt;
+&lt;&lt;set _deadNPCs.push({npc: $NPCsExtended[_di], label: &quot;your &quot; + $NPCsExtended[_di].relationship})&gt;&gt;
 &lt;&lt;if (_cause is &quot;smallpox&quot; or _cause is &quot;measles&quot;) and _extendedContagion is &quot;&quot;&gt;&gt;&lt;&lt;set _extendedContagion to _cause&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;elseif $NPCsExtended[_di].age is &quot;elderly adult&quot;&gt;&gt;
-&lt;&lt;if random(1,100) is 1&gt;&gt;&lt;&lt;set $NPCsExtended[_di].health to &quot;deceased&quot;&gt;&gt;Your $NPCsExtended[_di].relationship $NPCsExtended[_di].name has died of old age.&lt;br&gt;&lt;&lt;funeral-choice $NPCsExtended[_di]&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if random(1,100) is 1&gt;&gt;&lt;&lt;set $NPCsExtended[_di].health to &quot;deceased&quot;&gt;&gt;Your $NPCsExtended[_di].relationship $NPCsExtended[_di].name has died of old age.&lt;br&gt;
+&lt;&lt;set _deadNPCs.push({npc: $NPCsExtended[_di], label: &quot;your &quot; + $NPCsExtended[_di].relationship})&gt;&gt;
+&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;/for&gt;&gt;
 
 /* === $NPCsServants (servants) === */
 &lt;&lt;for _di = 0; _di lt $NPCsServants.length; _di++&gt;&gt;
 &lt;&lt;if $NPCsServants[_di].health is &quot;healthy&quot;&gt;&gt;&lt;&lt;if $NPCsServants[_di].age is &quot;infant&quot;&gt;&gt;
 &lt;&lt;if random(1,1000) lte 56&gt;&gt;
-&lt;&lt;set _cause to weightedEither(_causeWeights)&gt;&gt;&lt;&lt;set $NPCsServants[_di].health to &quot;deceased&quot;&gt;&gt;Your servant $NPCsServants[_di].name has died of _cause.&lt;br&gt;&lt;&lt;funeral-choice $NPCsServants[_di]&gt;&gt;
+&lt;&lt;set _cause to weightedEither(_causeWeights)&gt;&gt;&lt;&lt;set $NPCsServants[_di].health to &quot;deceased&quot;&gt;&gt;Your servant $NPCsServants[_di].name has died of _cause.&lt;br&gt;
+&lt;&lt;set _deadNPCs.push({npc: $NPCsServants[_di], label: &quot;your servant&quot;})&gt;&gt;
 &lt;&lt;if (_cause is &quot;smallpox&quot; or _cause is &quot;measles&quot;) and _servantsContagion is &quot;&quot;&gt;&gt;&lt;&lt;set _servantsContagion to _cause&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;elseif $NPCsServants[_di].age is &quot;child&quot;&gt;&gt;
 &lt;&lt;if random(1,1000) is 1&gt;&gt;
-&lt;&lt;set _cause to weightedEither(_causeWeights)&gt;&gt;&lt;&lt;set $NPCsServants[_di].health to &quot;deceased&quot;&gt;&gt;Your servant $NPCsServants[_di].name has died of _cause.&lt;br&gt;&lt;&lt;funeral-choice $NPCsServants[_di]&gt;&gt;
+&lt;&lt;set _cause to weightedEither(_causeWeights)&gt;&gt;&lt;&lt;set $NPCsServants[_di].health to &quot;deceased&quot;&gt;&gt;Your servant $NPCsServants[_di].name has died of _cause.&lt;br&gt;
+&lt;&lt;set _deadNPCs.push({npc: $NPCsServants[_di], label: &quot;your servant&quot;})&gt;&gt;
 &lt;&lt;if (_cause is &quot;smallpox&quot; or _cause is &quot;measles&quot;) and _servantsContagion is &quot;&quot;&gt;&gt;&lt;&lt;set _servantsContagion to _cause&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;elseif $NPCsServants[_di].age is &quot;elderly adult&quot;&gt;&gt;
-&lt;&lt;if random(1,100) is 1&gt;&gt;&lt;&lt;set $NPCsServants[_di].health to &quot;deceased&quot;&gt;&gt;Your servant $NPCsServants[_di].name has died of old age.&lt;br&gt;&lt;&lt;funeral-choice $NPCsServants[_di]&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if random(1,100) is 1&gt;&gt;&lt;&lt;set $NPCsServants[_di].health to &quot;deceased&quot;&gt;&gt;Your servant $NPCsServants[_di].name has died of old age.&lt;br&gt;
+&lt;&lt;set _deadNPCs.push({npc: $NPCsServants[_di], label: &quot;your servant&quot;})&gt;&gt;
+&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;/for&gt;&gt;
 
 /* === Contagion: $NPCs === */
@@ -5920,7 +5978,7 @@ You have found a &lt;&lt;if $gender is &quot;female&quot;&gt;&gt;husband&lt;&lt;
 &lt;&lt;elseif _npcContagion is &quot;measles&quot;&gt;&gt;
 &lt;&lt;if _cr lte 10&gt;&gt;&lt;&lt;set $NPCs[_di].health to &quot;deceased&quot;&gt;&gt;&lt;&lt;set _contagionDead.push(_di)&gt;&gt;
 &lt;&lt;elseif _cr lte 90&gt;&gt;&lt;&lt;set _contagionSurvived.push(_di)&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
-&lt;&lt;if _contagionDead.length gt 0&gt;&gt;Tragically, &lt;&lt;for _gi = 0; _gi lt _contagionDead.length; _gi++&gt;&gt;&lt;&lt;if _gi gt 0&gt;&gt; and &lt;&lt;/if&gt;&gt;your $NPCs[_contagionDead[_gi]].relationship $NPCs[_contagionDead[_gi]].name&lt;&lt;/for&gt;&gt; &lt;&lt;if _contagionDead.length eq 1&gt;&gt;has&lt;&lt;else&gt;&gt;have&lt;&lt;/if&gt;&gt; also died of _npcContagion.&lt;br&gt;&lt;&lt;for _gi = 0; _gi lt _contagionDead.length; _gi++&gt;&gt;&lt;&lt;funeral-choice $NPCs[_contagionDead[_gi]]&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if _contagionDead.length gt 0&gt;&gt;Tragically, &lt;&lt;for _gi = 0; _gi lt _contagionDead.length; _gi++&gt;&gt;&lt;&lt;if _gi gt 0&gt;&gt; and &lt;&lt;/if&gt;&gt;your $NPCs[_contagionDead[_gi]].relationship $NPCs[_contagionDead[_gi]].name&lt;&lt;/for&gt;&gt; &lt;&lt;if _contagionDead.length eq 1&gt;&gt;has&lt;&lt;else&gt;&gt;have&lt;&lt;/if&gt;&gt; also died of _npcContagion.&lt;br&gt;&lt;&lt;for _gi = 0; _gi lt _contagionDead.length; _gi++&gt;&gt;&lt;&lt;set _deadNPCs.push({npc: $NPCs[_contagionDead[_gi]], label: &quot;your &quot; + $NPCs[_contagionDead[_gi]].relationship})&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;if _contagionSurvived.length gt 0&gt;&gt;&lt;&lt;for _gi = 0; _gi lt _contagionSurvived.length; _gi++&gt;&gt;&lt;&lt;if _gi gt 0&gt;&gt; and &lt;&lt;/if&gt;&gt;your $NPCs[_contagionSurvived[_gi]].relationship $NPCs[_contagionSurvived[_gi]].name&lt;&lt;/for&gt;&gt; &lt;&lt;if _contagionSurvived.length eq 1&gt;&gt;has&lt;&lt;else&gt;&gt;have&lt;&lt;/if&gt;&gt; contracted _npcContagion but survived.&lt;br&gt;&lt;br&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 
@@ -5935,7 +5993,7 @@ You have found a &lt;&lt;if $gender is &quot;female&quot;&gt;&gt;husband&lt;&lt;
 &lt;&lt;elseif _masterContagion is &quot;measles&quot;&gt;&gt;
 &lt;&lt;if _cr lte 10&gt;&gt;&lt;&lt;set $NPCsMaster[_di].health to &quot;deceased&quot;&gt;&gt;&lt;&lt;set _contagionDead.push(_di)&gt;&gt;
 &lt;&lt;elseif _cr lte 90&gt;&gt;&lt;&lt;set _contagionSurvived.push(_di)&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
-&lt;&lt;if _contagionDead.length gt 0&gt;&gt;Tragically, &lt;&lt;for _gi = 0; _gi lt _contagionDead.length; _gi++&gt;&gt;&lt;&lt;if _gi gt 0&gt;&gt; and &lt;&lt;/if&gt;&gt;the $NPCsMaster[_contagionDead[_gi]].relationship $NPCsMaster[_contagionDead[_gi]].name&lt;&lt;/for&gt;&gt; &lt;&lt;if _contagionDead.length eq 1&gt;&gt;has&lt;&lt;else&gt;&gt;have&lt;&lt;/if&gt;&gt; also died of _masterContagion.&lt;br&gt;&lt;&lt;for _gi = 0; _gi lt _contagionDead.length; _gi++&gt;&gt;&lt;&lt;funeral-choice $NPCsMaster[_contagionDead[_gi]]&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if _contagionDead.length gt 0&gt;&gt;Tragically, &lt;&lt;for _gi = 0; _gi lt _contagionDead.length; _gi++&gt;&gt;&lt;&lt;if _gi gt 0&gt;&gt; and &lt;&lt;/if&gt;&gt;the $NPCsMaster[_contagionDead[_gi]].relationship $NPCsMaster[_contagionDead[_gi]].name&lt;&lt;/for&gt;&gt; &lt;&lt;if _contagionDead.length eq 1&gt;&gt;has&lt;&lt;else&gt;&gt;have&lt;&lt;/if&gt;&gt; also died of _masterContagion.&lt;br&gt;&lt;&lt;for _gi = 0; _gi lt _contagionDead.length; _gi++&gt;&gt;&lt;&lt;set _deadNPCs.push({npc: $NPCsMaster[_contagionDead[_gi]], label: &quot;the &quot; + $NPCsMaster[_contagionDead[_gi]].relationship})&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;if _contagionSurvived.length gt 0&gt;&gt;&lt;&lt;for _gi = 0; _gi lt _contagionSurvived.length; _gi++&gt;&gt;&lt;&lt;if _gi gt 0&gt;&gt; and &lt;&lt;/if&gt;&gt;the $NPCsMaster[_contagionSurvived[_gi]].relationship $NPCsMaster[_contagionSurvived[_gi]].name&lt;&lt;/for&gt;&gt; &lt;&lt;if _contagionSurvived.length eq 1&gt;&gt;has&lt;&lt;else&gt;&gt;have&lt;&lt;/if&gt;&gt; contracted _masterContagion but survived.&lt;br&gt;&lt;br&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 
@@ -5950,7 +6008,7 @@ You have found a &lt;&lt;if $gender is &quot;female&quot;&gt;&gt;husband&lt;&lt;
 &lt;&lt;elseif _extendedContagion is &quot;measles&quot;&gt;&gt;
 &lt;&lt;if _cr lte 10&gt;&gt;&lt;&lt;set $NPCsExtended[_di].health to &quot;deceased&quot;&gt;&gt;&lt;&lt;set _contagionDead.push(_di)&gt;&gt;
 &lt;&lt;elseif _cr lte 90&gt;&gt;&lt;&lt;set _contagionSurvived.push(_di)&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
-&lt;&lt;if _contagionDead.length gt 0&gt;&gt;Tragically, &lt;&lt;for _gi = 0; _gi lt _contagionDead.length; _gi++&gt;&gt;&lt;&lt;if _gi gt 0&gt;&gt; and &lt;&lt;/if&gt;&gt;your $NPCsExtended[_contagionDead[_gi]].relationship $NPCsExtended[_contagionDead[_gi]].name&lt;&lt;/for&gt;&gt; &lt;&lt;if _contagionDead.length eq 1&gt;&gt;has&lt;&lt;else&gt;&gt;have&lt;&lt;/if&gt;&gt; also died of _extendedContagion.&lt;br&gt;&lt;&lt;for _gi = 0; _gi lt _contagionDead.length; _gi++&gt;&gt;&lt;&lt;funeral-choice $NPCsExtended[_contagionDead[_gi]]&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if _contagionDead.length gt 0&gt;&gt;Tragically, &lt;&lt;for _gi = 0; _gi lt _contagionDead.length; _gi++&gt;&gt;&lt;&lt;if _gi gt 0&gt;&gt; and &lt;&lt;/if&gt;&gt;your $NPCsExtended[_contagionDead[_gi]].relationship $NPCsExtended[_contagionDead[_gi]].name&lt;&lt;/for&gt;&gt; &lt;&lt;if _contagionDead.length eq 1&gt;&gt;has&lt;&lt;else&gt;&gt;have&lt;&lt;/if&gt;&gt; also died of _extendedContagion.&lt;br&gt;&lt;&lt;for _gi = 0; _gi lt _contagionDead.length; _gi++&gt;&gt;&lt;&lt;set _deadNPCs.push({npc: $NPCsExtended[_contagionDead[_gi]], label: &quot;your &quot; + $NPCsExtended[_contagionDead[_gi]].relationship})&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;if _contagionSurvived.length gt 0&gt;&gt;&lt;&lt;for _gi = 0; _gi lt _contagionSurvived.length; _gi++&gt;&gt;&lt;&lt;if _gi gt 0&gt;&gt; and &lt;&lt;/if&gt;&gt;your $NPCsExtended[_contagionSurvived[_gi]].relationship $NPCsExtended[_contagionSurvived[_gi]].name&lt;&lt;/for&gt;&gt; &lt;&lt;if _contagionSurvived.length eq 1&gt;&gt;has&lt;&lt;else&gt;&gt;have&lt;&lt;/if&gt;&gt; contracted _extendedContagion but survived.&lt;br&gt;&lt;br&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 
@@ -5965,19 +6023,24 @@ You have found a &lt;&lt;if $gender is &quot;female&quot;&gt;&gt;husband&lt;&lt;
 &lt;&lt;elseif _servantsContagion is &quot;measles&quot;&gt;&gt;
 &lt;&lt;if _cr lte 10&gt;&gt;&lt;&lt;set $NPCsServants[_di].health to &quot;deceased&quot;&gt;&gt;&lt;&lt;set _contagionDead.push(_di)&gt;&gt;
 &lt;&lt;elseif _cr lte 90&gt;&gt;&lt;&lt;set _contagionSurvived.push(_di)&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
-&lt;&lt;if _contagionDead.length gt 0&gt;&gt;Tragically, &lt;&lt;for _gi = 0; _gi lt _contagionDead.length; _gi++&gt;&gt;&lt;&lt;if _gi gt 0&gt;&gt; and &lt;&lt;/if&gt;&gt;your servant $NPCsServants[_contagionDead[_gi]].name&lt;&lt;/for&gt;&gt; &lt;&lt;if _contagionDead.length eq 1&gt;&gt;has&lt;&lt;else&gt;&gt;have&lt;&lt;/if&gt;&gt; also died of _servantsContagion.&lt;br&gt;&lt;&lt;for _gi = 0; _gi lt _contagionDead.length; _gi++&gt;&gt;&lt;&lt;funeral-choice $NPCsServants[_contagionDead[_gi]]&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if _contagionDead.length gt 0&gt;&gt;Tragically, &lt;&lt;for _gi = 0; _gi lt _contagionDead.length; _gi++&gt;&gt;&lt;&lt;if _gi gt 0&gt;&gt; and &lt;&lt;/if&gt;&gt;your servant $NPCsServants[_contagionDead[_gi]].name&lt;&lt;/for&gt;&gt; &lt;&lt;if _contagionDead.length eq 1&gt;&gt;has&lt;&lt;else&gt;&gt;have&lt;&lt;/if&gt;&gt; also died of _servantsContagion.&lt;br&gt;&lt;&lt;for _gi = 0; _gi lt _contagionDead.length; _gi++&gt;&gt;&lt;&lt;set _deadNPCs.push({npc: $NPCsServants[_contagionDead[_gi]], label: &quot;your servant&quot;})&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;if _contagionSurvived.length gt 0&gt;&gt;&lt;&lt;for _gi = 0; _gi lt _contagionSurvived.length; _gi++&gt;&gt;&lt;&lt;if _gi gt 0&gt;&gt; and &lt;&lt;/if&gt;&gt;your servant $NPCsServants[_contagionSurvived[_gi]].name&lt;&lt;/for&gt;&gt; &lt;&lt;if _contagionSurvived.length eq 1&gt;&gt;has&lt;&lt;else&gt;&gt;have&lt;&lt;/if&gt;&gt; contracted _servantsContagion but survived.&lt;br&gt;&lt;br&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;servant-master-death&gt;&gt;
 &lt;&lt;check-widowed&gt;&gt;
 &lt;&lt;set-hoh&gt;&gt;
+
+/* Single combined funeral choice for all deaths this month */
+&lt;br&gt;&lt;&lt;funeral-choice&gt;&gt;
+
 &lt;&lt;/if&gt;&gt; /* end _deathYear gt 0 */
 &lt;&lt;/if&gt;&gt; /* end plague/quarantine check */
-&lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="110" name="pregnancy widgets" tags="widget" position="2375,50" size="100,100">&lt;&lt;widget &quot;pregnant&quot;&gt;&gt;
+&lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;
+</tw-passagedata><tw-passagedata pid="110" name="pregnancy widgets" tags="widget" position="2375,50" size="100,100">&lt;&lt;widget &quot;pregnant&quot;&gt;&gt;
 &lt;&lt;nobr&gt;&gt;
 &lt;&lt;set $pregnant to 4&gt;&gt;
 You have realized you are pregnant! You look forward to adding a new member to the family&lt;&lt;if $socio is &quot;beggars&quot; or $socio is &quot;day labourers&quot;&gt;&gt; even if it means another mouth to feed&lt;&lt;/if&gt;&gt;. In a few months you&#39;ll have a new baby, but until then life continues as usual.
-&lt;&lt;storyline-return&gt;&gt;
+&lt;&lt;storyline-return &quot;Continue.&quot; 0&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;
 
@@ -5990,7 +6053,7 @@ For a few weeks, you thought you might be pregnant, but it is now clear that you
 &lt;&lt;unset $pregnant&gt;&gt;&lt;&lt;unset $miscarriage&gt;&gt;
 Unfortunately, you have suffered a miscarriage and are no longer pregnant.
 &lt;&lt;/if&gt;&gt;
-&lt;&lt;storyline-return&gt;&gt;
+&lt;&lt;storyline-return &quot;Continue.&quot; 0&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;
 
@@ -6000,9 +6063,9 @@ Unfortunately, you have suffered a miscarriage and are no longer pregnant.
 &lt;&lt;death-announcement&gt;&gt;
 &lt;&lt;else&gt;&gt;
 &lt;&lt;if random(1,4) is 1&gt;&gt;After a long, hard labor you are devastated to find your baby was stillborn. You bury &lt;&lt;= either(&quot;him&quot;, &quot;her&quot;)&gt;&gt;&lt;&lt;set $money -=9&gt;&gt; and attempt to move on.
-&lt;&lt;storyline-return&gt;&gt;
+&lt;&lt;storyline-return &quot;Continue.&quot; 0&gt;&gt;
 &lt;&lt;else&gt;&gt;
-&lt;&lt;addNewbornNPC&gt;&gt;After a long, hard labor you are delighted to add a baby to your family. 
+&lt;&lt;addNewbornNPC&gt;&gt;After a long, hard labor you are delighted to add a baby to your family.
 
 Do you &lt;span id=&quot;decision&quot;&gt;
 &lt;&lt;link &quot;host a celebration&quot;&gt;&gt;
@@ -6018,14 +6081,14 @@ Do you &lt;span id=&quot;decision&quot;&gt;
     &lt;&lt;set $money -=6&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Childbirth: Threw a Party&quot;, money: -6, repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 You have your new baby, $NPCs.last().name, baptized then celebrate with all your family, friends, and neighbors. You know such a gathering might be dangerous, in such a time of plague, but there is a good chance that $NPCs.last().name will not be one of the babies who survives their perilous first year of life and you want everyone to meet them.
-&lt;&lt;storyline-return&gt;&gt;
+&lt;&lt;storyline-return &quot;Continue.&quot; 0&gt;&gt;
 &lt;&lt;/replace&gt;&gt;
-&lt;&lt;/link&gt;&gt; | 
+&lt;&lt;/link&gt;&gt; |
 &lt;&lt;link &quot;have a quick baptism&quot;&gt;&gt;
 &lt;&lt;replace &quot;#decision&quot;&gt;&gt;
 &lt;&lt;set $decisions.push({text: &quot;Childbirth: Had a quick baptism&quot;, money: -6, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;
 You quickly baptize them&lt;&lt;set $money -=6&gt;&gt; and pray to God that $NPCs.last().name will be one of the babies who survives their perilous first year of life.
-&lt;&lt;storyline-return&gt;&gt;
+&lt;&lt;storyline-return &quot;Continue.&quot; 0&gt;&gt;
 &lt;&lt;/replace&gt;&gt;
 &lt;&lt;/link&gt;&gt;
 &lt;/span&gt;
@@ -6125,6 +6188,13 @@ You quickly baptize them&lt;&lt;set $money -=6&gt;&gt; and pray to God that $NPC
 
 
 &lt;p&gt;&lt;i&gt;For comparison: St Mary Islington (a suburban parish) had only 58 plague deaths over the whole outbreak, while the deadliest parish was St Dunstan Stepney with 1,392 recorded plague deaths. Parishes inside the City walls were generally safer than the poorer suburbs, where plague arrived earlier and spread faster due to crowded housing.&lt;/i&gt;&lt;/p&gt;</tw-passagedata><tw-passagedata pid="113" name="random events widget" tags="widget" position="2100,50" size="100,100">&lt;&lt;widget &quot;random-events&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
+/* Guard: if returning from a random event, skip everything and let
+   the storyline passage render its normal monthly narrative. */
+&lt;&lt;if $randomEventCompleted&gt;&gt;
+	&lt;&lt;set _randomEventFired to false&gt;&gt;
+	&lt;&lt;set $randomEventCompleted to false&gt;&gt;
+	&lt;&lt;church-services&gt;&gt;
+&lt;&lt;else&gt;&gt;
 &lt;&lt;set _randomEventFired to true&gt;&gt;
 /* _randomEventFired starts true each tick. Events that present
    decisions (wedding, birth, funeral, etc.) leave it true and provide
@@ -6270,6 +6340,7 @@ You quickly baptize them&lt;&lt;set $money -=6&gt;&gt; and pray to God that $NPC
 &lt;&lt;if not _randomEventFired&gt;&gt;
 &lt;&lt;church-services&gt;&gt;
 &lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt; /* end $randomEventCompleted guard */
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="114" name="Claude-widgets" tags="widget" position="25,1100" size="100,100">/* all widgets generated via Claude  or other AI should be temporarily placed here then manually moved to new locations as needed */
 
@@ -7128,9 +7199,9 @@ You are devastated, but God willing, this will eventually turn out to &lt;&lt;st
 Your family has sent out enquiries to find a master willing to take you on as an apprentice and found several potential candidates. Each one requires a different entry fee and practices a different trade.
 &lt;br&gt;&lt;br&gt;
 &lt;&lt;if $reputation lte 2&gt;&gt;
-Unfortunately, your reputation is so poor that none of them is currently willing to take you on. They advise you to amend your behavior and increase your standing within the &lt;&lt;defParish &quot;parish&quot;&gt;&gt; after which &lt;&lt;storyline-return &quot;they might reconsider.&quot;&gt;&gt;
+Unfortunately, your reputation is so poor that none of them is currently willing to take you on. They advise you to amend your behavior and increase your standing within the &lt;&lt;defParish &quot;parish&quot;&gt;&gt; after which &lt;&lt;storyline-return &quot;they might reconsider.&quot; 0&gt;&gt;
 &lt;&lt;elseif $money lt 240&gt;&gt;
-Unfortunately, your family can&#39;t afford any of the entry fees right now. You hope that someone will still be willing to take you on, after you have &lt;&lt;storyline-return &quot;increased your savings.&quot;&gt;&gt;
+Unfortunately, your family can&#39;t afford any of the entry fees right now. You hope that someone will still be willing to take you on, after you have &lt;&lt;storyline-return &quot;increased your savings.&quot; 0&gt;&gt;
 &lt;&lt;else&gt;&gt;
 
 &lt;span id=&quot;apprentice-offer&quot;&gt;
@@ -7138,36 +7209,36 @@ Unfortunately, your family can&#39;t afford any of the entry fees right now. You
 Do you wish to apprentice with a
 &lt;ul&gt;
 &lt;&lt;if $money gte 240 and $reputation gt 2&gt;&gt;
-&lt;li&gt;&lt;&lt;link &quot;baker (£1 entry fee)&quot;&gt;&gt;&lt;&lt;replace &quot;#apprentice-offer&quot;&gt;&gt;&lt;&lt;set $apprenticeship to 1&gt;&gt;&lt;&lt;addMaster&gt;&gt;&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Apprenticed as a baker&quot;, money: -240, repDelta: 1, repBefore: _repBefore, infectPct: null})&gt;&gt;It may not be the most prestigious work, but as a baker you&#39;ll never go hungry. Your family pays the £1 entry fee and you move into your new $masterTitle&#39;s household to &lt;&lt;storyline-return &quot;begin learning the trade.&quot; 1 -240 1&gt;&gt;
+&lt;li&gt;&lt;&lt;link &quot;baker (£1 entry fee)&quot;&gt;&gt;&lt;&lt;replace &quot;#apprentice-offer&quot;&gt;&gt;&lt;&lt;set $apprenticeship to 1&gt;&gt;&lt;&lt;addMaster&gt;&gt;&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Apprenticed as a baker&quot;, money: -240, repDelta: 1, repBefore: _repBefore, infectPct: null})&gt;&gt;It may not be the most prestigious work, but as a baker you&#39;ll never go hungry. Your family pays the £1 entry fee and you move into your new $masterTitle&#39;s household to &lt;&lt;storyline-return &quot;begin learning the trade.&quot; 0 -240 1&gt;&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
 &lt;&lt;/if&gt;&gt;
 
 &lt;&lt;if $money gte 1200 and $reputation gt 3&gt;&gt;
-&lt;li&gt;&lt;&lt;link &quot;weaver (£5 entry fee)&quot;&gt;&gt;&lt;&lt;replace &quot;#apprentice-offer&quot;&gt;&gt;&lt;&lt;set $apprenticeship to 2&gt;&gt;&lt;&lt;addMaster&gt;&gt;&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Apprenticed as a weaver&quot;, money: -1200, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: null})&gt;&gt;Weavers may not be one of the Great Twelve livery companies, but they are the oldest company in the city. Your family pays the £5 entry fee and you move into your new $masterTitle&#39;s household to &lt;&lt;storyline-return &quot;begin learning the trade.&quot; 1 -1200 1&gt;&gt;
+&lt;li&gt;&lt;&lt;link &quot;weaver (£5 entry fee)&quot;&gt;&gt;&lt;&lt;replace &quot;#apprentice-offer&quot;&gt;&gt;&lt;&lt;set $apprenticeship to 2&gt;&gt;&lt;&lt;addMaster&gt;&gt;&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Apprenticed as a weaver&quot;, money: -1200, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: null})&gt;&gt;Weavers may not be one of the Great Twelve livery companies, but they are the oldest company in the city. Your family pays the £5 entry fee and you move into your new $masterTitle&#39;s household to &lt;&lt;storyline-return &quot;begin learning the trade.&quot; 0 -1200 1&gt;&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
 &lt;&lt;/if&gt;&gt;
 
 &lt;&lt;if $money gte 2400 and $reputation gt 4 and $gender is &quot;male&quot;&gt;&gt;
 &lt;li&gt;&lt;&lt;link &quot;draper (£10 entry fee)&quot;&gt;&gt;&lt;&lt;replace &quot;#apprentice-offer&quot;&gt;&gt;
 &lt;&lt;set $apprenticeship to 3&gt;&gt;&lt;&lt;addMaster &quot;merchants&quot;&gt;&gt;
-&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Apprenticed as a draper&quot;, money: -2400, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: null})&gt;&gt;The drapers are one of the Great Twelve livery companies and you are eager to be apprenticed in a trade that will set you on a path to success within the city. Your family pays the £10 entry fee and you move into your new $masterTitle&#39;s household to &lt;&lt;storyline-return &quot;begin learning the trade.&quot; 1 -2400 1&gt;&gt;
+&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Apprenticed as a draper&quot;, money: -2400, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: null})&gt;&gt;The drapers are one of the Great Twelve livery companies and you are eager to be apprenticed in a trade that will set you on a path to success within the city. Your family pays the £10 entry fee and you move into your new $masterTitle&#39;s household to &lt;&lt;storyline-return &quot;begin learning the trade.&quot; 0 -2400 1&gt;&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
 &lt;&lt;/if&gt;&gt;
 
 &lt;&lt;if $money gte 6000 and $reputation gt 5 and $gender is &quot;male&quot;&gt;&gt;
 &lt;li&gt;&lt;&lt;link &quot;mercer (£25 entry fee)&quot;&gt;&gt;&lt;&lt;replace &quot;#apprentice-offer&quot;&gt;&gt;
-&lt;&lt;set $apprenticeship to 4&gt;&gt;&lt;&lt;addMaster &quot;merchants&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Apprenticed as a mercer&quot;, money: -6000, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: null})&gt;&gt;Although £25 is a substantial investment, the mercers are the most prestigious and powerful of the Great Twelve livery companies and apprenticing with one is sure to guarantee your future success. You are eager to move into your new $masterTitle&#39;s household to &lt;&lt;storyline-return &quot;begin learning the trade.&quot; 1 -6000 1&gt;&gt;
+&lt;&lt;set $apprenticeship to 4&gt;&gt;&lt;&lt;addMaster &quot;merchants&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Apprenticed as a mercer&quot;, money: -6000, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: null})&gt;&gt;Although £25 is a substantial investment, the mercers are the most prestigious and powerful of the Great Twelve livery companies and apprenticing with one is sure to guarantee your future success. You are eager to move into your new $masterTitle&#39;s household to &lt;&lt;storyline-return &quot;begin learning the trade.&quot; 0 -6000 1&gt;&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
 &lt;&lt;/if&gt;&gt;
 
 &lt;&lt;if $money gte 12000 and $reputation gt 6 and $gender is &quot;male&quot;&gt;&gt;
 &lt;li&gt;&lt;&lt;link &quot;goldsmith (£50 entry fee)&quot;&gt;&gt;&lt;&lt;replace &quot;#apprentice-offer&quot;&gt;&gt;
 &lt;&lt;set $apprenticeship to 5&gt;&gt;&lt;&lt;addMaster &quot;merchants&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Apprenticed as a goldsmith&quot;, money: -12000, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: null})&gt;&gt;
-Although £50 is a small fortune, the goldsmiths are some of the wealthiest and most powerful people in the city. Not only are you apprenticing to one of the Great Twelve livery companies, but you are guaranteeing yourself a lifetime of elite customers and social connections. You are eager to move into your new $masterTitle&#39;s household to &lt;&lt;storyline-return &quot;begin learning the trade.&quot; 1 -12000 1&gt;&gt;
+Although £50 is a small fortune, the goldsmiths are some of the wealthiest and most powerful people in the city. Not only are you apprenticing to one of the Great Twelve livery companies, but you are guaranteeing yourself a lifetime of elite customers and social connections. You are eager to move into your new $masterTitle&#39;s household to &lt;&lt;storyline-return &quot;begin learning the trade.&quot; 0 -12000 1&gt;&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
 &lt;&lt;/if&gt;&gt;
 
-&lt;li&gt;&lt;&lt;link &quot;no one for now&quot;&gt;&gt;&lt;&lt;replace &quot;#apprentice-offer&quot;&gt;&gt;You decide that the moment isn&#39;t right to pay for an apprenticeship and move in with a new master, but your &lt;&lt;storyline-return &quot;search will continue.&quot;&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
+&lt;li&gt;&lt;&lt;link &quot;no one for now&quot;&gt;&gt;&lt;&lt;replace &quot;#apprentice-offer&quot;&gt;&gt;You decide that the moment isn&#39;t right to pay for an apprenticeship and move in with a new master, but your &lt;&lt;storyline-return &quot;search will continue.&quot; 0&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;
 &lt;/ul&gt;
 &lt;/span&gt;
 &lt;&lt;/if&gt;&gt;

--- a/variables.md
+++ b/variables.md
@@ -489,6 +489,13 @@ This document lists all global (story) variables used in **Gaming the Great Plag
 - **Used for:** Tracks whether the player has already been presented with the marriage or apprenticeship choice, preventing the question from being asked again. Value `2` also gates out the marriage-market widget for characters who chose the apprenticeship path.
 - **Dependency:** Checked in January 1665 (pid 9) to determine which widget to show
 
+### `$randomEventCompleted`
+- **Type:** Boolean
+- **Possible values:** `true`, `false`
+- **Set by:** `false` in StoryInit; set to `true` inside `<<storyline-return>>` widget (pid 41) when the time offset is 0 (i.e., the player is returning to the same storyline passage); reset to `false` at the top of `<<random-events>>` widget (pid 113) on reload
+- **Used for:** Guards against re-running the entire `<<random-events>>` widget body when a player returns to a storyline passage after completing a random event. When true, random-events skips all logic (pregnancy tracking, NPC death, priority cascade) and sets `_randomEventFired` to false so the passage's monthly narrative renders.
+- **Dependency:** Works with `<<storyline-return>>` (pid 41) and `<<random-events>>` (pid 113)
+
 ### `$seekingApprenticeship`
 - **Type:** Integer (boolean-like)
 - **Possible values:** `0` (not seeking), `1` (seeking an apprenticeship)


### PR DESCRIPTION
…ces — bump to v3.17

Random events now return the player to the same storyline passage (offset 0) instead of advancing to the next month, so they see the monthly narrative after completing the event. A $randomEventCompleted guard variable prevents the random-events widget from re-running on reload.

Exception events (sickPC, sickFam, sickOtherHH, steward, player death) keep their existing navigation behavior.

Funeral-choice rewritten: NPC-death now collects all dead NPCs into a _deadNPCs array and presents one combined "quick burial / proper funeral" choice for the entire month rather than per-NPC choices.

Modified passages: 10, 13, 41, 92, 97, 100, 101, 103, 105, 108, 109, 110, 113, 122.

https://claude.ai/code/session_016EBEkX9a6ZDXiRj7K1V56d