### PR TITLE
Add master-pays mechanic for servant household expenses — bump to v3.39

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v3.38" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v3.39" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -1916,14 +1916,14 @@ On Christmas Eve, you see a comet in the sky and you wonder if it is [[a sign of
 
 &lt;span id=&quot;funeral-combined&quot;&gt;Do you give &lt;&lt;print _deathList&gt;&gt;
 &lt;&lt;link &quot;a quick burial&quot;&gt;&gt;&lt;&lt;replace &quot;#funeral-combined&quot;&gt;&gt;
-&lt;&lt;set $money -= _burialCost&gt;&gt;
-&lt;&lt;for _fi = 0; _fi lt _deadNPCs.length; _fi++&gt;&gt;&lt;&lt;set _deadNPCs[_fi].npc.funeralDone to true&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Quick burial for &quot; + _deadNPCs[_fi].npc.name, money: -9, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;/for&gt;&gt;
+&lt;&lt;master-pays _burialCost&gt;&gt;
+&lt;&lt;for _fi = 0; _fi lt _deadNPCs.length; _fi++&gt;&gt;&lt;&lt;set _deadNPCs[_fi].npc.funeralDone to true&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Quick burial for &quot; + _deadNPCs[_fi].npc.name, money: (_masterPaid ? 0 : -9), repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;/for&gt;&gt;
 a quick burial.&lt;&lt;storyline-return &quot;Continue.&quot; 0&gt;&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;a proper funeral&quot;&gt;&gt;&lt;&lt;replace &quot;#funeral-combined&quot;&gt;&gt;
 &lt;&lt;set _rate to $parishRate[$parish][$monthIndex]&gt;&gt;&lt;&lt;set _riskPct to Math.round((10000 / _rate) + 200) / 100&gt;&gt;&lt;&lt;if random(1, _rate) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;if random(1, 50) eq 1&gt;&gt;&lt;&lt;set $plagueInfection to 1&gt;&gt;&lt;&lt;/if&gt;&gt;
-&lt;&lt;set $money -= _funeralCost&gt;&gt;
+&lt;&lt;master-pays _funeralCost&gt;&gt;
 &lt;&lt;set _perCost to Math.round(_funeralCost / _deadNPCs.length)&gt;&gt;
-&lt;&lt;for _fi = 0; _fi lt _deadNPCs.length; _fi++&gt;&gt;&lt;&lt;set _deadNPCs[_fi].npc.funeralDone to true&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Proper funeral for &quot; + _deadNPCs[_fi].npc.name, money: -_perCost, repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;&lt;&lt;/for&gt;&gt;
+&lt;&lt;for _fi = 0; _fi lt _deadNPCs.length; _fi++&gt;&gt;&lt;&lt;set _deadNPCs[_fi].npc.funeralDone to true&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Proper funeral for &quot; + _deadNPCs[_fi].npc.name, money: (_masterPaid ? 0 : -_perCost), repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;&lt;&lt;/for&gt;&gt;
 a proper funeral.&lt;&lt;storyline-return &quot;Continue.&quot; 0&gt;&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;
 &lt;/span&gt;
@@ -2969,7 +2969,9 @@ It is a difficult decision, but &lt;&lt;set-caretaker&gt;&gt;&lt;&lt;if $hoh is 
 &lt;&lt;for _pi = 0; _pi &lt; $NPCs.length; _pi++&gt;&gt;&lt;&lt;if $NPCs[_pi].health is &quot;infected&quot;&gt;&gt;&lt;&lt;set _pesthouseCount += 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
 &lt;&lt;for _pi = 0; _pi &lt; $NPCsServants.length; _pi++&gt;&gt;&lt;&lt;if $NPCsServants[_pi].health is &quot;infected&quot;&gt;&gt;&lt;&lt;set _pesthouseCount += 1&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt;
 &lt;&lt;set _pesthouseFee to _pesthouseCount * 12&gt;&gt;
-&lt;&lt;if $money gte _pesthouseFee&gt;&gt;&lt;&lt;set $money -= _pesthouseFee&gt;&gt;&lt;&lt;/if&gt;&gt;
+&lt;&lt;if $socio is &quot;servants&quot; and ($hoh is 3 or $hoh is 0)&gt;&gt;
+  /* Master pays pesthouse fees */
+&lt;&lt;elseif $money gte _pesthouseFee&gt;&gt;&lt;&lt;set $money -= _pesthouseFee&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;/silently&gt;&gt;
 
 &lt;&lt;silently&gt;&gt;
@@ -2982,8 +2984,8 @@ It is a difficult decision, but &lt;&lt;set-caretaker&gt;&gt;&lt;&lt;if $hoh is 
             &lt;&lt;set _phDead.push(_pi)&gt;&gt;
             /* Silent quick burial for pesthouse deaths */
             &lt;&lt;set $NPCs[_pi].funeralDone to true&gt;&gt;
-            &lt;&lt;set $money -= 9&gt;&gt;
-            &lt;&lt;set $decisions.push({text: &quot;Quick burial for &quot; + $NPCs[_pi].name, money: -9, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;
+            &lt;&lt;master-pays 9&gt;&gt;
+            &lt;&lt;set $decisions.push({text: &quot;Quick burial for &quot; + $NPCs[_pi].name, money: (_masterPaid ? 0 : -9), repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;
         &lt;&lt;else&gt;&gt;
             &lt;&lt;set $NPCs[_pi].health to &quot;recovered&quot;&gt;&gt;
             &lt;&lt;set _phRec.push(_pi)&gt;&gt;
@@ -2998,8 +3000,8 @@ It is a difficult decision, but &lt;&lt;set-caretaker&gt;&gt;&lt;&lt;if $hoh is 
             &lt;&lt;set $NPCsServants[_pi].health to &quot;deceased&quot;&gt;&gt;
             &lt;&lt;set _phSvDead.push(_pi)&gt;&gt;
             &lt;&lt;set $NPCsServants[_pi].funeralDone to true&gt;&gt;
-            &lt;&lt;set $money -= 9&gt;&gt;
-            &lt;&lt;set $decisions.push({text: &quot;Quick burial for &quot; + $NPCsServants[_pi].name, money: -9, repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;
+            &lt;&lt;master-pays 9&gt;&gt;
+            &lt;&lt;set $decisions.push({text: &quot;Quick burial for &quot; + $NPCsServants[_pi].name, money: (_masterPaid ? 0 : -9), repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;
         &lt;&lt;else&gt;&gt;
             &lt;&lt;set $NPCsServants[_pi].health to &quot;recovered&quot;&gt;&gt;
             &lt;&lt;set _phSvRec.push(_pi)&gt;&gt;
@@ -4997,7 +4999,8 @@ Do you:&lt;ul&gt;
 &lt;&lt;else&gt;&gt;
 &lt;&lt;set _partyCost to 6&gt;&gt;
 &lt;&lt;/if&gt;&gt;
-&lt;&lt;set $money -= _partyCost&gt;&gt;
+&lt;&lt;master-pays _partyCost&gt;&gt;
+&lt;&lt;if _masterPaid&gt;&gt;&lt;&lt;set _partyCost to 0&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;
 
 &lt;&lt;widget &quot;quarantine-costs&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
@@ -5051,6 +5054,7 @@ Do you:&lt;ul&gt;
 &lt;&lt;/nobr&gt;&gt;</tw-passagedata><tw-passagedata pid="79" name="Apothecary" tags="menu" position="650,150" size="100,100">&lt;&lt;nobr&gt;&gt;
 &lt;&lt;silently&gt;&gt;
 &lt;&lt;set _hhSize to $NPCs.filter(function(n) { return n.health isnot &quot;deceased&quot;; }).length + 1&gt;&gt;
+&lt;&lt;if $socio is &quot;servants&quot; and ($hoh is 3 or $hoh is 0)&gt;&gt;&lt;&lt;set _hhSize to 1&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;set _celestialPrice to _hhSize*36&gt;&gt;
 &lt;&lt;set _treaclePrice to _hhSize*6&gt;&gt;
 &lt;&lt;set _incensePrice to _hhSize*3&gt;&gt;
@@ -5132,9 +5136,9 @@ You have some &lt;&lt;defRemedies &quot;remedies&quot;&gt;&gt; on hand in your h
 &lt;&lt;set _remedyEffect to 0&gt;&gt;
 &lt;ul&gt;
 &lt;li&gt;&lt;&lt;linkreplace &quot;offer a purgative drink&quot;&gt;&gt;You offer the sick a &lt;&lt;defPurgative &quot;purgative&quot;&gt;&gt; drink, which induces vomiting. It&#39;s incredibly unpleasant.&lt;&lt;/linkreplace&gt;&gt;&lt;/li&gt;
-&lt;li&gt;&lt;&lt;if $remedies.Plaster.quantity gt _plasterQuantity&gt;&gt;&lt;&lt;linkreplace &quot;apply a plaster to the plague buboes for one week&quot;&gt;&gt;&lt;&lt;set _remedyEffect to 1&gt;&gt;&lt;&lt;set $remedies.Plaster.quantity -= _plasterQuantity&gt;&gt;You apply a &lt;&lt;defBlisteringPlaster &quot;blistering plaster&quot;&gt;&gt; to the plague &lt;&lt;defBuboes &quot;buboes&quot;&gt;&gt; on the infected, especially those around the ears, armpits, and groin. If left on half the day, the plaster can break the buboes and draw out the &lt;&lt;defMalignity &quot;malignity&quot;&gt;&gt;. Once broken open, you can apply another plaster to keep the buboe draining. If the buboes do not break, you may need to lance them.&lt;&lt;/linkreplace&gt;&gt;&lt;&lt;elseif $money gt $remedies.Plaster.cost*_plasterQuantity&gt;&gt;&lt;&lt;linkreplace &quot;purchase one week&#39;s worth of a blistering plaster for the plague buboes&quot;&gt;&gt;You apply a &lt;&lt;defBlisteringPlaster &quot;blistering plaster&quot;&gt;&gt; to the plague &lt;&lt;defBuboes &quot;buboes&quot;&gt;&gt; on the infected, especially those around the ears, armpits, and groin. If left on half the day, the plaster can break the buboes and draw out the &lt;&lt;defMalignity &quot;malignity&quot;&gt;&gt;. Once broken open, you can apply another plaster to keep the buboe draining. If the buboes do not break, you may need to lance them.&lt;&lt;set _remedyEffect to 1&gt;&gt;&lt;&lt;money `-1 * $remedies.Plaster.cost*_plasterQuantity`&gt;&gt;&lt;&lt;/linkreplace&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;/li&gt;
-&lt;li&gt;&lt;&lt;if $remedies.Cordial.quantity gt _cordialQuantity&gt;&gt;&lt;&lt;linkreplace &quot;give the sick a cordial tincture for the first two days of their illness&quot;&gt;&gt;&lt;&lt;set $remedies.Cordial.quantity -= _cordialQuantity&gt;&gt;Twice a day, you give the sick a dose of &lt;&lt;defTincture &quot;tincture&quot;&gt;&gt;. After each dose, you heavily cover their bodies for 3 hours to induce sweating, then wipe them down with hot napkins.&lt;&lt;/linkreplace&gt;&gt;&lt;&lt;elseif $money gt $remedies.Cordial.cost*_cordialQuantity&gt;&gt;&lt;&lt;linkreplace &quot;purchase and give a cordial tincture to the sick&quot;&gt;&gt;Twice a day, you give the sick a dose of &lt;&lt;defTincture &quot;tincture&quot;&gt;&gt;. After each dose, you heavily cover their bodies for 3 hours to induce sweating, then wipe them down with hot napkins.&lt;&lt;money `-1 * $remedies.Cordial.cost*_cordialQuantity`&gt;&gt;&lt;&lt;/linkreplace&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;/li&gt;
-&lt;li&gt;&lt;&lt;if $remedies.Treacle.quantity gt _treacleQuantity&gt;&gt;&lt;&lt;linkreplace &quot;drink a posset of London Treacle for the first few days of illness&quot;&gt;&gt;You are given &lt;&lt;defLondonTreacle &quot;London Treacle&quot;&gt;&gt; dissolved in spoonfuls of warm vinegar, and drink 1/4 pint of this for the first few days of your illness.&lt;&lt;set $remedies.Treacle.quantity -= _treacleQuantity&gt;&gt;&lt;&lt;/linkreplace&gt;&gt;&lt;&lt;elseif $money gt $remedies.Treacle.cost*_treacleQuantity&gt;&gt;&lt;&lt;linkreplace &quot;purchase and give a posset of London Treacle to the sick&quot;&gt;&gt;You dissolve a few spoonfuls of &lt;&lt;defLondonTreacle &quot;London Treacle&quot;&gt;&gt; in warm vinegar, and give the sick 1/4 pint of this for the first few days of their illness.&lt;&lt;money `-1 * $remedies.Treacle.cost*_treacleQuantity`&gt;&gt;&lt;&lt;/linkreplace&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;/li&gt;
+&lt;li&gt;&lt;&lt;if $remedies.Plaster.quantity gt _plasterQuantity&gt;&gt;&lt;&lt;linkreplace &quot;apply a plaster to the plague buboes for one week&quot;&gt;&gt;&lt;&lt;set _remedyEffect to 1&gt;&gt;&lt;&lt;set $remedies.Plaster.quantity -= _plasterQuantity&gt;&gt;You apply a &lt;&lt;defBlisteringPlaster &quot;blistering plaster&quot;&gt;&gt; to the plague &lt;&lt;defBuboes &quot;buboes&quot;&gt;&gt; on the infected, especially those around the ears, armpits, and groin. If left on half the day, the plaster can break the buboes and draw out the &lt;&lt;defMalignity &quot;malignity&quot;&gt;&gt;. Once broken open, you can apply another plaster to keep the buboe draining. If the buboes do not break, you may need to lance them.&lt;&lt;/linkreplace&gt;&gt;&lt;&lt;elseif $money gt $remedies.Plaster.cost*_plasterQuantity or ($socio is &quot;servants&quot; and ($hoh is 3 or $hoh is 0))&gt;&gt;&lt;&lt;linkreplace &quot;purchase one week&#39;s worth of a blistering plaster for the plague buboes&quot;&gt;&gt;You apply a &lt;&lt;defBlisteringPlaster &quot;blistering plaster&quot;&gt;&gt; to the plague &lt;&lt;defBuboes &quot;buboes&quot;&gt;&gt; on the infected, especially those around the ears, armpits, and groin. If left on half the day, the plaster can break the buboes and draw out the &lt;&lt;defMalignity &quot;malignity&quot;&gt;&gt;. Once broken open, you can apply another plaster to keep the buboe draining. If the buboes do not break, you may need to lance them.&lt;&lt;set _remedyEffect to 1&gt;&gt;&lt;&lt;master-pays $remedies.Plaster.cost*_plasterQuantity&gt;&gt;&lt;&lt;if not _masterPaid&gt;&gt;&lt;&lt;replace &quot;#conversion&quot;&gt;&gt;&lt;&lt;conversion&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/linkreplace&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;/li&gt;
+&lt;li&gt;&lt;&lt;if $remedies.Cordial.quantity gt _cordialQuantity&gt;&gt;&lt;&lt;linkreplace &quot;give the sick a cordial tincture for the first two days of their illness&quot;&gt;&gt;&lt;&lt;set $remedies.Cordial.quantity -= _cordialQuantity&gt;&gt;Twice a day, you give the sick a dose of &lt;&lt;defTincture &quot;tincture&quot;&gt;&gt;. After each dose, you heavily cover their bodies for 3 hours to induce sweating, then wipe them down with hot napkins.&lt;&lt;/linkreplace&gt;&gt;&lt;&lt;elseif $money gt $remedies.Cordial.cost*_cordialQuantity or ($socio is &quot;servants&quot; and ($hoh is 3 or $hoh is 0))&gt;&gt;&lt;&lt;linkreplace &quot;purchase and give a cordial tincture to the sick&quot;&gt;&gt;Twice a day, you give the sick a dose of &lt;&lt;defTincture &quot;tincture&quot;&gt;&gt;. After each dose, you heavily cover their bodies for 3 hours to induce sweating, then wipe them down with hot napkins.&lt;&lt;master-pays $remedies.Cordial.cost*_cordialQuantity&gt;&gt;&lt;&lt;if not _masterPaid&gt;&gt;&lt;&lt;replace &quot;#conversion&quot;&gt;&gt;&lt;&lt;conversion&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/linkreplace&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;/li&gt;
+&lt;li&gt;&lt;&lt;if $remedies.Treacle.quantity gt _treacleQuantity&gt;&gt;&lt;&lt;linkreplace &quot;drink a posset of London Treacle for the first few days of illness&quot;&gt;&gt;You are given &lt;&lt;defLondonTreacle &quot;London Treacle&quot;&gt;&gt; dissolved in spoonfuls of warm vinegar, and drink 1/4 pint of this for the first few days of your illness.&lt;&lt;set $remedies.Treacle.quantity -= _treacleQuantity&gt;&gt;&lt;&lt;/linkreplace&gt;&gt;&lt;&lt;elseif $money gt $remedies.Treacle.cost*_treacleQuantity or ($socio is &quot;servants&quot; and ($hoh is 3 or $hoh is 0))&gt;&gt;&lt;&lt;linkreplace &quot;purchase and give a posset of London Treacle to the sick&quot;&gt;&gt;You dissolve a few spoonfuls of &lt;&lt;defLondonTreacle &quot;London Treacle&quot;&gt;&gt; in warm vinegar, and give the sick 1/4 pint of this for the first few days of their illness.&lt;&lt;master-pays $remedies.Treacle.cost*_treacleQuantity&gt;&gt;&lt;&lt;if not _masterPaid&gt;&gt;&lt;&lt;replace &quot;#conversion&quot;&gt;&gt;&lt;&lt;conversion&gt;&gt;&lt;&lt;/replace&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/linkreplace&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;/li&gt;
 &lt;li&gt;&lt;&lt;linkreplace &quot;give a suppository&quot;&gt;&gt;You give a homemade &lt;&lt;defSuppository &quot;suppository&quot;&gt;&gt; of a fig filled with salt to the sick. It&#39;s unclear how this helps.&lt;&lt;/linkreplace&gt;&gt;&lt;/li&gt;
 &lt;li&gt;&lt;&lt;linkreplace &quot;give an anti-diarrheal&quot;&gt;&gt;You mix extra &lt;&lt;defPosset &quot;posset&quot;&gt;&gt; mixed with herbs like plantain, sorrel, or knot grass and offer it to the sick.&lt;&lt;/linkreplace&gt;&gt;&lt;/li&gt;
 &lt;/ul&gt;
@@ -7023,6 +7027,19 @@ You hate to send any of your family away, but you &lt;&lt;if $hoh is 4&gt;&gt;an
   &lt;/span&gt;
 
 &lt;&lt;/if&gt;&gt;
+&lt;&lt;/if&gt;&gt;
+&lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;
+
+/* master-pays — deducts _args[0] pence from $money UNLESS the player
+   is a servant living in their master&#39;s household ($hoh is 3 or child
+   servant with $hoh is 0), in which case the master absorbs the cost.
+   Sets _masterPaid to true when the master absorbed the expense. */
+&lt;&lt;widget &quot;master-pays&quot;&gt;&gt;&lt;&lt;nobr&gt;&gt;
+&lt;&lt;if $socio is &quot;servants&quot; and ($hoh is 3 or $hoh is 0)&gt;&gt;
+  &lt;&lt;set _masterPaid to true&gt;&gt;
+&lt;&lt;else&gt;&gt;
+  &lt;&lt;set _masterPaid to false&gt;&gt;
+  &lt;&lt;set $money -= _args[0]&gt;&gt;
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;/nobr&gt;&gt;&lt;&lt;/widget&gt;&gt;
 </tw-passagedata><tw-passagedata pid="115" name="june-1665-helper-widget" tags="widget" position="1475,325" size="100,100">&lt;&lt;widget &quot;june-1665-helper&quot;&gt;&gt;


### PR DESCRIPTION
Servants living with their master ($hoh is 3 or child servant $hoh is 0) no longer pay for expenses that would logically be covered by the master:

- Party/feast costs (party-costs widget): master absorbs the cost
- Funeral costs (funeral-choice widget): master pays for burials and proper funerals of household members
- Pesthouse fees and burials (FamPesthouse): master covers admission fees and burial costs for infected household members
- Household plague treatments (hh-treatments widget): master pays for purchased remedies (plaster, cordial, treacle) for sick household NPCs
- Apothecary purchases: _hhSize set to 1 for servants with master so they only buy preventatives/fumigants for themselves, not the whole master's household

New master-pays widget in Claude-widgets (pid 114) centralizes the logic and sets _masterPaid flag for decision-tracking accuracy.

https://claude.ai/code/session_01H9yeDJs32DgLuJuTBtE8kY