### PR TITLE
Fix multiple bugs and add surviving NPCs to death passage — bump to v…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v3.32" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v3.33" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -1319,7 +1319,72 @@ Send not to know for whom the church bells toll. They toll for you.
 &lt;&lt;death-announcement&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;
 
-You are survived by /* Claude - here is where to insert surviving NPC info */</tw-passagedata><tw-passagedata pid="6" name="Sickness" tags="infection-rates" position="150,450" size="100,100">&lt;&lt;nobr&gt;&gt;
+&lt;&lt;nobr&gt;&gt;
+&lt;&lt;silently&gt;&gt;
+/* Collect surviving NPCs from each array */
+&lt;&lt;set _survNPCs to []&gt;&gt;
+&lt;&lt;for _si = 0; _si &lt; $NPCs.length; _si++&gt;&gt;
+&lt;&lt;if $NPCs[_si].health isnot &quot;deceased&quot; and $NPCs[_si].health isnot &quot;deceased-pq&quot; and !$NPCs[_si].relationship.startsWith(&quot;landlord&quot;)&gt;&gt;
+&lt;&lt;set _survNPCs.push($NPCs[_si])&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/for&gt;&gt;
+&lt;&lt;set _survExtended to []&gt;&gt;
+&lt;&lt;for _si = 0; _si &lt; $NPCsExtended.length; _si++&gt;&gt;
+&lt;&lt;if $NPCsExtended[_si].health isnot &quot;deceased&quot; and $NPCsExtended[_si].health isnot &quot;deceased-pq&quot;&gt;&gt;
+&lt;&lt;set _survExtended.push($NPCsExtended[_si])&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/for&gt;&gt;
+&lt;&lt;set _survServants to []&gt;&gt;
+&lt;&lt;for _si = 0; _si &lt; $NPCsServants.length; _si++&gt;&gt;
+&lt;&lt;if $NPCsServants[_si].health isnot &quot;deceased&quot; and $NPCsServants[_si].health isnot &quot;deceased-pq&quot;&gt;&gt;
+&lt;&lt;set _survServants.push($NPCsServants[_si])&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/for&gt;&gt;
+&lt;&lt;set _survMaster to []&gt;&gt;
+&lt;&lt;for _si = 0; _si &lt; $NPCsMaster.length; _si++&gt;&gt;
+&lt;&lt;if $NPCsMaster[_si].health isnot &quot;deceased&quot; and $NPCsMaster[_si].health isnot &quot;deceased-pq&quot;&gt;&gt;
+&lt;&lt;set _survMaster.push($NPCsMaster[_si])&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/for&gt;&gt;
+/* Count fled family and servants (all alive) */
+&lt;&lt;set _survFled to $FledFamily.length&gt;&gt;
+&lt;&lt;set _survFledSv to $FledServants.length&gt;&gt;
+/* Build the survivor text */
+&lt;&lt;set _parts to []&gt;&gt;
+&lt;&lt;if $socio is &quot;servants&quot; and _survMaster.length gt 0&gt;&gt;
+/* Servant living with master: full details on extended, summary for master&#39;s household */
+&lt;&lt;for _si = 0; _si &lt; _survExtended.length; _si++&gt;&gt;
+&lt;&lt;set _parts.push(&quot;your &quot; + _survExtended[_si].relationship + &quot; &quot; + _survExtended[_si].name)&gt;&gt;
+&lt;&lt;/for&gt;&gt;
+&lt;&lt;set _hhCount to _survNPCs.length + _survServants.length + _survMaster.length + _survFled + _survFledSv&gt;&gt;
+&lt;&lt;if _hhCount gt 0&gt;&gt;
+&lt;&lt;set _parts.push(_hhCount + &quot; member&quot; + (_hhCount gt 1 ? &quot;s&quot; : &quot;&quot;) + &quot; of your &quot; + $masterTitle + &quot;&#39;s household&quot;)&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;else&gt;&gt;
+/* Standard: full details on household NPCs, summaries for others */
+&lt;&lt;for _si = 0; _si &lt; _survNPCs.length; _si++&gt;&gt;
+&lt;&lt;set _parts.push(&quot;your &quot; + _survNPCs[_si].relationship + &quot; &quot; + _survNPCs[_si].name)&gt;&gt;
+&lt;&lt;/for&gt;&gt;
+/* Add fled family with full details */
+&lt;&lt;for _si = 0; _si &lt; $FledFamily.length; _si++&gt;&gt;
+&lt;&lt;set _parts.push(&quot;your &quot; + $FledFamily[_si].relationship + &quot; &quot; + $FledFamily[_si].name)&gt;&gt;
+&lt;&lt;/for&gt;&gt;
+&lt;&lt;if _survExtended.length gt 0&gt;&gt;
+&lt;&lt;set _parts.push(_survExtended.length + &quot; member&quot; + (_survExtended.length gt 1 ? &quot;s&quot; : &quot;&quot;) + &quot; of your extended family&quot;)&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;set _svTotal to _survServants.length + _survFledSv&gt;&gt;
+&lt;&lt;if _svTotal gt 0&gt;&gt;
+&lt;&lt;set _parts.push(_svTotal + &quot; servant&quot; + (_svTotal gt 1 ? &quot;s&quot; : &quot;&quot;))&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;if _survMaster.length gt 0&gt;&gt;
+&lt;&lt;set _parts.push(_survMaster.length + &quot; member&quot; + (_survMaster.length gt 1 ? &quot;s&quot; : &quot;&quot;) + &quot; of your &quot; + $masterTitle + &quot;&#39;s household&quot;)&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/silently&gt;&gt;
+&lt;&lt;if _parts.length gt 0&gt;&gt;You are survived by &lt;&lt;for _pi = 0; _pi &lt; _parts.length; _pi++&gt;&gt;&lt;&lt;if _pi gt 0 and _parts.length gt 2&gt;&gt;, &lt;&lt;/if&gt;&gt;&lt;&lt;if _pi gt 0 and _pi is _parts.length - 1&gt;&gt;&lt;&lt;if _parts.length is 2&gt;&gt; and &lt;&lt;else&gt;&gt;and &lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;print _parts[_pi]&gt;&gt;&lt;&lt;/for&gt;&gt;.
+&lt;&lt;else&gt;&gt;You have no surviving family.
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="6" name="Sickness" tags="infection-rates" position="150,450" size="100,100">&lt;&lt;nobr&gt;&gt;
 /* this passage is either called from quarantine or sickPC */
 &lt;&lt;silently&gt;&gt;&lt;&lt;check-NPCs&gt;&gt;&lt;&lt;set _remedyEffect to 0&gt;&gt;&lt;&lt;set $plagueInfection to 2&gt;&gt;&lt;&lt;/silently&gt;&gt;
 &lt;&lt;if ndef $textGroup&gt;&gt;&lt;&lt;set $textGroup = 1&gt;&gt;&lt;&lt;/if&gt;&gt;
@@ -2411,7 +2476,7 @@ Maybe things will be better in [[1666-&gt;January 1666]].&lt;&lt;/replace&gt;&gt
 A bad storm blows down tiles from houses and shuts down &lt;&lt;defRiverTraffic &quot;river traffic&quot;&gt;&gt;, but all in all, it&#39;s a good month.&lt;br&gt;&lt;br&gt;You look forward to even better things in [[February 1666]].&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No, you keep out of people&#39;s way&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jan 1666: Stayed out of people&#39;s way&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;replace &quot;#help&quot;&gt;&gt;You don&#39;t venture out to help as a porter, hoping to avoid being run over by the many carts and carriages in the street. A bad storm blows down tiles from houses and shuts down &lt;&lt;defRiverTraffic &quot;river traffic&quot;&gt;&gt;, but all in all, it&#39;s a good month.&lt;br&gt;&lt;br&gt;You look forward to even better things in [[February 1666]].&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 
 &lt;&lt;elseif $socio is &quot;nobles&quot;&gt;&gt;
-After six months of travel, the king finally returns the Court to &lt;&lt;defHamptonCourt &quot;Hampton Court Palace&quot;&gt;&gt;, so that he can be near to the City of London and the government officials working out of Westminster.&lt;br&gt;&lt;br&gt;&lt;span id=&quot;greet&quot;&gt;Do you ride out to greet them? &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace #greet&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;&lt;&lt;set $money -=60&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jan 1666: Rode to Hampton Court&quot;, money: -60, repDelta: 1, repBefore: _repBefore, infectPct: 0})&gt;&gt;You ride out to greet the returning royal family and reconnect with you friends and allies in Court. Things finally feel like they are returning to normal and you look forward to continued favor and promotion in [[February 1666]].&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace #greet&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jan 1666: Absented yourself from Court&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: 0})&gt;&gt;You remain in London and send letters to your friends and allies in Court, welcoming their return and excusing your absence as a desire to avoid exposing them to any lingering infection. You ensure them that you are looking forward to reconnecting with them whenever they feel safe to return to the city and you look forward to continued favor and promotion in [[February 1666]].&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;&lt;/span&gt;&gt;
+After six months of travel, the king finally returns the Court to &lt;&lt;defHamptonCourt &quot;Hampton Court Palace&quot;&gt;&gt;, so that he can be near to the City of London and the government officials working out of Westminster.&lt;br&gt;&lt;br&gt;&lt;span id=&quot;greet&quot;&gt;Do you ride out to greet them? &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace #greet&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;&lt;&lt;set $money -=60&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jan 1666: Rode to Hampton Court&quot;, money: -60, repDelta: 1, repBefore: _repBefore, infectPct: 0})&gt;&gt;You ride out to greet the returning royal family and reconnect with you friends and allies in Court. Things finally feel like they are returning to normal and you look forward to continued favor and promotion in [[February 1666]].&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace #greet&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jan 1666: Absented yourself from Court&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: 0})&gt;&gt;You remain in London and send letters to your friends and allies in Court, welcoming their return and excusing your absence as a desire to avoid exposing them to any lingering infection. You ensure them that you are looking forward to reconnecting with them whenever they feel safe to return to the city and you look forward to continued favor and promotion in [[February 1666]].&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 
 &lt;&lt;else&gt;&gt;&lt;span id=&quot;help&quot;&gt;Do you offer to help any of your returning neighbors with their luggage? &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;set _repBefore to $reputation&gt;&gt;&lt;&lt;set $reputation to Math.clamp($reputation + 1, 0, 10)&gt;&gt;&lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round(10000 / _rate) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jan 1666: Helped returning neighbors&quot;, money: 0, repDelta: $reputation - _repBefore, repBefore: _repBefore, infectPct: _riskPct})&gt;&gt;&lt;&lt;replace &quot;#help&quot;&gt;&gt;You offer to help your returning neighbors carry some of their luggage. It is a good opportunity to catch up on all their news from their time in the country, and you are glad to talk to someone after the city has been so empty for so long. A bad storm blows down tiles from houses and shuts down &lt;&lt;defRiverTraffic &quot;river traffic&quot;&gt;&gt;, but all in all, it&#39;s a good month.&lt;br&gt;&lt;br&gt;You look forward to even better things in [[February 1666]].&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Jan 1666: Did not help returning neighbors&quot;, money: 0, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;replace &quot;#help&quot;&gt;&gt;You don&#39;t offer to help your returning neighbors, but you shout your greetings down to them, glad to see the city so lively again after it had been empty for so long. A bad storm blows down tiles from houses and shuts down &lt;&lt;defRiverTraffic &quot;river traffic&quot;&gt;&gt;, but all in all, it&#39;s a good month.&lt;br&gt;&lt;br&gt;You look forward to even better things in [[February 1666]].&lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;&lt;/span&gt;
 &lt;&lt;/if&gt;&gt;
@@ -4515,19 +4580,86 @@ Do you:&lt;ul&gt;
 &lt;&lt;widget &quot;stats-cumulative-risk&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
 &lt;h3&gt;Your Character&lt;/h3&gt;
 &lt;&lt;silently&gt;&gt;
+/* Count decision-based exposures */
 &lt;&lt;set _exposureCount to 0&gt;&gt;
-&lt;&lt;set _survivalProb to 1.0&gt;&gt;
 &lt;&lt;for _di to 0; _di lt $decisions.length; _di++&gt;&gt;
 &lt;&lt;set _d to $decisions[_di]&gt;&gt;
 &lt;&lt;if typeof _d is &quot;object&quot; and _d.infectPct neq null and _d.infectPct gt 0&gt;&gt;
 &lt;&lt;set _exposureCount += 1&gt;&gt;
-&lt;&lt;set _survivalProb to _survivalProb * (1.0 - (_d.infectPct / 100))&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/for&gt;&gt;
-&lt;&lt;set _cumRisk to Math.round((1.0 - _survivalProb) * 100)&gt;&gt;
+
+/* Compute parish baseline survival (mirrors dataviz approach) */
+&lt;&lt;set _rates to $parishRate[$parish]&gt;&gt;
+&lt;&lt;set _tLen to $timeline.length&gt;&gt;
+&lt;&lt;set _parishPct to []&gt;&gt;
+&lt;&lt;for _i to 0; _i lt _tLen; _i++&gt;&gt;
+&lt;&lt;if _rates[_i] lt 1000&gt;&gt;
+&lt;&lt;set _parishPct.push(Math.round((1.0 / _rates[_i]) * 10000) / 100)&gt;&gt;
+&lt;&lt;else&gt;&gt;
+&lt;&lt;set _parishPct.push(0)&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/for&gt;&gt;
+
+/* Account for fled months */
+&lt;&lt;set _isFled to ($fled is 1 or $fled is 2 or $fled is 6)&gt;&gt;
+&lt;&lt;if _isFled&gt;&gt;
+&lt;&lt;set _returnIndex to _tLen&gt;&gt;
+&lt;&lt;for _di to 0; _di lt $decisions.length; _di++&gt;&gt;
+&lt;&lt;set _d to $decisions[_di]&gt;&gt;
+&lt;&lt;if typeof _d is &quot;object&quot;&gt;&gt;
+&lt;&lt;set _colonIdx to _d.text.indexOf(&quot;:&quot;)&gt;&gt;
+&lt;&lt;if _colonIdx gt 0&gt;&gt;
+&lt;&lt;set _monthStr to _d.text.slice(0, _colonIdx)&gt;&gt;
+&lt;&lt;set _mIdx to $timeline.indexOf(_monthStr)&gt;&gt;
+&lt;&lt;if _mIdx gt $fledFromIndex and _mIdx lt _returnIndex&gt;&gt;&lt;&lt;set _returnIndex to _mIdx&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/for&gt;&gt;
+&lt;&lt;for _i to $fledFromIndex + 1; _i lt _returnIndex; _i++&gt;&gt;
+&lt;&lt;set _parishPct[_i] to 0&gt;&gt;
+&lt;&lt;/for&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+
+/* Bin decisions by month (mirrors dataviz approach) */
+&lt;&lt;set _decPctByMonth to []&gt;&gt;
+&lt;&lt;for _i to 0; _i lt _tLen; _i++&gt;&gt;
+&lt;&lt;set _decPctByMonth.push(0)&gt;&gt;
+&lt;&lt;/for&gt;&gt;
+&lt;&lt;for _di to 0; _di lt $decisions.length; _di++&gt;&gt;
+&lt;&lt;set _d to $decisions[_di]&gt;&gt;
+&lt;&lt;if typeof _d is &quot;object&quot; and _d.infectPct neq null and _d.infectPct gt 0&gt;&gt;
+&lt;&lt;set _colonIdx to _d.text.indexOf(&quot;:&quot;)&gt;&gt;
+&lt;&lt;if _colonIdx gt 0&gt;&gt;
+&lt;&lt;set _monthStr to _d.text.slice(0, _colonIdx)&gt;&gt;
+&lt;&lt;set _mIdx to $timeline.indexOf(_monthStr)&gt;&gt;
+&lt;&lt;if _mIdx gte 0&gt;&gt;
+&lt;&lt;set _decPctByMonth[_mIdx] to _decPctByMonth[_mIdx] + _d.infectPct&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/for&gt;&gt;
+
+/* Compute parish-only and total survival */
+&lt;&lt;set _survParish to 1.0&gt;&gt;
+&lt;&lt;set _survAll to 1.0&gt;&gt;
+&lt;&lt;for _i to 0; _i lt _tLen; _i++&gt;&gt;
+&lt;&lt;if _parishPct[_i] gt 0&gt;&gt;
+&lt;&lt;set _survParish to _survParish * (1.0 - (_parishPct[_i] / 100))&gt;&gt;
+&lt;&lt;set _survAll to _survAll * (1.0 - (_parishPct[_i] / 100))&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;if _decPctByMonth[_i] gt 0&gt;&gt;
+&lt;&lt;set _survAll to _survAll * (1.0 - (_decPctByMonth[_i] / 100))&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/for&gt;&gt;
+
+&lt;&lt;set _cumParish to Math.round((1.0 - _survParish) * 100)&gt;&gt;
+&lt;&lt;set _cumTotal to Math.round((1.0 - _survAll) * 100)&gt;&gt;
+&lt;&lt;set _cumRisk to _cumTotal - _cumParish&gt;&gt;
+&lt;&lt;if _cumRisk lt 0&gt;&gt;&lt;&lt;set _cumRisk to 0&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;/silently&gt;&gt;
 &lt;&lt;if _exposureCount gt 0&gt;&gt;
-&lt;p&gt;Over the course of the game, your decisions exposed you to plague infection &lt;&lt;print _exposureCount&gt;&gt; time&lt;&lt;if _exposureCount gt 1&gt;&gt;s&lt;&lt;/if&gt;&gt;, for a combined cumulative risk of approximately &lt;b&gt;&lt;&lt;print _cumRisk&gt;&gt;%&lt;/b&gt;. This is over and above the risk you faced just living in $parish.&lt;/p&gt;
+&lt;p&gt;Over the course of the game, your decisions exposed you to plague infection &lt;&lt;print _exposureCount&gt;&gt; time&lt;&lt;if _exposureCount gt 1&gt;&gt;s&lt;&lt;/if&gt;&gt;, for a combined cumulative risk of approximately &lt;b&gt;&lt;&lt;print _cumRisk&gt;&gt;%&lt;/b&gt;. This is over and above the &lt;&lt;print _cumParish&gt;&gt;% risk you faced just living in $parish.&lt;/p&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="76" name="infection-widgets" tags="widget infection-rates" position="25,575" size="100,100">/*Infection Program: determines rate of plague infection based on parish-level historical data*/
 &lt;&lt;widget &quot;infection-program&quot;&gt;&gt;
@@ -5093,8 +5225,13 @@ You return to your &lt;&lt;defHousehold &quot;household&quot;&gt;&gt; and begin 
 
 &lt;&lt;return-children&gt;&gt;
 
-/* Funeral choices for NPCs who died while the player was away */
-&lt;&lt;for _qi = 0; _qi &lt; $NPCs.length; _qi++&gt;&gt;&lt;&lt;if $NPCs[_qi].health is &quot;deceased&quot; and !$NPCs[_qi].funeralDone&gt;&gt;&lt;&lt;funeral-choice $NPCs[_qi]&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;for _qi = 0; _qi &lt; $NPCsServants.length; _qi++&gt;&gt;&lt;&lt;if $NPCsServants[_qi].health is &quot;deceased&quot; and !$NPCsServants[_qi].funeralDone&gt;&gt;&lt;&lt;funeral-choice $NPCsServants[_qi]&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;for _qi = 0; _qi &lt; $NPCsMaster.length; _qi++&gt;&gt;&lt;&lt;if $NPCsMaster[_qi].health is &quot;deceased&quot; and !$NPCsMaster[_qi].funeralDone&gt;&gt;&lt;&lt;funeral-choice $NPCsMaster[_qi]&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;for _qi = 0; _qi &lt; $NPCsExtended.length; _qi++&gt;&gt;&lt;&lt;if $NPCsExtended[_qi].health is &quot;deceased&quot; and !$NPCsExtended[_qi].funeralDone&gt;&gt;&lt;&lt;funeral-choice $NPCsExtended[_qi]&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
+/* Collect all dead NPCs for a single grouped funeral choice */
+&lt;&lt;set _deadNPCs to []&gt;&gt;
+&lt;&lt;for _qi = 0; _qi &lt; $NPCs.length; _qi++&gt;&gt;&lt;&lt;if ($NPCs[_qi].health is &quot;deceased&quot; or $NPCs[_qi].health is &quot;deceased-pq&quot;) and !$NPCs[_qi].funeralDone&gt;&gt;&lt;&lt;set _deadNPCs.push({npc: $NPCs[_qi], label: &quot;your &quot; + $NPCs[_qi].relationship})&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
+&lt;&lt;for _qi = 0; _qi &lt; $NPCsServants.length; _qi++&gt;&gt;&lt;&lt;if ($NPCsServants[_qi].health is &quot;deceased&quot; or $NPCsServants[_qi].health is &quot;deceased-pq&quot;) and !$NPCsServants[_qi].funeralDone&gt;&gt;&lt;&lt;set _deadNPCs.push({npc: $NPCsServants[_qi], label: &quot;your servant&quot;})&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
+&lt;&lt;for _qi = 0; _qi &lt; $NPCsMaster.length; _qi++&gt;&gt;&lt;&lt;if ($NPCsMaster[_qi].health is &quot;deceased&quot; or $NPCsMaster[_qi].health is &quot;deceased-pq&quot;) and !$NPCsMaster[_qi].funeralDone&gt;&gt;&lt;&lt;set _deadNPCs.push({npc: $NPCsMaster[_qi], label: &quot;the &quot; + $NPCsMaster[_qi].relationship})&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
+&lt;&lt;for _qi = 0; _qi &lt; $NPCsExtended.length; _qi++&gt;&gt;&lt;&lt;if ($NPCsExtended[_qi].health is &quot;deceased&quot; or $NPCsExtended[_qi].health is &quot;deceased-pq&quot;) and !$NPCsExtended[_qi].funeralDone&gt;&gt;&lt;&lt;set _deadNPCs.push({npc: $NPCsExtended[_qi], label: &quot;your &quot; + $NPCsExtended[_qi].relationship})&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
+&lt;&lt;funeral-choice&gt;&gt;
 &lt;&lt;servant-master-death&gt;&gt;
 
 &lt;&lt;storyline-return&gt;&gt;
@@ -5127,8 +5264,13 @@ Lord be praised, your &lt;&lt;defHousehold &quot;household&quot;&gt;&gt; has sur
 
 &lt;&lt;return-children&gt;&gt;
 
-/* Funeral choices for NPCs who died during quarantine */
-&lt;&lt;for _qi = 0; _qi &lt; $NPCs.length; _qi++&gt;&gt;&lt;&lt;if $NPCs[_qi].health is &quot;deceased&quot; and !$NPCs[_qi].funeralDone&gt;&gt;&lt;&lt;funeral-choice $NPCs[_qi]&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;for _qi = 0; _qi &lt; $NPCsServants.length; _qi++&gt;&gt;&lt;&lt;if $NPCsServants[_qi].health is &quot;deceased&quot; and !$NPCsServants[_qi].funeralDone&gt;&gt;&lt;&lt;funeral-choice $NPCsServants[_qi]&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;for _qi = 0; _qi &lt; $NPCsMaster.length; _qi++&gt;&gt;&lt;&lt;if $NPCsMaster[_qi].health is &quot;deceased&quot; and !$NPCsMaster[_qi].funeralDone&gt;&gt;&lt;&lt;funeral-choice $NPCsMaster[_qi]&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;for _qi = 0; _qi &lt; $NPCsExtended.length; _qi++&gt;&gt;&lt;&lt;if $NPCsExtended[_qi].health is &quot;deceased&quot; and !$NPCsExtended[_qi].funeralDone&gt;&gt;&lt;&lt;funeral-choice $NPCsExtended[_qi]&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
+/* Collect all dead NPCs for a single grouped funeral choice */
+&lt;&lt;set _deadNPCs to []&gt;&gt;
+&lt;&lt;for _qi = 0; _qi &lt; $NPCs.length; _qi++&gt;&gt;&lt;&lt;if ($NPCs[_qi].health is &quot;deceased&quot; or $NPCs[_qi].health is &quot;deceased-pq&quot;) and !$NPCs[_qi].funeralDone&gt;&gt;&lt;&lt;set _deadNPCs.push({npc: $NPCs[_qi], label: &quot;your &quot; + $NPCs[_qi].relationship})&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
+&lt;&lt;for _qi = 0; _qi &lt; $NPCsServants.length; _qi++&gt;&gt;&lt;&lt;if ($NPCsServants[_qi].health is &quot;deceased&quot; or $NPCsServants[_qi].health is &quot;deceased-pq&quot;) and !$NPCsServants[_qi].funeralDone&gt;&gt;&lt;&lt;set _deadNPCs.push({npc: $NPCsServants[_qi], label: &quot;your servant&quot;})&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
+&lt;&lt;for _qi = 0; _qi &lt; $NPCsMaster.length; _qi++&gt;&gt;&lt;&lt;if ($NPCsMaster[_qi].health is &quot;deceased&quot; or $NPCsMaster[_qi].health is &quot;deceased-pq&quot;) and !$NPCsMaster[_qi].funeralDone&gt;&gt;&lt;&lt;set _deadNPCs.push({npc: $NPCsMaster[_qi], label: &quot;the &quot; + $NPCsMaster[_qi].relationship})&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
+&lt;&lt;for _qi = 0; _qi &lt; $NPCsExtended.length; _qi++&gt;&gt;&lt;&lt;if ($NPCsExtended[_qi].health is &quot;deceased&quot; or $NPCsExtended[_qi].health is &quot;deceased-pq&quot;) and !$NPCsExtended[_qi].funeralDone&gt;&gt;&lt;&lt;set _deadNPCs.push({npc: $NPCsExtended[_qi], label: &quot;your &quot; + $NPCsExtended[_qi].relationship})&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
+&lt;&lt;funeral-choice&gt;&gt;
 &lt;&lt;orphan-check&gt;&gt;
 &lt;&lt;servant-master-death&gt;&gt;
 
@@ -7461,33 +7603,33 @@ Household size: &lt;&lt;if $fled is 5&gt;&gt;&lt;&lt;set _hhSize to $FledFamily.
 
 &#39;&#39;Household:&#39;&#39; &lt;&lt;if $fled is 5&gt;&gt;&#39;&#39;fled to $hhlocation&#39;&#39;&lt;&lt;/if&gt;&gt;&lt;br&gt;
         &lt;&lt;for _i, _idx range $FledFamily&gt;&gt;
-        $FledFamily[_i].name, $FledFamily[_i].age &lt;&lt;print $FledFamily[_i].relationship.replace(/^master/, $masterTitle || &quot;master&quot;)&gt;&gt;: &lt;&lt;if $FledFamily[_i].health is &quot;infected&quot; and $plagueRevealed is 0&gt;&gt;healthy&lt;&lt;else&gt;&gt;$FledFamily[_i].health&lt;&lt;/if&gt;&gt;.&lt;br&gt;
+        $FledFamily[_i].name, $FledFamily[_i].age &lt;&lt;print $FledFamily[_i].relationship.replace(/^master/, $masterTitle || &quot;master&quot;)&gt;&gt;: &lt;&lt;if $FledFamily[_i].health is &quot;infected&quot; and $plagueRevealed is 0&gt;&gt;healthy&lt;&lt;elseif $FledFamily[_i].health is &quot;deceased-pq&quot;&gt;&gt;deceased&lt;&lt;else&gt;&gt;$FledFamily[_i].health&lt;&lt;/if&gt;&gt;.&lt;br&gt;
         &lt;&lt;/for&gt;&gt;
         &lt;&lt;for _i, _idx range $NPCs&gt;&gt;
-        &lt;&lt;if !$NPCs[_i].relationship.startsWith(&quot;landlord&quot;)&gt;&gt;$NPCs[_i].name, $NPCs[_i].age &lt;&lt;print $NPCs[_i].relationship.replace(/^master/, $masterTitle || &quot;master&quot;)&gt;&gt;: &lt;&lt;if $NPCs[_i].health is &quot;infected&quot; and $plagueRevealed is 0&gt;&gt;healthy&lt;&lt;else&gt;&gt;$NPCs[_i].health&lt;&lt;/if&gt;&gt;.&lt;br&gt;&lt;&lt;/if&gt;&gt;
+        &lt;&lt;if !$NPCs[_i].relationship.startsWith(&quot;landlord&quot;)&gt;&gt;$NPCs[_i].name, $NPCs[_i].age &lt;&lt;print $NPCs[_i].relationship.replace(/^master/, $masterTitle || &quot;master&quot;)&gt;&gt;: &lt;&lt;if $NPCs[_i].health is &quot;infected&quot; and $plagueRevealed is 0&gt;&gt;healthy&lt;&lt;elseif $NPCs[_i].health is &quot;deceased-pq&quot;&gt;&gt;deceased&lt;&lt;else&gt;&gt;$NPCs[_i].health&lt;&lt;/if&gt;&gt;.&lt;br&gt;&lt;&lt;/if&gt;&gt;
         &lt;&lt;/for&gt;&gt;
     &lt;&lt;if _landlordCount gt 0&gt;&gt;
 &lt;br&gt;&#39;&#39;Landlord&#39;s Household:&#39;&#39; &lt;br&gt;&lt;&lt;for _li, _idx range $NPCs&gt;&gt;&lt;&lt;if $NPCs[_li].relationship.startsWith(&quot;landlord&quot;)&gt;&gt;
-        $NPCs[_li].name, $NPCs[_li].age $NPCs[_li].relationship: $NPCs[_li].health.&lt;br&gt;
+        $NPCs[_li].name, $NPCs[_li].age $NPCs[_li].relationship: &lt;&lt;if $NPCs[_li].health is &quot;deceased-pq&quot;&gt;&gt;deceased&lt;&lt;else&gt;&gt;$NPCs[_li].health&lt;&lt;/if&gt;&gt;.&lt;br&gt;
 &lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
     &lt;&lt;/if&gt;&gt;
 &lt;br&gt;&lt;br&gt;
         &lt;&lt;if $NPCsExtended.length gt 0&gt;&gt;
 &#39;&#39;Extended family:&#39;&#39; &lt;br&gt;&lt;&lt;for _e, _idx range $NPCsExtended&gt;&gt;
-	$NPCsExtended[_e].name, $NPCsExtended[_e].age $NPCsExtended[_e].relationship: &lt;&lt;if $NPCsExtended[_e].health is &quot;infected&quot; and $plagueRevealed is 0&gt;&gt;healthy&lt;&lt;else&gt;&gt;$NPCsExtended[_e].health&lt;&lt;/if&gt;&gt;&lt;br&gt;
+	$NPCsExtended[_e].name, $NPCsExtended[_e].age $NPCsExtended[_e].relationship: &lt;&lt;if $NPCsExtended[_e].health is &quot;infected&quot; and $plagueRevealed is 0&gt;&gt;healthy&lt;&lt;elseif $NPCsExtended[_e].health is &quot;deceased-pq&quot;&gt;&gt;deceased&lt;&lt;else&gt;&gt;$NPCsExtended[_e].health&lt;&lt;/if&gt;&gt;&lt;br&gt;
     &lt;&lt;/for&gt;&gt;
     &lt;&lt;/if&gt;&gt;
     &lt;&lt;if $NPCsServants.length gt 0&gt;&gt;
 &lt;br&gt;&#39;&#39;Household servants:&#39;&#39; &lt;br&gt;/* &lt;&lt;set _svHealthy to 0&gt;&gt;&lt;&lt;set _svInfected to 0&gt;&gt;&lt;&lt;set _svDeceased to 0&gt;&gt;&lt;&lt;set _svRecovered to 0&gt;&gt;&lt;&lt;for _sv, _idx range $NPCsServants&gt;&gt;&lt;&lt;if $NPCsServants[_sv].health is &quot;healthy&quot; or ($NPCsServants[_sv].health is &quot;infected&quot; and $plagueRevealed is 0)&gt;&gt;&lt;&lt;set _svHealthy += 1&gt;&gt;&lt;&lt;elseif $NPCsServants[_sv].health is &quot;infected&quot;&gt;&gt;&lt;&lt;set _svInfected += 1&gt;&gt;&lt;&lt;elseif $NPCsServants[_sv].health is &quot;deceased&quot;&gt;&gt;&lt;&lt;set _svDeceased += 1&gt;&gt;&lt;&lt;elseif $NPCsServants[_sv].health is &quot;recovered&quot;&gt;&gt;&lt;&lt;set _svRecovered += 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;if _svHealthy gt 0&gt;&gt;_svHealthy healthy&lt;br&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if _svInfected gt 0&gt;&gt;_svInfected infected&lt;br&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if _svDeceased gt 0&gt;&gt;_svDeceased deceased&lt;br&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if _svRecovered gt 0&gt;&gt;_svRecovered recovered&lt;br&gt;&lt;&lt;/if&gt;&gt; */
         &lt;&lt;for _sv, _idx range $NPCsServants&gt;&gt;
-        $NPCsServants[_sv].name, $NPCsServants[_sv].age $NPCsServants[_sv].relationship: &lt;&lt;if $NPCsServants[_sv].health is &quot;infected&quot; and $plagueRevealed is 0&gt;&gt;healthy&lt;&lt;else&gt;&gt;$NPCsServants[_sv].health&lt;&lt;/if&gt;&gt;.&lt;br&gt;
+        $NPCsServants[_sv].name, $NPCsServants[_sv].age $NPCsServants[_sv].relationship: &lt;&lt;if $NPCsServants[_sv].health is &quot;infected&quot; and $plagueRevealed is 0&gt;&gt;healthy&lt;&lt;elseif $NPCsServants[_sv].health is &quot;deceased-pq&quot;&gt;&gt;deceased&lt;&lt;else&gt;&gt;$NPCsServants[_sv].health&lt;&lt;/if&gt;&gt;.&lt;br&gt;
         &lt;&lt;/for&gt;&gt;
     &lt;&lt;if $FledServants.length gt 0&gt;&gt;
 &#39;&#39;Fled servants:&#39;&#39; &lt;br&gt;$FledServants.length fled to $hhlocation&lt;br&gt;
     &lt;&lt;/if&gt;&gt;
     &lt;&lt;/if&gt;&gt;
     &lt;&lt;if $NPCsMaster.length gt 0&gt;&gt;
-&lt;br&gt;&#39;&#39;&lt;&lt;if $masterGender is &quot;female&quot;&gt;&gt;Mistress&#39;s&lt;&lt;else&gt;&gt;Master&#39;s&lt;&lt;/if&gt;&gt; Household:&#39;&#39; &lt;br&gt;&lt;&lt;set _mhHealthy to 0&gt;&gt;&lt;&lt;set _mhInfected to 0&gt;&gt;&lt;&lt;set _mhDeceased to 0&gt;&gt;&lt;&lt;set _mhRecovered to 0&gt;&gt;&lt;&lt;for _mh, _idx range $NPCsMaster&gt;&gt;&lt;&lt;if $NPCsMaster[_mh].health is &quot;healthy&quot; or ($NPCsMaster[_mh].health is &quot;infected&quot; and $plagueRevealed is 0)&gt;&gt;&lt;&lt;set _mhHealthy += 1&gt;&gt;&lt;&lt;elseif $NPCsMaster[_mh].health is &quot;infected&quot;&gt;&gt;&lt;&lt;set _mhInfected += 1&gt;&gt;&lt;&lt;elseif $NPCsMaster[_mh].health is &quot;deceased&quot;&gt;&gt;&lt;&lt;set _mhDeceased += 1&gt;&gt;&lt;&lt;elseif $NPCsMaster[_mh].health is &quot;recovered&quot;&gt;&gt;&lt;&lt;set _mhRecovered += 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;if _mhHealthy gt 0&gt;&gt;_mhHealthy healthy&lt;br&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if _mhInfected gt 0&gt;&gt;_mhInfected infected&lt;br&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if _mhDeceased gt 0&gt;&gt;_mhDeceased deceased&lt;br&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if _mhRecovered gt 0&gt;&gt;_mhRecovered recovered&lt;br&gt;&lt;&lt;/if&gt;&gt;
+&lt;br&gt;&#39;&#39;&lt;&lt;if $masterGender is &quot;female&quot;&gt;&gt;Mistress&#39;s&lt;&lt;else&gt;&gt;Master&#39;s&lt;&lt;/if&gt;&gt; Household:&#39;&#39; &lt;br&gt;&lt;&lt;set _mhHealthy to 0&gt;&gt;&lt;&lt;set _mhInfected to 0&gt;&gt;&lt;&lt;set _mhDeceased to 0&gt;&gt;&lt;&lt;set _mhRecovered to 0&gt;&gt;&lt;&lt;for _mh, _idx range $NPCsMaster&gt;&gt;&lt;&lt;if $NPCsMaster[_mh].health is &quot;healthy&quot; or ($NPCsMaster[_mh].health is &quot;infected&quot; and $plagueRevealed is 0)&gt;&gt;&lt;&lt;set _mhHealthy += 1&gt;&gt;&lt;&lt;elseif $NPCsMaster[_mh].health is &quot;infected&quot;&gt;&gt;&lt;&lt;set _mhInfected += 1&gt;&gt;&lt;&lt;elseif $NPCsMaster[_mh].health is &quot;deceased&quot; or $NPCsMaster[_mh].health is &quot;deceased-pq&quot;&gt;&gt;&lt;&lt;set _mhDeceased += 1&gt;&gt;&lt;&lt;elseif $NPCsMaster[_mh].health is &quot;recovered&quot;&gt;&gt;&lt;&lt;set _mhRecovered += 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;if _mhHealthy gt 0&gt;&gt;_mhHealthy healthy&lt;br&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if _mhInfected gt 0&gt;&gt;_mhInfected infected&lt;br&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if _mhDeceased gt 0&gt;&gt;_mhDeceased deceased&lt;br&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if _mhRecovered gt 0&gt;&gt;_mhRecovered recovered&lt;br&gt;&lt;&lt;/if&gt;&gt;
     &lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;
 &lt;&lt;/widget&gt;&gt;</tw-passagedata><tw-passagedata pid="126" name="add-master widgets" tags="widget" position="275,1225" size="100,100">&lt;&lt;widget &quot;addMaster&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;


### PR DESCRIPTION
…3.33

Bug fixes:
- Fix "deceased-pq" displaying literally in sidebar NPC list
- Fix <</span>> macro error in January 1666 noble section (was <<...>> instead of <...>)
- Fix stats cumulative risk mismatch with dataviz (compute incremental risk on top of parish baseline to match dataviz breakdown)
- Fix funeral widget in Reconnecting passage to group all dead NPCs into a single funeral choice instead of asking individually

New feature:
- Death passage now lists surviving NPCs with full details for household members and summaries for extended family/servants/master's household. Servants living with masters get the inverse pattern.

https://claude.ai/code/session_01WeS844DPWznkii3Y8wvwDf