### PR TITLE
Fix stats visualizations by using @ attribute directives — bump to v3.25

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v3.24" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v3.25" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -6497,9 +6497,9 @@ You quickly baptize them&lt;&lt;set $money -=6&gt;&gt; and pray to God that $NPC
 &lt;&lt;set _dH to (_decPct[_i] / _chartMax) * 200&gt;&gt;
 &lt;&lt;set _barW to &quot;calc((100% - &quot; + (_visCount * 2) + &quot;px) / &quot; + _visCount + &quot;)&quot;&gt;&gt;
 &lt;div style=&quot;flex: 1; display: flex; flex-direction: column; justify-content: flex-end; min-width: 0;&quot;&gt;
-&lt;&lt;if _decPct[_i] gt 0&gt;&gt;&lt;div title=&quot;&lt;&lt;print _shortLabels[_i]&gt;&gt; decisions: &lt;&lt;print _decPct[_i]&gt;&gt;%&quot; style=&quot;height: &lt;&lt;print _dH&gt;&gt;px; background: #DAA520; min-height: 1px;&quot;&gt;&lt;/div&gt;&lt;&lt;/if&gt;&gt;
-&lt;&lt;if _rolePct[_i] gt 0&gt;&gt;&lt;div title=&quot;&lt;&lt;print _shortLabels[_i]&gt;&gt; role: &lt;&lt;print _rolePct[_i]&gt;&gt;%&quot; style=&quot;height: &lt;&lt;print _rH&gt;&gt;px; background: #B22222; min-height: 1px;&quot;&gt;&lt;/div&gt;&lt;&lt;/if&gt;&gt;
-&lt;&lt;if _parishPct[_i] gt 0&gt;&gt;&lt;div title=&quot;&lt;&lt;print _shortLabels[_i]&gt;&gt; parish: &lt;&lt;print (Math.round(_parishPct[_i] * 10) / 10)&gt;&gt;%&quot; style=&quot;height: &lt;&lt;print _pH&gt;&gt;px; background: #8B7355; min-height: 1px;&quot;&gt;&lt;/div&gt;&lt;&lt;else&gt;&gt;&lt;div style=&quot;height: 0;&quot;&gt;&lt;/div&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if _decPct[_i] gt 0&gt;&gt;&lt;div @title=&quot;_shortLabels[_i] + &#39; decisions: &#39; + _decPct[_i] + &#39;%&#39;&quot; @style=&quot;&#39;height: &#39; + _dH + &#39;px; background: #DAA520; min-height: 1px;&#39;&quot;&gt;&lt;/div&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if _rolePct[_i] gt 0&gt;&gt;&lt;div @title=&quot;_shortLabels[_i] + &#39; role: &#39; + _rolePct[_i] + &#39;%&#39;&quot; @style=&quot;&#39;height: &#39; + _rH + &#39;px; background: #B22222; min-height: 1px;&#39;&quot;&gt;&lt;/div&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if _parishPct[_i] gt 0&gt;&gt;&lt;div @title=&quot;_shortLabels[_i] + &#39; parish: &#39; + (Math.round(_parishPct[_i] * 10) / 10) + &#39;%&#39;&quot; @style=&quot;&#39;height: &#39; + _pH + &#39;px; background: #8B7355; min-height: 1px;&#39;&quot;&gt;&lt;/div&gt;&lt;&lt;else&gt;&gt;&lt;div style=&quot;height: 0;&quot;&gt;&lt;/div&gt;&lt;&lt;/if&gt;&gt;
 &lt;/div&gt;
 &lt;&lt;/for&gt;&gt;
 &lt;/div&gt;
@@ -6525,9 +6525,9 @@ You quickly baptize them&lt;&lt;set $money -=6&gt;&gt; and pray to God that $NPC
 
 &lt;div style=&quot;width: 100%; max-width: 600px; margin: 0 auto;&quot;&gt;
 &lt;div style=&quot;position: relative; height: 32px; background: #333; border: 1px solid #555; border-radius: 4px; overflow: hidden;&quot;&gt;
-&lt;&lt;if _cumParish gt 0&gt;&gt;&lt;div title=&quot;Parish risk: &lt;&lt;print _cumParish&gt;&gt;%&quot; style=&quot;display: inline-block; height: 100%; width: &lt;&lt;print _cumParish&gt;&gt;%; background: #8B7355; float: left;&quot;&gt;&lt;/div&gt;&lt;&lt;/if&gt;&gt;
-&lt;&lt;if _cumRole gt 0&gt;&gt;&lt;div title=&quot;Role risk: +&lt;&lt;print _cumRole&gt;&gt;%&quot; style=&quot;display: inline-block; height: 100%; width: &lt;&lt;print _cumRole&gt;&gt;%; background: #B22222; float: left;&quot;&gt;&lt;/div&gt;&lt;&lt;/if&gt;&gt;
-&lt;&lt;if _cumDec gt 0&gt;&gt;&lt;div title=&quot;Decision risk: +&lt;&lt;print _cumDec&gt;&gt;%&quot; style=&quot;display: inline-block; height: 100%; width: &lt;&lt;print _cumDec&gt;&gt;%; background: #DAA520; float: left;&quot;&gt;&lt;/div&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if _cumParish gt 0&gt;&gt;&lt;div @title=&quot;&#39;Parish risk: &#39; + _cumParish + &#39;%&#39;&quot; @style=&quot;&#39;display: inline-block; height: 100%; width: &#39; + _cumParish + &#39;%; background: #8B7355; float: left;&#39;&quot;&gt;&lt;/div&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if _cumRole gt 0&gt;&gt;&lt;div @title=&quot;&#39;Role risk: +&#39; + _cumRole + &#39;%&#39;&quot; @style=&quot;&#39;display: inline-block; height: 100%; width: &#39; + _cumRole + &#39;%; background: #B22222; float: left;&#39;&quot;&gt;&lt;/div&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if _cumDec gt 0&gt;&gt;&lt;div @title=&quot;&#39;Decision risk: +&#39; + _cumDec + &#39;%&#39;&quot; @style=&quot;&#39;display: inline-block; height: 100%; width: &#39; + _cumDec + &#39;%; background: #DAA520; float: left;&#39;&quot;&gt;&lt;/div&gt;&lt;&lt;/if&gt;&gt;
 &lt;/div&gt;
 
 /* ── Tick marks ── */


### PR DESCRIPTION
The bar chart and cumulative risk thermometer in the final stats passage were not displaying any data because <<print>> macros were used inside HTML tag attributes (style, title). SugarCube does not process macros within HTML attributes — they are treated as literal text, producing invalid CSS values like "height: <<print _pH>>px".

Replaced all <<print>> calls in attributes with SugarCube's @ attribute directive syntax (e.g., @style="'height: ' + _pH + 'px; ...'"), which evaluates JavaScript expressions for attribute values.

Modified passage: pid 114 (Claude-widgets)

https://claude.ai/code/session_01EwERhqx35Nr5Ya6LV1Beag