### PR TITLE
Fix March 1666 stray <</if>> and funeral-choice undefined _deadNPCs —…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v3.26" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v3.27" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -1796,7 +1796,13 @@ On Christmas Eve, you see a comet in the sky and you wonder if it is [[a sign of
 //Great Comet of 1665//
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;&lt;&lt;/linkappend&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="13" name="NPC-funeral widget" tags="widget" position="275,725" size="100,100">&lt;&lt;widget &quot;funeral-choice&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
-/* Expects _deadNPCs: array of {npc, label} objects where label is e.g. &quot;your daughter&quot; or &quot;your servant&quot; */
+/* Accepts either a pre-set _deadNPCs array or a single NPC argument */
+&lt;&lt;if ndef _deadNPCs&gt;&gt;
+&lt;&lt;set _deadNPCs to []&gt;&gt;
+&lt;&lt;if _args.length gt 0&gt;&gt;
+&lt;&lt;set _deadNPCs.push({npc: _args[0], label: &quot;your &quot; + _args[0].relationship})&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
 &lt;&lt;if _deadNPCs.length gt 0&gt;&gt;
 &lt;&lt;set _npcDeathOccurred to true&gt;&gt;
 
@@ -2436,7 +2442,6 @@ The Queen of Portugal, mother to England&#39;s beloved &lt;&lt;defQueenCatherine
 &lt;br&gt;
 &lt;span id=&quot;pray&quot;&gt;Do you go to church and &lt;&lt;if $religion is &quot;Catholic&quot;&gt;&gt;light a candle&lt;&lt;else&gt;&gt;pray&lt;&lt;/if&gt;&gt; for the queen?&lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#pray&quot;&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Mar 1666: Went to church to pray for the Queen of Portugal&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;You go to church and &lt;&lt;if $religion is &quot;Catholic&quot;&gt;&gt;light a candle&lt;&lt;else&gt;&gt;pray&lt;&lt;/if&gt;&gt; for the late queen.&lt;&lt;march-1666-helper&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#pray&quot;&gt;&gt;You don&#39;t want to risk going to church, but you privately do pray that God shows mercy on her &lt;&lt;if $religion isnot &quot;Catholic&quot;&gt;&gt;&lt;&lt;defPapists &quot;papist&quot;&gt;&gt;&lt;&lt;/if&gt;&gt;soul. &lt;&lt;march-1666-helper&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Mar 1666: Prayed privately for the Queen of Portugal&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
-&lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="26" name="April 1666" tags="storyline 1666" position="1075,925" size="100,100">&lt;&lt;nobr&gt;&gt;


### PR DESCRIPTION
… bump to v3.27

- March 1666 (pid 25): Removed extra <</if>> that had no matching <<if>>, causing "child tag <</if>> was found outside of a call to its parent macro"
- funeral-choice widget (pid 13): Added guard to construct _deadNPCs from widget arguments when not pre-set by caller. Fixes the "undefined is not an object (evaluating 'State.temporary.deadNPCs.length')" error when the widget is called from Reconnecting with a single NPC argument.

https://claude.ai/code/session_01TBphF8aJaV3BhDJ7zuTsXh