### PR TITLE
Add alt-text to all game images — bump to v3.31

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v3.30" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v3.31" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -1298,7 +1298,7 @@ But enough about the king! What about you?
 
 Either [[create your character-&gt;identity]] or [[automatically generate a character-&gt;bio]].
 
-&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/4/48/Claude_de_Jongh_-_View_of_London_Bridge_-_Google_Art_Project_bridge.jpg&quot; width=&quot;100%&quot;&gt;
+&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/4/48/Claude_de_Jongh_-_View_of_London_Bridge_-_Google_Art_Project_bridge.jpg&quot; width=&quot;100%&quot; alt=&quot;Painting of London Bridge lined with buildings spanning the River Thames&quot;&gt;
 //Claude de Jongh - &quot;View of London Bridge,&quot; 1632.//</tw-passagedata><tw-passagedata pid="4" name="identity" tags="" position="1225,200" size="100,100">&lt;&lt;chunkText&gt;&gt;While infant mortality is common in this era, God granted your parents a healthy &lt;&lt;set $birthgender = [&quot;daughter&quot;,&quot;son&quot;]&gt;&gt;&lt;&lt;listbox &quot;$birthgender&quot;&gt;&gt;&lt;&lt;optionsfrom $birthgender&gt;&gt;&lt;&lt;/listbox&gt;&gt; who not only survived but thrived and you are now a &lt;&lt;set _age = [&quot;child&quot;, &quot;adolescent&quot;, &quot;young adult&quot;, &quot;middle-aged adult&quot;, &quot;elderly adult&quot;]&gt;&gt;&lt;&lt;listbox &quot;$age&quot;&gt;&gt;&lt;&lt;optionsfrom _age&gt;&gt;&lt;&lt;/listbox&gt;&gt;.
 
 &lt;&lt;next&gt;&gt;&lt;&lt;playerAge&gt;&gt;&lt;&lt;if $agenum lte 15&gt;&gt;While the rich and powerful might get &lt;&lt;defBetrothed &quot;betrothed&quot;&gt;&gt; as children and marry as teenagers, most people wait until their mid or late 20s when they have enough wealth to establish their own &lt;&lt;defHousehold &quot;households&quot;&gt;&gt;. You are currently &lt;&lt;set _relationship = [&quot;single&quot;, &quot;betrothed&quot;]&gt;&gt;&lt;&lt;listbox &quot;$relationship&quot;&gt;&gt;&lt;&lt;optionsfrom _relationship&gt;&gt;&lt;&lt;/listbox&gt;&gt;.&lt;&lt;else&gt;&gt;Most people get married in their mid or late 20s to start a family, and those who are widowed often remarry as well. You are currently &lt;&lt;set _relationship = [&quot;single&quot;, &quot;married&quot;, &quot;widowed&quot;]&gt;&gt;&lt;&lt;listbox &quot;$relationship&quot;&gt;&gt;&lt;&lt;optionsfrom _relationship&gt;&gt;&lt;&lt;/listbox&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if $birthgender is &quot;son&quot;&gt;&gt;&lt;&lt;set $gender to &quot;male&quot;&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $gender to &quot;female&quot;&gt;&gt;&lt;&lt;/if&gt;&gt;
@@ -1311,7 +1311,7 @@ It&#39;s a great city for &lt;&lt;set _socio = [&quot;day labourers&quot;, &quot
 
 Your home is &lt;&lt;set _location = [&quot;inside the City walls&quot;, &quot;in the western suburbs, specifically Westminster&quot;, &quot;in another part of the western suburbs&quot;, &quot;in the northern suburbs&quot;, &quot;in the eastern suburbs&quot;, &quot;across the river in the southern suburbs&quot;]&gt;&gt;&lt;&lt;listbox &quot;$location&quot;&gt;&gt;&lt;&lt;optionsfrom _location&gt;&gt;&lt;&lt;/listbox&gt;&gt;.
 &lt;br&gt;
-&lt;img src=&quot;https://wesleyan-dac-open-access.s3.amazonaws.com/images/DAC_1940-D1-131_001_OA.jpg&quot; width=&quot;100%&quot;&gt;
+&lt;img src=&quot;https://wesleyan-dac-open-access.s3.amazonaws.com/images/DAC_1940-D1-131_001_OA.jpg&quot; width=&quot;100%&quot; alt=&quot;Panoramic map of London showing the city and River Thames&quot;&gt;
 //Map of London, before the Fire of 1666 by Wencelaus Holler. Wesleyan University Davison Art Center.//
 &lt;&lt;/chunkText&gt;&gt;</tw-passagedata><tw-passagedata pid="5" name="death" tags="infection-rates" position="500,750" size="100,100">&lt;&lt;nobr&gt;&gt;
 Send not to know for whom the church bells toll. They toll for you.
@@ -1352,7 +1352,7 @@ Your neighbors shut up the entrances to your house and paint a red cross with th
   &lt;&lt;case 3&gt;&gt;
     &lt;&lt;link &quot;Unfortunately, your fever spikes, you grow weak, and you fear for your life.&quot; `passage()`&gt;&gt;&lt;&lt;/link&gt;&gt;
 &lt;br&gt;&lt;br&gt;
-&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/c/cb/Two_holy_men_lie_side_by_side_affected_by_the_plague_Wellcome_L0073320.jpg&quot; width=&quot;100%&quot;&gt;
+&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/c/cb/Two_holy_men_lie_side_by_side_affected_by_the_plague_Wellcome_L0073320.jpg&quot; width=&quot;100%&quot; alt=&quot;Drawing of two men lying side by side affected by the plague&quot;&gt;
 //Italian drawing of two men who lie side by side affected by the plague, c. 17th century. Wellcome Images//
 &lt;br&gt;
   &lt;&lt;case 4&gt;&gt;
@@ -1487,10 +1487,10 @@ The &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; has even followed the King&#39;
 &lt;br&gt;
 &lt;br&gt;
 A man offers you a groat to take his wife away without letting her corpse be examined by a searcher first. Do you take the bribe? &lt;span id=&quot;cb-bribe&quot;&gt;
-&lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#cb-bribe&quot;&gt;&gt;With so many dying, it seems pointless to force the few survivors into quarantine. For all you know, the poor woman just died of spotted fever. All the same, you take care &lt;&lt;storyline-return &quot;not to examine the corpse too carefully.&quot; 1 4 -2&gt;&gt;&lt;br&gt;&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/7/7a/Wilson_%22The_plague...%22%3B_a_corpses_bearer_Wellcome_L0016624.jpg&quot; width=&quot;100%&quot;&gt;
+&lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#cb-bribe&quot;&gt;&gt;With so many dying, it seems pointless to force the few survivors into quarantine. For all you know, the poor woman just died of spotted fever. All the same, you take care &lt;&lt;storyline-return &quot;not to examine the corpse too carefully.&quot; 1 4 -2&gt;&gt;&lt;br&gt;&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/7/7a/Wilson_%22The_plague...%22%3B_a_corpses_bearer_Wellcome_L0016624.jpg&quot; width=&quot;100%&quot; alt=&quot;Engraving of a corpse bearer carrying away the dead&quot;&gt;
 //Printed by R. Price, A corpse bearer; reproduction of an engraving from a series of London Cries, 1655. Wellcome Images//
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;
-| &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#cb-bribe&quot;&gt;&gt;You insist on waiting for the searcher to examine the corpse and consider reporting the man to your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; clerk, but decide that it was merely his grief speaking rather than an attempt to avoid being quarantined. After the searcher diagnoses the woman as dead from spotted fever, &lt;&lt;storyline-return &quot;you take her corpse away.&quot; 1 0 1&gt;&gt;&lt;br&gt;&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/7/7a/Wilson_%22The_plague...%22%3B_a_corpses_bearer_Wellcome_L0016624.jpg&quot; width=&quot;100%&quot;&gt;
+| &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#cb-bribe&quot;&gt;&gt;You insist on waiting for the searcher to examine the corpse and consider reporting the man to your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; clerk, but decide that it was merely his grief speaking rather than an attempt to avoid being quarantined. After the searcher diagnoses the woman as dead from spotted fever, &lt;&lt;storyline-return &quot;you take her corpse away.&quot; 1 0 1&gt;&gt;&lt;br&gt;&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/7/7a/Wilson_%22The_plague...%22%3B_a_corpses_bearer_Wellcome_L0016624.jpg&quot; width=&quot;100%&quot; alt=&quot;Engraving of a corpse bearer carrying away the dead&quot;&gt;
 //Printed by R. Price, A corpse bearer; reproduction of an engraving from a series of London Cries, 1655. Wellcome Images//&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 
 &lt;&lt;elseif $role is &quot;warder&quot;&gt;&gt;You stand watch outside shut up houses to ensure that no one tries to escape. Listening to the pleas of those locked inside with the sick and dying is bad enough. But the worst is when the houses go silent.
@@ -1498,27 +1498,27 @@ A man offers you a groat to take his wife away without letting her corpse be exa
 
 &lt;br&gt;
 One night, a pair of men approach and offer you a groat to look the other way while they remove something from the house. Do you take the bribe? &lt;span id=&quot;wd-bribe&quot;&gt;
-&lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#wd-bribe&quot;&gt;&gt;With so many dying, it seems pointless to pretend that shutting up the houses will stop the spread of plague. You say nothing as a woman inside the house lowers a small child out the window and into the arms of the waiting men. As they spirit the child away, you &lt;&lt;storyline-return &quot;wonder if any of them will survive.&quot; 1 4 -2&gt;&gt;&lt;br&gt;&lt;img src=&quot;https://iiif.wellcomecollection.org/image/V0010606EL/full/1024%2C/0/default.jpg&quot; width=&quot;100%&quot;&gt;
+&lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#wd-bribe&quot;&gt;&gt;With so many dying, it seems pointless to pretend that shutting up the houses will stop the spread of plague. You say nothing as a woman inside the house lowers a small child out the window and into the arms of the waiting men. As they spirit the child away, you &lt;&lt;storyline-return &quot;wonder if any of them will survive.&quot; 1 4 -2&gt;&gt;&lt;br&gt;&lt;img src=&quot;https://iiif.wellcomecollection.org/image/V0010606EL/full/1024%2C/0/default.jpg&quot; width=&quot;100%&quot; alt=&quot;Engraving of a death cart in a London street during the plague&quot;&gt;
     //A death cart in a street in London during the great plague. Engraving by S. Davenport, 1835, after G. Cruikshank. Wellcome Collection//&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;
-| &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#wd-bribe&quot;&gt;&gt;You refuse to abandon your duty and the men slip away into the darkness. The next morning, when your replacement comes, you warn him about what happened and hope that he will be &lt;&lt;storyline-return &quot;as diligent as you were.&quot; 1 0 1&gt;&gt;&lt;br&gt;&lt;img src=&quot;https://iiif.wellcomecollection.org/image/V0010606EL/full/1024%2C/0/default.jpg&quot; width=&quot;100%&quot;&gt;
+| &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#wd-bribe&quot;&gt;&gt;You refuse to abandon your duty and the men slip away into the darkness. The next morning, when your replacement comes, you warn him about what happened and hope that he will be &lt;&lt;storyline-return &quot;as diligent as you were.&quot; 1 0 1&gt;&gt;&lt;br&gt;&lt;img src=&quot;https://iiif.wellcomecollection.org/image/V0010606EL/full/1024%2C/0/default.jpg&quot; width=&quot;100%&quot; alt=&quot;Engraving of a death cart in a London street during the plague&quot;&gt;
     //A death cart in a street in London during the great plague. Engraving by S. Davenport, 1835, after G. Cruikshank. Wellcome Collection//&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 
     &lt;&lt;elseif $role is &quot;searcher&quot;&gt;&gt;Day in and day out, you examine the corpses of people who have died. There are so many dead of &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; that it has become almost a joyful occasion when you find someone dead of a regular consumption or bad teeth.
     &lt;br&gt;
     &lt;br&gt;
 One day, a woman offers you a groat to say that her son died of spotted fever, despite the obvious tokens of &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; on the poor boy&#39;s body. Do you take the bribe? &lt;span id=&quot;bribe-yn&quot;&gt;
-&lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#bribe-yn&quot;&gt;&gt;With so many dying, it seems pointless to try to stop the spread of disease anymore. Besides, you&#39;ve always been troubled by the practice of shutting up the healthy alongside the sick, to later become infected and die themselves. What does it hurt to profit a little while &lt;&lt;storyline-return &quot;maybe saving a life?&quot; 1 4 -2&gt;&gt;&lt;br&gt;&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/6/67/Plague_in_1665_%28BM_1875%2C0508.1513%29.jpg&quot; width=&quot;100%&quot;&gt;//Nathaniel Parr, Three men loading plague victims from the street onto a cart to left, two of them smoking pipes to protect themselves, a figure with a bundle over his shoulder walking under an arch in the background to right; illustration to a &#39;History of England&#39;, c. 1747, published by Thomas Astley. British Museum.//
+&lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#bribe-yn&quot;&gt;&gt;With so many dying, it seems pointless to try to stop the spread of disease anymore. Besides, you&#39;ve always been troubled by the practice of shutting up the healthy alongside the sick, to later become infected and die themselves. What does it hurt to profit a little while &lt;&lt;storyline-return &quot;maybe saving a life?&quot; 1 4 -2&gt;&gt;&lt;br&gt;&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/6/67/Plague_in_1665_%28BM_1875%2C0508.1513%29.jpg&quot; width=&quot;100%&quot; alt=&quot;Engraving of men loading plague victims onto a cart&quot;&gt;//Nathaniel Parr, Three men loading plague victims from the street onto a cart to left, two of them smoking pipes to protect themselves, a figure with a bundle over his shoulder walking under an arch in the background to right; illustration to a &#39;History of England&#39;, c. 1747, published by Thomas Astley. British Museum.//
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;
-| &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#bribe-yn&quot;&gt;&gt;As distasteful as it is to be the one to declare a household has been stricken by plague, it is your duty to tell the truth as you see it. You report the plague death to your parish clerk and see to it that the woman and her household are &lt;&lt;storyline-return &quot;properly shut up.&quot; 1 0 1&gt;&gt;&lt;br&gt;&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/6/67/Plague_in_1665_%28BM_1875%2C0508.1513%29.jpg&quot; width=&quot;100%&quot;&gt;//Nathaniel Parr, Three men loading plague victims from the street onto a cart to left, two of them smoking pipes to protect themselves, a figure with a bundle over his shoulder walking under an arch in the background to right; illustration to a &#39;History of England&#39;, c. 1747, published by Thomas Astley. British Museum.//
+| &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#bribe-yn&quot;&gt;&gt;As distasteful as it is to be the one to declare a household has been stricken by plague, it is your duty to tell the truth as you see it. You report the plague death to your parish clerk and see to it that the woman and her household are &lt;&lt;storyline-return &quot;properly shut up.&quot; 1 0 1&gt;&gt;&lt;br&gt;&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/6/67/Plague_in_1665_%28BM_1875%2C0508.1513%29.jpg&quot; width=&quot;100%&quot; alt=&quot;Engraving of men loading plague victims onto a cart&quot;&gt;//Nathaniel Parr, Three men loading plague victims from the street onto a cart to left, two of them smoking pipes to protect themselves, a figure with a bundle over his shoulder walking under an arch in the background to right; illustration to a &#39;History of England&#39;, c. 1747, published by Thomas Astley. British Museum.//
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 
 &lt;&lt;elseif $role is &quot;nurse&quot;&gt;&gt;You fear death every day. You pray to God to protect you from harm and to gather up the souls of the innocent children you cannot save here on earth.
     &lt;br&gt;
     &lt;br&gt;
 One day, you are bringing food to a house that was shut up so recently that the quarantine cross painted on the door is still fresh. The woman inside thanks you for your help then offers you a groat to smuggle her baby out in your empty basket. Do you take the bribe? &lt;span id=&quot;ns-bribe&quot;&gt;
-&lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#ns-bribe&quot;&gt;&gt;The little boy is perfectly healthy and you can&#39;t bear to condemn him to being shut up to die. You tuck him into your basket and smuggle him out to his waiting aunt, who blesses you and promises to name her &lt;&lt;storyline-return &quot;next child in your honor.&quot; 1 4 -2&gt;&gt;&lt;br&gt;&lt;img src=&quot;https://iiif.wellcomecollection.org/image/V0010610/full/1024%2C/0/default.jpg&quot; width=&quot;100%&quot;&gt;
+&lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#ns-bribe&quot;&gt;&gt;The little boy is perfectly healthy and you can&#39;t bear to condemn him to being shut up to die. You tuck him into your basket and smuggle him out to his waiting aunt, who blesses you and promises to name her &lt;&lt;storyline-return &quot;next child in your honor.&quot; 1 4 -2&gt;&gt;&lt;br&gt;&lt;img src=&quot;https://iiif.wellcomecollection.org/image/V0010610/full/1024%2C/0/default.jpg&quot; width=&quot;100%&quot; alt=&quot;Etching of a man consuming antidotes to the plague&quot;&gt;
     //A man consuming many antidotes to the plague during the Great Plague of London. Etching by J. Franklin, 1841. Wellcome Collection//&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;
-| &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#ns-bribe&quot;&gt;&gt;It breaks your heart to say no, but you can&#39;t risk smuggling the little boy out of the house. What if he were to cry and you were to be discovered? Or worse, what if he is already harboring the plague and your attempts to save him only doom whatever family takes him in? You encourage her to put her faith in God and &lt;&lt;storyline-return &quot;hurry away.&quot; 1 0 1&gt;&gt;&lt;br&gt;&lt;img src=&quot;https://iiif.wellcomecollection.org/image/V0010610/full/1024%2C/0/default.jpg&quot; width=&quot;100%&quot;&gt;
+| &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#ns-bribe&quot;&gt;&gt;It breaks your heart to say no, but you can&#39;t risk smuggling the little boy out of the house. What if he were to cry and you were to be discovered? Or worse, what if he is already harboring the plague and your attempts to save him only doom whatever family takes him in? You encourage her to put her faith in God and &lt;&lt;storyline-return &quot;hurry away.&quot; 1 0 1&gt;&gt;&lt;br&gt;&lt;img src=&quot;https://iiif.wellcomecollection.org/image/V0010610/full/1024%2C/0/default.jpg&quot; width=&quot;100%&quot; alt=&quot;Etching of a man consuming antidotes to the plague&quot;&gt;
     //A man consuming many antidotes to the plague during the Great Plague of London. Etching by J. Franklin, 1841. Wellcome Collection//&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 &lt;&lt;else&gt;&gt;
 You are grateful to have survived long enough to see [[August 1665]].
@@ -1591,7 +1591,7 @@ You are not freezing or starving to death, even if you are always cold and hungr
 /* Noble Story */
 &lt;&lt;if $socio is &quot;nobles&quot;&gt;&gt;As &lt;&lt;if $agenum lte 15&gt;&gt;the child of &lt;&lt;/if&gt;&gt;a minor noble, you spend much of your time inside at the royal Court of King Charles II in hopes of securing more titles, honor, and riches for yourself and your family&lt;&lt;if $religion is &quot;Catholic&quot;&gt;&gt;, especially since &lt;&lt;defQueenCatherine &quot;Queen Catherine&quot;&gt;&gt; and the &lt;&lt;defQueenMother &quot;Queen Mother&quot;&gt;&gt; both share your &lt;&lt;defCatholic &quot;Catholic&quot;&gt;&gt; faith&lt;&lt;/if&gt;&gt;. You fill your days traveling among the royal family&#39;s various London palaces—including attending the &lt;&lt;defQueenMother &quot;Queen Mother&#39;s&quot;&gt;&gt; weekly social circle as faithfully as if it were church—and spending money on the latest fashions and trends. But you can’t help but worry about how the war will impact your life.
 &lt;br&gt;&lt;br&gt;
-&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/2/2d/Anthony_van_Dyck_-_Queen_Henrietta_Maria_of_England_-_KMSsp240_-_Statens_Museum_for_Kunst.jpg&quot; width=&quot;100%&quot;&gt;
+&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/2/2d/Anthony_van_Dyck_-_Queen_Henrietta_Maria_of_England_-_KMSsp240_-_Statens_Museum_for_Kunst.jpg&quot; width=&quot;100%&quot; alt=&quot;Portrait of Queen Henrietta Maria of England&quot;&gt;
 &lt;br&gt;
 //Anthony van Dyck, Queen Henrietta Maria of England, c. 1614-1641.//
 &lt;&lt;/if&gt;&gt;
@@ -1788,14 +1788,14 @@ John: 1500, Thomas: 1300, William: 1300, Richard: 620, Robert: 600, Henry: 500, 
 &lt;br&gt;&lt;br&gt;
 On Christmas Eve, you see a comet in the sky and you wonder if it is [[a sign of good things to come-&gt;January 1665]].
 &lt;br&gt;&lt;br&gt;
-&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/6/6c/Comet_1665.png&quot; width=&quot;100%&quot;&gt;
+&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/6/6c/Comet_1665.png&quot; width=&quot;100%&quot; alt=&quot;Illustration of a comet streaking across the night sky&quot;&gt;
 //Great Comet of 1665//
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;
 &lt;&lt;replace &quot;#decision&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Dec 1664: Skipped the Christmas feast to save money&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;if $hoh is 4&gt;&gt;You convince your husband&lt;&lt;elseif $hoh is 3 or ($hoh is 0 and $socio is &quot;servants&quot;)&gt;&gt;You convince your $masterTitle&lt;&lt;elseif $hoh isnot 1&gt;&gt;You convince your family&lt;&lt;else&gt;&gt;You decide&lt;&lt;/if&gt;&gt; to save money and forego a large feast for the holiday.
 &lt;br&gt;&lt;br&gt;
 On Christmas Eve, you see a comet in the sky and you wonder if it is [[a sign of good things to come-&gt;January 1665]].
 &lt;br&gt;&lt;br&gt;
-&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/6/6c/Comet_1665.png&quot; width=&quot;100%&quot;&gt;
+&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/6/6c/Comet_1665.png&quot; width=&quot;100%&quot; alt=&quot;Illustration of a comet streaking across the night sky&quot;&gt;
 //Great Comet of 1665//
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;&lt;&lt;/linkappend&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="13" name="NPC-funeral widget" tags="widget" position="275,725" size="100,100">&lt;&lt;widget &quot;funeral-choice&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
@@ -2234,7 +2234,7 @@ You &lt;span id=&quot;decision&quot;&gt;
         [[You know that plague only grows worse as the weather warms and you dread the coming of June and the first real heat of summer.-&gt;June 1665]]
             &lt;&lt;/if&gt;&gt;
       &lt;&lt;else&gt;&gt;&lt;&lt;linkappend &quot;Worse, the first case of plague has appeared in your parish.&quot;&gt;&gt;&lt;br&gt;&lt;br&gt;&lt;&lt;include &quot;First Plague Day&quot;&gt;&gt;&lt;&lt;/linkappend&gt;&gt;
-    &lt;&lt;/if&gt;&gt;&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/c/c4/Lord_haue_mercy_on_London.jpg&quot; width=&quot;100%&quot;&gt;
+    &lt;&lt;/if&gt;&gt;&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/c/c4/Lord_haue_mercy_on_London.jpg&quot; width=&quot;100%&quot; alt=&quot;Woodcut broadside depicting scenes of plague in London&quot;&gt;
 //Lord haue mercy on London, c. 1665.//&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;take their word for it.&quot;&gt;&gt;&lt;&lt;replace &quot;#decision&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;May 1665: Took their word about the plague&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;take their word for it and not investigate further.
     &lt;br&gt;
     &lt;&lt;if $location isnot &quot;in the western suburbs&quot;&gt;&gt;&lt;&lt;no-plague-yet&gt;&gt;&lt;br&gt;
@@ -2257,7 +2257,7 @@ You &lt;span id=&quot;decision&quot;&gt;
     &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#decision&quot;&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jun 1665: Sought out war news&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;
     You keep your ears open for news of the war. It takes almost a week, but news finally arrives of a great battle that killed many important men, especially on the ship of the &lt;&lt;defDukeOfYork &quot;Duke of York, James Stuart&quot;&gt;&gt;, the current heir to the throne—at least until the King and Queen manage to have children of their own. According to rumor, the battle came so close to killing the Duke that he was covered with blood and the head of a man named Mr. Boyle flew off and struck down the Duke. You happily repeat the rumors to anyone who will listen as bonfires break out in the street and people make merry, freely sharing their food and wine in celebration.
     &lt;br&gt;&lt;br&gt;
-&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/9/99/James_II_by_Peter_Lely.jpg&quot; width=&quot;100%&quot;&gt;
+&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/9/99/James_II_by_Peter_Lely.jpg&quot; width=&quot;100%&quot; alt=&quot;Portrait of James II, Duke of York&quot;&gt;
 &lt;br&gt;
 //Peter Lely, James II, c. 1650-1675//&lt;br&gt;&lt;br&gt;
 &lt;&lt;if $agenum gte 16 and $agenum lte 59 and $gender isnot &quot;female&quot; and $socio isnot &quot;nobles&quot; and $socio isnot &quot;merchants&quot;&gt;&gt;&lt;span id=&quot;volunteer&quot;&gt;Do you want to be there for the next battle?
@@ -2310,13 +2310,13 @@ You &lt;span id=&quot;decision&quot;&gt;
 People are dying so fast now that burials have to happen night and day to keep corpses from piling up throughout the city.&lt;br&gt;&lt;br&gt;
 So many people are sick and shut up in their houses that the city has imposed a 9pm curfew for healthy people, so that the sick can go out for a bit of air. &lt;span id=&quot;curfew&quot;&gt;Do you adhere to the curfew? &lt;&lt;link &quot;Yes, of course&quot;&gt;&gt;&lt;&lt;replace &quot;#curfew&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Aug 1665: Obeyed the curfew&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;You keep to the curfew. 
         &lt;br&gt;&lt;br&gt;
-       &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/1/1d/Nine_images_of_the_plague_in_London%2C_17th_century_Wellcome_L0016640_%28cropped%29_7.jpg&quot; width=&quot;100%&quot;&gt;
+       &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/1/1d/Nine_images_of_the_plague_in_London%2C_17th_century_Wellcome_L0016640_%28cropped%29_7.jpg&quot; width=&quot;100%&quot; alt=&quot;Engraving depicting scenes of plague in London&quot;&gt;
        //Nine images of the plague in London, 17th century, Wellcome Images.//
         &lt;br&gt;&lt;br&gt;
         &lt;&lt;august-1665-helper&gt;&gt; 
   &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No, I need to know more&quot;&gt;&gt;&lt;&lt;replace &quot;#curfew&quot;&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Aug 1665: Broke curfew to seek news&quot;, money: 0, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: _riskPct})&gt;&gt;You step out, despite the curfew, hoping to hear more news. You learn that there is sickness in the &lt;&lt;defFleet &quot;fleet&quot;&gt;&gt; and everyone worries what that means for the war.
       &lt;br&gt;&lt;br&gt;
-       &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/1/1d/Nine_images_of_the_plague_in_London%2C_17th_century_Wellcome_L0016640_%28cropped%29_7.jpg&quot; width=&quot;100%&quot;&gt;
+       &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/1/1d/Nine_images_of_the_plague_in_London%2C_17th_century_Wellcome_L0016640_%28cropped%29_7.jpg&quot; width=&quot;100%&quot; alt=&quot;Engraving depicting scenes of plague in London&quot;&gt;
        //Nine images of the plague in London, 17th century, Wellcome Images.//
         &lt;br&gt;&lt;br&gt;
         &lt;&lt;august-1665-helper&gt;&gt; 
@@ -2417,7 +2417,7 @@ After six months of travel, the king finally returns the Court to &lt;&lt;defHam
 
 &lt;&lt;else&gt;&gt;&lt;span id=&quot;help&quot;&gt;Do you offer to help any of your returning neighbors with their luggage? &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jan 1666: Helped returning neighbors&quot;, money: 0, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: _riskPct})&gt;&gt;&lt;&lt;replace &quot;#help&quot;&gt;&gt;You offer to help your returning neighbors carry some of their luggage. It is a good opportunity to catch up on all their news from their time in the country, and you are glad to talk to someone after the city has been so empty for so long. A bad storm blows down tiles from houses and shuts down &lt;&lt;defRiverTraffic &quot;river traffic&quot;&gt;&gt;, but all in all, it&#39;s a good month.&lt;br&gt;&lt;br&gt;You look forward to even better things in [[February 1666]].&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jan 1666: Did not help returning neighbors&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;replace &quot;#help&quot;&gt;&gt;You don&#39;t offer to help your returning neighbors, but you shout your greetings down to them, glad to see the city so lively again after it had been empty for so long. A bad storm blows down tiles from houses and shuts down &lt;&lt;defRiverTraffic &quot;river traffic&quot;&gt;&gt;, but all in all, it&#39;s a good month.&lt;br&gt;&lt;br&gt;You look forward to even better things in [[February 1666]].&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 &lt;&lt;/if&gt;&gt;
-&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/c/ca/London_welcomes_home_runaways_Wellcome_L0002722.jpg&quot; width=&quot;100%&quot;&gt;
+&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/c/ca/London_welcomes_home_runaways_Wellcome_L0002722.jpg&quot; width=&quot;100%&quot; alt=&quot;Woodcut of Londoners welcoming home those who fled the plague&quot;&gt;
 //Henry Petowe and Frank Percy Wilson, &quot;London welcomes home her runaways&quot;. Taken from a woodcut in Henry Petowe&#39;s:The Countrie Ague, 1625. Wellcome Images//
 
 &lt;&lt;/if&gt;&gt;
@@ -2513,7 +2513,7 @@ Those who remain in the city hear the sounds of another battle in the distance--
 &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#pray&quot;&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jul 1666: Prayed for London&#39;s safety&quot;, money: 0, repDelta: 1, repBefore: $reputation - 1, infectPct: _riskPct})&gt;&gt;You join your neighbors in prayer for the city&#39;s deliverance, finding comfort in shared devotion during these dark times. You wonder if you will make it to [[August 1666]].&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#pray&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jul 1666: Did not pray for London&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;You keep to yourself and hope for the best. You wonder if you will make it to [[August 1666]].&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 
 &lt;&lt;/if&gt;&gt;
-&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/3/34/St._James_Day_Fight%2C_Pic_1.jpg&quot; width=&quot;100%&quot;&gt;
+&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/3/34/St._James_Day_Fight%2C_Pic_1.jpg&quot; width=&quot;100%&quot; alt=&quot;Engraving of a naval battle between English and Dutch ships&quot;&gt;
 //By unknown Dutch artist, &quot;Zee-Slag tussen de Engelse en Nederlandtse Vloot, op den 4 Aug. 1666.&quot; Engraving showing the St. James&#39; Day Battle on August 4th, 1666 between English and Dutch ships//
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;fumigant&gt;&gt;
@@ -2573,7 +2573,7 @@ You ask around and discover the fire began in the King&#39;s Baker&#39;s house o
 &lt;&lt;if $preFireLocation neq &quot;&quot;&gt;&gt;Everyone is still reeling from the shock of the Great Fire at the beginning of [[October 1666]].&lt;&lt;/if&gt;&gt; 
 
 &lt;&lt;/if&gt;&gt;
-&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/b/b6/Great_Fire_London.jpg&quot; width=&quot;100%&quot;&gt;
+&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/b/b6/Great_Fire_London.jpg&quot; width=&quot;100%&quot; alt=&quot;Painting of the Great Fire of London engulfing the city&quot;&gt;
 //Josepha Jane Battlehooke, The Great Fire of London, 1675//
 &lt;&lt;fumigant&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="32" name="October 1666" tags="storyline 1666" position="1325,1075" size="100,100">&lt;&lt;nobr&gt;&gt;
@@ -2931,7 +2931,7 @@ It is a difficult decision, but &lt;&lt;set-caretaker&gt;&gt;&lt;&lt;if $hoh is 
 &lt;&lt;orphan-check&gt;&gt;
 &lt;&lt;storyline-return&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;
-&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/5/58/The_pest_house_and_plague_pit%2C_Moorfields%2C_London._Wellcome_V0013229.jpg&quot; width=&quot;100%&quot;&gt;
+&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/5/58/The_pest_house_and_plague_pit%2C_Moorfields%2C_London._Wellcome_V0013229.jpg&quot; width=&quot;100%&quot; alt=&quot;Wood engraving of the pest house and plague pit at Moorfields, London&quot;&gt;
 &lt;br&gt;
 //The pest house and &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; pit, Moorfields, London. Wood engraving. Wellcome Images.//
 </tw-passagedata><tw-passagedata pid="40" name="sick-fam-widget" tags="widget infection-rates" position="25,325" size="100,100">&lt;&lt;widget &quot;sickFam&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
@@ -3330,7 +3330,7 @@ The &lt;&lt;defPesthouse &quot;pesthouse&quot;&gt;&gt; is a terrible place to be
 &lt;&lt;if $socio is &quot;merchants&quot;&gt;&gt;It occurs to you that perhaps you ought to have written your will, but your reputation is so poor and the pesthouse is so terrifying that no one can be convinced to bring you the writing materials you need.&lt;br&gt;&lt;br&gt;&lt;&lt;elseif $socio is &quot;artisans&quot;&gt;&gt;It occurs to you that perhaps you ought to have written your will, but your reputation is so poor and the pesthouse is so terrifying that you can&#39;t convince a &lt;&lt;defScrivener &quot;scrivener&quot;&gt;&gt; to come help you.&lt;br&gt;&lt;br&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;if random(1,2) is 1&gt;&gt;Luckily, you will grow too delirious to notice how miserable you are in the hours before your [[death]].&lt;&lt;else&gt;&gt;You spend all your remaining energy in prayer that God will spare you from death. &lt;&lt;set $playerPlagueStatus to &quot;recovered&quot;&gt;&gt;Despite the neglect of the overworked pesthouse staff, after a few days you feel your fever break and your &lt;&lt;defBuboes &quot;buboes&quot;&gt;&gt; begin to go down. Thanks be to God, you have survived the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt;.
 &lt;br&gt;&lt;br&gt;
-&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/5/58/The_pest_house_and_plague_pit%2C_Moorfields%2C_London._Wellcome_V0013229.jpg&quot; width=&quot;100%&quot;&gt;
+&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/5/58/The_pest_house_and_plague_pit%2C_Moorfields%2C_London._Wellcome_V0013229.jpg&quot; width=&quot;100%&quot; alt=&quot;Wood engraving of the pest house and plague pit at Moorfields, London&quot;&gt;
 &lt;br&gt;
 //The pest house and plague pit, Moorfields, London. Wood engraving. Wellcome Images.//
 &lt;br&gt;&lt;br&gt;
@@ -3458,14 +3458,14 @@ One of your neighbors &lt;&lt;if $reputation gte 6&gt;&gt;provides you with left
     &lt;&lt;if $disability is 0 and $religion isnot &quot;Catholic&quot; and $skipServices isnot 1 and $agenum gt 16&gt;&gt; and the &lt;&lt;defOverseersOfThePoor &quot;Overseers of the Poor&quot;&gt;&gt; have decided it will be your job to
         &lt;&lt;if $reputation gte 6&gt;&gt;&lt;&lt;if $gender is &quot;female&quot;&gt;&gt;&lt;&lt;set $role to &quot;searcher&quot;&gt;&gt;look at the corpses and determine if they died of &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; or some other cause of death
         &lt;br&gt;
-    &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/6/67/Plague_in_1665_%28BM_1875%2C0508.1513%29.jpg&quot; width=&quot;100%&quot;&gt;
+    &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/6/67/Plague_in_1665_%28BM_1875%2C0508.1513%29.jpg&quot; width=&quot;100%&quot; alt=&quot;Engraving of men loading plague victims onto a cart&quot;&gt;
     //Nathaniel Parr, published by Thomas Astley, Plague in 1665, 1747.//
         &lt;&lt;else&gt;&gt;&lt;&lt;set $role to &quot;warder&quot;&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation - 1, 0, 10)&gt;&gt;stand guard outside quarantined houses to prevent anyone from escaping
         &lt;&lt;/if&gt;&gt;
         &lt;&lt;else&gt;&gt;&lt;&lt;if $gender is &quot;female&quot;&gt;&gt;&lt;&lt;set $role to &quot;nurse&quot;&gt;&gt;nurse the sick and dying, despite the risk to your own life
         &lt;&lt;else&gt;&gt;&lt;&lt;set $role to &quot;corpsebearer&quot;&gt;&gt;remove the &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; corpses if anyone dies
         &lt;br&gt;
-&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/7/7a/Wilson_%22The_plague...%22%3B_a_corpses_bearer_Wellcome_L0016624.jpg&quot; width=&quot;100%&quot;&gt;
+&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/7/7a/Wilson_%22The_plague...%22%3B_a_corpses_bearer_Wellcome_L0016624.jpg&quot; width=&quot;100%&quot; alt=&quot;Engraving of a corpse bearer carrying away the dead&quot;&gt;
 //Printed by R. Price, A corpse bearer; reproduction of an engraving from a series of London Cries, 1655. Wellcome Images//
         &lt;&lt;/if&gt;&gt;
         &lt;&lt;/if&gt;&gt;
@@ -4308,22 +4308,22 @@ Luckily, there are no &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; cases in your
 &lt;&lt;if $socio is &quot;beggars&quot;&gt;&gt;
 	&lt;&lt;if $role is &quot;corpsebearer&quot;&gt;&gt;As a corpsebearer, every night, you and your fellow corpsebearer&lt;&lt;if _cwCrew gt 2&gt;&gt;s&lt;&lt;/if&gt;&gt; must go round to the locked up houses of your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; and call for them to bring out their dead, while praying to God that you remain safe.
 &lt;br&gt;
-&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/7/7a/Wilson_%22The_plague...%22%3B_a_corpses_bearer_Wellcome_L0016624.jpg&quot; width=&quot;100%&quot;&gt;
+&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/7/7a/Wilson_%22The_plague...%22%3B_a_corpses_bearer_Wellcome_L0016624.jpg&quot; width=&quot;100%&quot; alt=&quot;Engraving of a corpse bearer carrying away the dead&quot;&gt;
 //Printed by R. Price, A corpse bearer; reproduction of an engraving from a series of London Cries, 1655. Wellcome Images//
 
      &lt;&lt;elseif $role is &quot;searcher&quot;&gt;&gt;As a searcher, every time you and your fellow searcher&lt;&lt;if _cwCrew gt 2&gt;&gt;s&lt;&lt;/if&gt;&gt; are called to someone&#39;s house to determine a cause of death, you pray to God to protect you. You are starting to have nightmares about seeing &lt;&lt;defBuboes &quot;buboes&quot;&gt;&gt; and the tokens of &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; on your neighbors.
     &lt;br&gt;
-    &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/6/67/Plague_in_1665_%28BM_1875%2C0508.1513%29.jpg&quot; width=&quot;100%&quot;&gt;
+    &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/6/67/Plague_in_1665_%28BM_1875%2C0508.1513%29.jpg&quot; width=&quot;100%&quot; alt=&quot;Engraving of men loading plague victims onto a cart&quot;&gt;
     //Nathaniel Parr, published by Thomas Astley, Plague in 1665, 1747.//
      
      &lt;&lt;elseif $role is &quot;nurse&quot;&gt;&gt;The &lt;&lt;defOverseersOfThePoor &quot;Overseers of the Poor&quot;&gt;&gt; assign you to your first &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; patient to nurse. You must tend to the sick in their own homes, bringing them food, changing their linens, and applying what remedies you can. The work is grim and thankless, but someone must care for those whom God has afflicted.
     &lt;br&gt;
-    &lt;img src=&quot;https://iiif.wellcomecollection.org/image/ddddaws6/full/1024%2C/0/default.jpg&quot; width=&quot;100%&quot;&gt;
+    &lt;img src=&quot;https://iiif.wellcomecollection.org/image/ddddaws6/full/1024%2C/0/default.jpg&quot; width=&quot;100%&quot; alt=&quot;Etching of a man consuming antidotes to the plague&quot;&gt;
     //A man consuming many antidotes to the plague during the Great Plague of London. Etching by J. Franklin, 1841. Wellcome Collection//
 
      &lt;&lt;elseif $role is &quot;warder&quot;&gt;&gt;As a warder, you stand guard outside the locked up houses of your &lt;&lt;defParish &quot;parish&quot;&gt;&gt;, making sure no one escapes their quarantine. A great red cross is painted on each door, with the words &quot;Lord have mercy upon us&quot; written above it. You must remain at your post day and night, listening to the pleas and cries of those locked within, and pray to God that the sickness does not reach you through the door.
     &lt;br&gt;
-    &lt;img src=&quot;https://iiif.wellcomecollection.org/image/wsbkbmqj/full/1024%2C/0/default.jpg&quot; width=&quot;100%&quot;&gt;
+    &lt;img src=&quot;https://iiif.wellcomecollection.org/image/wsbkbmqj/full/1024%2C/0/default.jpg&quot; width=&quot;100%&quot; alt=&quot;Illustration of a plague scene in London&quot;&gt;
     //A plague scene. Wellcome Collection//
      &lt;&lt;/if&gt;&gt;
 
@@ -4332,22 +4332,22 @@ Luckily, there are no &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; cases in your
 &lt;&lt;elseif $socio is &quot;day labourers&quot;&gt;&gt;
 	&lt;&lt;if $role is &quot;corpsebearer&quot;&gt;&gt;Every night, you and your fellow corpsebearer&lt;&lt;if _cwCrew gt 2&gt;&gt;s&lt;&lt;/if&gt;&gt; go round to the locked up houses of your &lt;&lt;defParish &quot;parish&quot;&gt;&gt; and call for them to bring out their dead, while praying to God that you remain safe.
         &lt;br&gt;
-&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/7/7a/Wilson_%22The_plague...%22%3B_a_corpses_bearer_Wellcome_L0016624.jpg&quot; width=&quot;100%&quot;&gt;
+&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/7/7a/Wilson_%22The_plague...%22%3B_a_corpses_bearer_Wellcome_L0016624.jpg&quot; width=&quot;100%&quot; alt=&quot;Engraving of a corpse bearer carrying away the dead&quot;&gt;
 //Printed by R. Price, A corpse bearer; reproduction of an engraving from a series of London Cries, 1655. Wellcome Images//
     
     &lt;&lt;elseif $role is &quot;searcher&quot;&gt;&gt;Every time you and your fellow searcher&lt;&lt;if _cwCrew gt 2&gt;&gt;s&lt;&lt;/if&gt;&gt; are called to someone&#39;s house to determine a cause of death, you pray to God to protect you. You are starting to have nightmares about seeing &lt;&lt;defBuboes &quot;buboes&quot;&gt;&gt; and the tokens of &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; on your neighbors.
     &lt;br&gt;
-    &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/6/67/Plague_in_1665_%28BM_1875%2C0508.1513%29.jpg&quot; width=&quot;100%&quot;&gt;
+    &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/6/67/Plague_in_1665_%28BM_1875%2C0508.1513%29.jpg&quot; width=&quot;100%&quot; alt=&quot;Engraving of men loading plague victims onto a cart&quot;&gt;
     //Nathaniel Parr, published by Thomas Astley, Plague in 1665, 1747.//
    
    &lt;&lt;elseif $role is &quot;nurse&quot;&gt;&gt;&lt;&lt;defParish &quot;Parish&quot;&gt;&gt; officials tell you there is a patient for you to nurse. You must tend to the sick in their own homes, bringing them food, changing their linens, and applying what remedies you can. The work is grim and thankless, but someone must care for those whom God has afflicted.
     &lt;br&gt;
-    &lt;img src=&quot;https://iiif.wellcomecollection.org/image/ddddaws6/full/1024%2C/0/default.jpg&quot; width=&quot;100%&quot;&gt;
+    &lt;img src=&quot;https://iiif.wellcomecollection.org/image/ddddaws6/full/1024%2C/0/default.jpg&quot; width=&quot;100%&quot; alt=&quot;Etching of a man consuming antidotes to the plague&quot;&gt;
     //A man consuming many antidotes to the plague during the Great Plague of London. Etching by J. Franklin, 1841. Wellcome Collection//
 
 	&lt;&lt;elseif $role is &quot;warder&quot;&gt;&gt;You stand guard outside the locked up houses of your &lt;&lt;defParish &quot;parish&quot;&gt;&gt;. A great red cross is painted on each door, with the words &quot;Lord have mercy upon us&quot; written above it. You must remain at your post day and night, listening to the pleas and cries of those locked within, and pray to God that the sickness does not reach you through the door.
     &lt;br&gt;
-    &lt;img src=&quot;https://iiif.wellcomecollection.org/image/wsbkbmqj/full/1024%2C/0/default.jpg&quot; width=&quot;100%&quot;&gt;
+    &lt;img src=&quot;https://iiif.wellcomecollection.org/image/wsbkbmqj/full/1024%2C/0/default.jpg&quot; width=&quot;100%&quot; alt=&quot;Illustration of a plague scene in London&quot;&gt;
     //A plague scene. Wellcome Collection//
 	&lt;&lt;/if&gt;&gt;
     
@@ -4357,7 +4357,7 @@ Luckily, there are no &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; cases in your
 
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;
-&lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="69" name="storyLogo" tags="" position="150,150" size="100,100">&lt;a href=&quot;https://rrchnm.org/&quot; target=&quot;_blank&quot;&gt;&lt;img src=&quot;https://avatars.githubusercontent.com/u/296531?s=280&amp;v=4&quot; height=&quot;50px&quot;&gt;&lt;/a&gt;</tw-passagedata><tw-passagedata pid="70" name="gameTitle" tags="" position="25,25" size="100,100">Gaming the Great &lt;&lt;defPlague &quot;Plague&quot;&gt;&gt;</tw-passagedata><tw-passagedata pid="71" name="storyAuthor" tags="" position="150,25" size="100,100">&lt;a href=&quot;https://rrchnm.org/&quot;&gt;RRCHNM&lt;/a&gt;</tw-passagedata><tw-passagedata pid="72" name="storyMenu" tags="" position="275,150" size="100,100">&lt;&lt;nobr&gt;&gt;&lt;div class=&quot;status-box&quot;&gt;&lt;&lt;if $reputation gte 9&gt;&gt;&lt;div class=&quot;rep-best&quot;&gt;&#39;&#39;Reputation:&#39;&#39; &lt;br&gt; a worthy soul&lt;/div&gt;&lt;&lt;elseif $reputation gte 6 and $reputation lte 8&gt;&gt;&lt;div class=&quot;rep-good&quot;&gt;&#39;&#39;Reputation:&#39;&#39;&lt;br&gt;of good credit and quality&lt;/div&gt;&lt;&lt;elseif $reputation gte 3 and $reputation lte 5&gt;&gt;&lt;div class=&quot;rep-poor&quot;&gt;&#39;&#39;Reputation:&#39;&#39;&lt;br&gt;bad credit is better than none&lt;/div&gt;&lt;&lt;elseif $reputation lte 2&gt;&gt;&lt;div class=&quot;rep-worst&quot;&gt;&#39;&#39;Reputation:&#39;&#39;&lt;br&gt;a worthless and base rogue&lt;/div&gt;&lt;&lt;/if&gt;&gt;&lt;/div&gt;&lt;br&gt;
+&lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="69" name="storyLogo" tags="" position="150,150" size="100,100">&lt;a href=&quot;https://rrchnm.org/&quot; target=&quot;_blank&quot;&gt;&lt;img src=&quot;https://avatars.githubusercontent.com/u/296531?s=280&amp;v=4&quot; height=&quot;50px&quot; alt=&quot;Roy Rosenzweig Center for History and New Media logo&quot;&gt;&lt;/a&gt;</tw-passagedata><tw-passagedata pid="70" name="gameTitle" tags="" position="25,25" size="100,100">Gaming the Great &lt;&lt;defPlague &quot;Plague&quot;&gt;&gt;</tw-passagedata><tw-passagedata pid="71" name="storyAuthor" tags="" position="150,25" size="100,100">&lt;a href=&quot;https://rrchnm.org/&quot;&gt;RRCHNM&lt;/a&gt;</tw-passagedata><tw-passagedata pid="72" name="storyMenu" tags="" position="275,150" size="100,100">&lt;&lt;nobr&gt;&gt;&lt;div class=&quot;status-box&quot;&gt;&lt;&lt;if $reputation gte 9&gt;&gt;&lt;div class=&quot;rep-best&quot;&gt;&#39;&#39;Reputation:&#39;&#39; &lt;br&gt; a worthy soul&lt;/div&gt;&lt;&lt;elseif $reputation gte 6 and $reputation lte 8&gt;&gt;&lt;div class=&quot;rep-good&quot;&gt;&#39;&#39;Reputation:&#39;&#39;&lt;br&gt;of good credit and quality&lt;/div&gt;&lt;&lt;elseif $reputation gte 3 and $reputation lte 5&gt;&gt;&lt;div class=&quot;rep-poor&quot;&gt;&#39;&#39;Reputation:&#39;&#39;&lt;br&gt;bad credit is better than none&lt;/div&gt;&lt;&lt;elseif $reputation lte 2&gt;&gt;&lt;div class=&quot;rep-worst&quot;&gt;&#39;&#39;Reputation:&#39;&#39;&lt;br&gt;a worthless and base rogue&lt;/div&gt;&lt;&lt;/if&gt;&gt;&lt;/div&gt;&lt;br&gt;
 
 &lt;div class=&quot;status-box&quot;&gt;&lt;div class=&quot;income&quot;&gt;&lt;&lt;defDisposableIncome &quot;Disposable Income&quot;&gt;&gt;:&lt;br&gt; /* @@#money; &lt;&lt;= $money&gt;&gt; @@ */ @@ #conversion; &lt;&lt;conversion&gt;&gt; @@&lt;/div&gt;&lt;/div&gt;
 
@@ -4950,7 +4950,7 @@ Remaining money: &lt;&lt;conversion&gt;&gt;&lt;br&gt;
 &lt;&lt;link &quot;Close&quot;&gt;&gt;&lt;&lt;run Dialog.close()&gt;&gt;&lt;&lt;/link&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;
 
-&lt;img src=&quot;https://iiif.wellcomecollection.org/image/L0064305/full/1024%2C/0/default.jpg&quot; width=&quot;100%&quot;&gt;</tw-passagedata><tw-passagedata pid="80" name="preventatives-treatments" tags="widget" position="775,150" size="100,100">&lt;&lt;widget &quot;preventative&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
+&lt;img src=&quot;https://iiif.wellcomecollection.org/image/L0064305/full/1024%2C/0/default.jpg&quot; width=&quot;100%&quot; alt=&quot;Historical illustration of an apothecary shop&quot;&gt;</tw-passagedata><tw-passagedata pid="80" name="preventatives-treatments" tags="widget" position="775,150" size="100,100">&lt;&lt;widget &quot;preventative&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
 &lt;ul&gt;&lt;li&gt;&lt;span id=&quot;church&quot;&gt;&lt;&lt;link &quot;Go to church and pray often&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: $timeline[$monthIndex] + &quot;: Went to church to pray often&quot;, money: 0, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: _riskPct})&gt;&gt;&lt;&lt;replace &quot;#church&quot;&gt;&gt;You go to church and pray regularly through the month. Others admire your piety in the face of such a grave situation!&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;&lt;/li&gt;
 &lt;li&gt;&lt;span id=&quot;eat&quot;&gt;&lt;&lt;link &quot;Avoid eating berries, cabbage, cucumbers, melon, and spinach.&quot;&gt;&gt;&lt;&lt;replace &quot;#eat&quot;&gt;&gt;You avoid eating berries, cabbage, cucumbers, melons, and spinach. Your neighbors swear by it!&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;&lt;/li&gt;
 &lt;li&gt;&lt;&lt;link &quot;Visit the apothecary&quot;&gt;&gt;&lt;&lt;run Dialog.setup(&quot;Apothecary&quot;, &quot;apothecary&quot;); Dialog.wiki(Story.get(&quot;Apothecary&quot;).text); Dialog.open()&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/li&gt;&lt;/ul&gt;
@@ -5515,7 +5515,7 @@ The Court is plunged into mourning&lt;&lt;if $socio is &quot;nobles&quot;&gt;&gt
 
 So much for the city being safe again.&lt;br&gt;
 &lt;br&gt;
-&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/d/d4/Catherine_of_Braganza_-_Lely_1663-65.jpg&quot; width=&quot;100%&quot;&gt;
+&lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/d/d4/Catherine_of_Braganza_-_Lely_1663-65.jpg&quot; width=&quot;100%&quot; alt=&quot;Portrait of Queen Catherine of Braganza&quot;&gt;
 &lt;br&gt;
 //Peter Lely, Catherine of Braganza, 1663-5//
 &lt;br&gt;&lt;br&gt;
@@ -5532,7 +5532,7 @@ You can continue to try and avoid the plague by visiting the &lt;&lt;defApotheca
 </tw-passagedata><tw-passagedata pid="96" name="june-1666-helper widget" tags="widget" position="1600,725" size="100,100">&lt;&lt;widget &quot;june-1666-helper&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
 One thing is for certain, though. The weather is so hot that &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; cases are on the rise again and you know it will only get worse in [[July 1666]]. 
 &lt;br&gt;&lt;br&gt;
-&lt;img src=&quot;https://collections.rmg.co.uk/media/287/368/bhc0286.jpg&quot; width=&quot;100%&quot;&gt;
+&lt;img src=&quot;https://collections.rmg.co.uk/media/287/368/bhc0286.jpg&quot; width=&quot;100%&quot; alt=&quot;Painting of warships engaged in the Four Days Battle at sea&quot;&gt;
 //Abraham Storck, The &#39;Royal Prince&#39; and other Vessels at the Four Days Battle, 1–4 June 1666, c. 1670//
 &lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="97" name="accident" tags="widget" position="2375,175" size="100,100">&lt;&lt;widget &quot;accident&quot;&gt;&gt;
 &lt;&lt;nobr&gt;&gt;
@@ -6873,7 +6873,7 @@ You hate to send any of your family away, but you &lt;&lt;if $hoh is 4&gt;&gt;an
 The &lt;&lt;defPlague &quot;plague&quot;&gt;&gt; grows worse and the streets are soon filled with coaches and wagons full of people fleeing with their goods to the countryside. The &lt;&lt;defQueenMother &quot;Queen Mother&quot;&gt;&gt; &lt;&lt;defHenriettaMaria &quot;Henrietta Maria&quot;&gt;&gt; moves back to France&lt;&lt;if $religion is &quot;Catholic&quot;&gt;&gt;, much to your dismay, and that of your fellow Catholics who flock to her chapel each week&lt;&lt;else&gt;&gt;, much to your relief, and that of all your fellow God-fearing &lt;&lt;defProtestants &quot;Protestants&quot;&gt;&gt;&lt;&lt;/if&gt;&gt;. On June 29th, the King packs up his entire &lt;&lt;defHousehold &quot;household&quot;&gt;&gt; in 148 carriages and moves 12 miles away, to his palace at &lt;&lt;defHamptonCourt &quot;Hampton Court&quot;&gt;&gt;.
     &lt;br&gt;&lt;br&gt;
     
- &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/4/41/Wilson_%22The_plague...%22%3B_people_fleeing_from_plague_Wellcome_L0016623.jpg&quot; width=&quot;100%&quot;&gt;
+ &lt;img src=&quot;https://upload.wikimedia.org/wikipedia/commons/4/41/Wilson_%22The_plague...%22%3B_people_fleeing_from_plague_Wellcome_L0016623.jpg&quot; width=&quot;100%&quot; alt=&quot;Woodcut of people fleeing from the plague&quot;&gt;
 //Runaways fleeing from the plague, a woodcut from &#39;A Looking-glasse for City and Countrey&#39;, printed by H. Gosson in 1630 and sold by E. Wright, c. 1630. Wellcome Images//
  &lt;br&gt;&lt;br&gt;
     &lt;&lt;if $location is &quot;inside the City walls&quot;&gt;&gt; There are still no plague cases in your &lt;&lt;defParish &quot;parish&quot;&gt;&gt;, but everyone knows that it is only a matter of time


### PR DESCRIPTION
Add descriptive alt attributes to all <img> tags across 21 passages for accessibility. Alt-text describes the visual content without repeating attribution/date info already present in captions.

https://claude.ai/code/session_01UvJLSTL1Jg2PjXU8goYvfM