### PR TITLE
Adjust money formulas: servant starting money, noble/merchant expense…

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v3.39" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v3.40" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -1239,6 +1239,8 @@ $(document).on(':passagestart', function (ev) {
 &lt;&lt;income&gt;&gt;
 &lt;&lt;if $socio is &quot;beggars&quot;&gt;&gt;
   &lt;&lt;set $money to 0&gt;&gt;
+&lt;&lt;elseif $socio is &quot;servants&quot; and ($age is &quot;child&quot; or $age is &quot;adolescent&quot;)&gt;&gt;
+  &lt;&lt;if $gender is &quot;male&quot;&gt;&gt;&lt;&lt;set $money to 60&gt;&gt;&lt;&lt;else&gt;&gt;&lt;&lt;set $money to 40&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;else&gt;&gt;
   &lt;&lt;set $money to $income&gt;&gt;
 &lt;&lt;/if&gt;&gt;
@@ -4922,8 +4924,8 @@ Do you:&lt;ul&gt;
   &lt;&lt;set $expenses to 20 * _hhCount&gt;&gt;
 &lt;&lt;elseif $socio is &quot;nobles&quot; or $socio is &quot;merchants&quot; or $socio is &quot;artisans&quot;&gt;&gt;
   /* Base per household */
-  &lt;&lt;if $socio is &quot;nobles&quot;&gt;&gt;&lt;&lt;set _baseExp to 11200&gt;&gt;&lt;&lt;set _perFamily to 120&gt;&gt;&lt;&lt;set _perServant to 60&gt;&gt;
-  &lt;&lt;elseif $socio is &quot;merchants&quot;&gt;&gt;&lt;&lt;set _baseExp to 2800&gt;&gt;&lt;&lt;set _perFamily to 120&gt;&gt;&lt;&lt;set _perServant to 60&gt;&gt;
+  &lt;&lt;if $socio is &quot;nobles&quot;&gt;&gt;&lt;&lt;set _baseExp to 12000&gt;&gt;&lt;&lt;set _perFamily to 240&gt;&gt;&lt;&lt;set _perServant to 60&gt;&gt;
+  &lt;&lt;elseif $socio is &quot;merchants&quot;&gt;&gt;&lt;&lt;set _baseExp to 2800&gt;&gt;&lt;&lt;set _perFamily to 90&gt;&gt;&lt;&lt;set _perServant to 40&gt;&gt;
   &lt;&lt;elseif $socio is &quot;artisans&quot;&gt;&gt;&lt;&lt;set _baseExp to 560&gt;&gt;&lt;&lt;set _perFamily to 60&gt;&gt;&lt;&lt;set _perServant to 40&gt;&gt;
   &lt;&lt;/if&gt;&gt;
   /* Count living family members (including PC = 1) */

--- a/variables.md
+++ b/variables.md
@@ -136,7 +136,7 @@ This document lists all global (story) variables used in **Gaming the Great Plag
 - **Range:** -10000000 to 10000000 (clamped)
 - **Initial values by `$socio`:** Starting capital equals one month's income at the character's socio level. Beggars start with `0`.
   - `"beggars"`: `0`
-  - `"servants"`: `60` (male adult) or `40` (female adult), `0` (child/adolescent)
+  - `"servants"`: `60` (male adult) or `40` (female adult), `60` (male child/adolescent) or `40` (female child/adolescent)
   - `"day labourers"`: household income (varies by composition)
   - `"artisans"`: `800`
   - `"merchants"`: `4000`
@@ -152,8 +152,8 @@ This document lists all global (story) variables used in **Gaming the Great Plag
 
 ### `$expenses`
 - **Type:** Integer (monthly expenses in pence)
-- **Nobles:** `11200` per household + `120` per family member (including PC) + `60` per servant
-- **Merchants:** `2800` per household + `120` per family member (including PC) + `60` per servant
+- **Nobles:** `12000` per household + `240` per family member (including PC) + `60` per servant
+- **Merchants:** `2800` per household + `90` per family member (including PC) + `40` per servant
 - **Artisans:** `560` per household + `60` per family member (including PC) + `40` per servant
 - **Servants:** `20` per person in the household. Child/adolescent or living-with-master servants pay `20` (PC only).
 - **Day labourers:** `60` per household + `20` per person in the household


### PR DESCRIPTION
…s — bump to v3.40

- Child/adolescent servants now start with 60d (male) or 40d (female) instead of 0
- Noble expenses changed to 12000 + 240/family + 60/servant (was 11200 + 120 + 60)
- Merchant expenses changed to 2800 + 90/family + 40/servant (was 2800 + 120 + 60)
- Updated variables.md to match

https://claude.ai/code/session_01GMzhVZ2zgh9ZHd9Lr892jZ