### PR TITLE
Fix navy-volunteer quote typo and add pregnancy tracking to storyline…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v3.22" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v3.23" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -3281,6 +3281,11 @@ As morning dawns, a terrible realization settles over your &lt;&lt;defHousehold 
 			&lt;&lt;set $plagueInfection to 1&gt;&gt;
 		&lt;&lt;/if&gt;&gt;
 	&lt;&lt;/if&gt;&gt;
+	/* Advance pregnancy for skipped months (random-events handles 1 month on landing) */
+	&lt;&lt;if $pregnant gt 0 and _timeOffset gt 1&gt;&gt;
+		&lt;&lt;set _pregCap to ($pregnant lt 4) ? 3 : 8&gt;&gt;
+		&lt;&lt;set $pregnant to Math.min($pregnant + _timeOffset - 1, _pregCap)&gt;&gt;
+	&lt;&lt;/if&gt;&gt;
 	&lt;&lt;if _timeOffset is 0&gt;&gt;
 		&lt;&lt;set $randomEventCompleted to true&gt;&gt;
 	&lt;&lt;/if&gt;&gt;
@@ -5565,7 +5570,7 @@ At least you didn&#39;t die of plague.&lt;br&gt;&lt;br&gt;
 &lt;&lt;set $death to random(1,10)&gt;&gt;
 &lt;&lt;set $discovery to random(1,10)&gt;&gt;
 &lt;&lt;if $discovery is 1 and $agenum lte 15&gt;&gt;When you show up to board your ship, the captain instantly realizes you are &lt;&lt;linkappend &quot;too young to volunteer.&quot;&gt;&gt;too young to volunteer. You are scolded and &lt;&lt;storyline-return &quot;sent home to your parents.&quot; 1 0 -1&gt;&gt;&lt;&lt;/linkappend&gt;&gt;
-    &lt;&lt;elseif $discovery is 1 and $agenum gte 55&gt;&gt;When you show up to board your ship, the captain instantly realizes you are &lt;&lt;linkappend &quot;too old to volunteer.&gt;&gt;too old to volunteer. He thanks you for volunteering but firmly refuses to let you board and &lt;&lt;storyline-return &quot;sails away without you.&quot; 1 0 1&gt;&gt;&lt;&lt;/linkappend&gt;&gt;
+    &lt;&lt;elseif $discovery is 1 and $agenum gte 55&gt;&gt;When you show up to board your ship, the captain instantly realizes you are &lt;&lt;linkappend &quot;too old to volunteer.&quot;&gt;&gt;too old to volunteer. He thanks you for volunteering but firmly refuses to let you board and &lt;&lt;storyline-return &quot;sails away without you.&quot; 1 0 1&gt;&gt;&lt;&lt;/linkappend&gt;&gt;
     &lt;&lt;elseif $discovery is 1 and $gender is &quot;female&quot;&gt;&gt;When you show up to board your ship, the captain instantly &lt;&lt;linkappend &quot;realizes you are female.&quot;&gt;&gt;realizes you are female. He has you cast back onto the dock while everyone &lt;&lt;storyline-return &quot;stops to watch and gossip about you.&quot; 1 0 -1&gt;&gt;&lt;&lt;/linkappend&gt;&gt;
     &lt;&lt;else&gt;&gt;
 &lt;&lt;income&gt;&gt;&lt;&lt;income&gt;&gt; /* sign-up bonus of 2 months income */


### PR DESCRIPTION
…-return — bump to v3.23

- Fixed missing closing quote in navy-volunteer linkappend for "too old" branch (pid 102)
- Added pregnancy increment logic to storyline-return widget (pid 41) for multi-month advances: when _timeOffset > 1, $pregnant now advances for skipped months, capped before milestone values (4 and 9) so random-events can still trigger announcements/births

https://claude.ai/code/session_0184DW6HRXrgHQh1mBhZ9Pkn