### PR TITLE
Fix excessive line breaks (3+ <br>) at widget boundaries — bump to v4.16

### DIFF
--- a/GamingtheGreatPlague.html
+++ b/GamingtheGreatPlague.html
@@ -104,7 +104,7 @@ var LZString=function(){var r=String.fromCharCode,o="ABCDEFGHIJKLMNOPQRSTUVWXYZa
 		<div id="init-lacking"><p>Browser lacks capabilities required to play.</p><p>Upgrade or switch to another browser.</p></div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-	<tw-storydata name="Gaming the Great Plague 2026 v4.15" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
+	<tw-storydata name="Gaming the Great Plague 2026 v4.16" startnode="3" creator="Twine" creator-version="2.9.2" format="SugarCube" format-version="2.37.3" ifid="82d2fee6-bab5-4bdd-86ed-694046b2191b" options="" tags="" zoom="0.6" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">.def {
 	color: #6A499B;
 	font-weight:bold;
     /*text-decoration: underline dotted;*/
@@ -1953,7 +1953,6 @@ On Christmas Eve, you see a comet in the sky and you wonder if it is [[a sign of
 &lt;&lt;/if&gt;&gt;
 &lt;&lt;if _deadNPCs.length gt 0&gt;&gt;
 &lt;&lt;set _npcDeathOccurred to true&gt;&gt;
-&lt;br&gt;
 /* Build a readable list of the dead */
 &lt;&lt;set _deathList to &quot;&quot;&gt;&gt;
 &lt;&lt;for _fi = 0; _fi lt _deadNPCs.length; _fi++&gt;&gt;
@@ -1975,14 +1974,14 @@ On Christmas Eve, you see a comet in the sky and you wonder if it is [[a sign of
 &lt;&lt;link &quot;a quick burial&quot;&gt;&gt;&lt;&lt;replace &quot;#funeral-combined&quot;&gt;&gt;
 &lt;&lt;master-pays _burialCost&gt;&gt;
 &lt;&lt;for _fi = 0; _fi lt _deadNPCs.length; _fi++&gt;&gt;&lt;&lt;set _deadNPCs[_fi].npc.funeralDone to true&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Quick burial for &quot; + _deadNPCs[_fi].npc.name, money: (_masterPaid ? 0 : -9), repDelta: 0, repBefore: $reputation, infectPct: null})&gt;&gt;&lt;&lt;/for&gt;&gt;
-&lt;&lt;if _funeralInline&gt;&gt;Given everything that is happening, a quick funeral will have to be enough for your dead.&lt;&lt;done&gt;&gt;&lt;&lt;run $(&quot;#funeral-continue&quot;).show()&gt;&gt;&lt;&lt;/done&gt;&gt;
+&lt;&lt;if _funeralInline&gt;&gt;Given everything that is happening, a quick funeral will have to be enough for your dead.&lt;br&gt;&lt;br&gt;&lt;&lt;done&gt;&gt;&lt;&lt;run $(&quot;#funeral-continue&quot;).show()&gt;&gt;&lt;&lt;/done&gt;&gt;
 &lt;&lt;else&gt;&gt;Given everything that is happening, a quick funeral will have to be &lt;&lt;storyline-return &quot;enough for your dead.&quot; 0&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;a proper funeral&quot;&gt;&gt;&lt;&lt;replace &quot;#funeral-combined&quot;&gt;&gt;
 &lt;&lt;plague-risk-check &quot;crowd&quot;&gt;&gt;
 &lt;&lt;master-pays _funeralCost&gt;&gt;
 &lt;&lt;set _perCost to Math.round(_funeralCost / _deadNPCs.length)&gt;&gt;
 &lt;&lt;for _fi = 0; _fi lt _deadNPCs.length; _fi++&gt;&gt;&lt;&lt;set _deadNPCs[_fi].npc.funeralDone to true&gt;&gt;&lt;&lt;set $decisions.push({text: &quot;Proper funeral for &quot; + _deadNPCs[_fi].npc.name, money: (_masterPaid ? 0 : -_perCost), repDelta: 0, repBefore: $reputation, infectPct: _riskPct})&gt;&gt;&lt;&lt;/for&gt;&gt;
-&lt;&lt;if _funeralInline&gt;&gt;Despite everything that is happening, you are still determined to give your dead a proper funeral.&lt;&lt;done&gt;&gt;&lt;&lt;run $(&quot;#funeral-continue&quot;).show()&gt;&gt;&lt;&lt;/done&gt;&gt;
+&lt;&lt;if _funeralInline&gt;&gt;Despite everything that is happening, you are still determined to give your dead a proper funeral.&lt;br&gt;&lt;br&gt;&lt;&lt;done&gt;&gt;&lt;&lt;run $(&quot;#funeral-continue&quot;).show()&gt;&gt;&lt;&lt;/done&gt;&gt;
 &lt;&lt;else&gt;&gt;Despite everything that is happening, you are still determined to give your dead &lt;&lt;storyline-return &quot;a proper funeral.&quot; 0&gt;&gt;&lt;&lt;/if&gt;&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;
 &lt;/span&gt;
@@ -2809,7 +2808,7 @@ Congratulations. You have [[survived the Great Plague of London-&gt;stats]]
   &lt;&lt;set $masterTitle to &quot;master&quot;&gt;&gt;&lt;&lt;set $masterGender to &quot;male&quot;&gt;&gt;
   &lt;&lt;set _smdSucceeded to true&gt;&gt;
   &lt;&lt;NPCpronouns&gt;&gt;
-  &lt;br&gt;&lt;br&gt;Following the death of your _smdOldTitle, your &lt;&lt;print _smdOldTitle&gt;&gt;&#39;s father has taken over as head of the household.&lt;br&gt;&lt;br&gt;
+  Following the death of your _smdOldTitle, your &lt;&lt;print _smdOldTitle&gt;&gt;&#39;s father has taken over as head of the household.&lt;br&gt;&lt;br&gt;
 &lt;&lt;elseif _smdMotherAlive&gt;&gt;
   /* Master&#39;s mother becomes new widowed mistress;
      surviving master&#39;s sons/daughters become master&#39;s grandsons/granddaughters */
@@ -2824,7 +2823,7 @@ Congratulations. You have [[survived the Great Plague of London-&gt;stats]]
   &lt;&lt;set $masterTitle to &quot;mistress&quot;&gt;&gt;&lt;&lt;set $masterGender to &quot;female&quot;&gt;&gt;
   &lt;&lt;set _smdSucceeded to true&gt;&gt;
   &lt;&lt;NPCpronouns&gt;&gt;
-  &lt;br&gt;&lt;br&gt;Following the death of your _smdOldTitle, your &lt;&lt;print _smdOldTitle&gt;&gt;&#39;s mother has taken over as head of the household.&lt;br&gt;&lt;br&gt;
+  Following the death of your _smdOldTitle, your &lt;&lt;print _smdOldTitle&gt;&gt;&#39;s mother has taken over as head of the household.&lt;br&gt;&lt;br&gt;
 &lt;&lt;elseif _smdAdultSons.length gt 0&gt;&gt;
   /* Oldest adult son becomes new master;
      remaining master&#39;s sons/daughters become master&#39;s brothers/sisters */
@@ -2840,7 +2839,7 @@ Congratulations. You have [[survived the Great Plague of London-&gt;stats]]
   &lt;&lt;set $masterTitle to &quot;master&quot;&gt;&gt;&lt;&lt;set $masterGender to &quot;male&quot;&gt;&gt;
   &lt;&lt;set _smdSucceeded to true&gt;&gt;
   &lt;&lt;NPCpronouns&gt;&gt;
-  &lt;br&gt;&lt;br&gt;Following the death of your _smdOldTitle, your &lt;&lt;print _smdOldTitle&gt;&gt;&#39;s oldest son has become the new head of the household.&lt;br&gt;&lt;br&gt;
+  Following the death of your _smdOldTitle, your &lt;&lt;print _smdOldTitle&gt;&gt;&#39;s oldest son has become the new head of the household.&lt;br&gt;&lt;br&gt;
 &lt;&lt;else&gt;&gt;
   /* No qualifying relatives — dissolve household and find new master */
   &lt;&lt;if _smdSingle&gt;&gt;
@@ -2852,7 +2851,7 @@ Congratulations. You have [[survived the Great Plague of London-&gt;stats]]
     &lt;&lt;addMasterHousehold&gt;&gt;
   &lt;&lt;/if&gt;&gt;
   &lt;&lt;NPCpronouns&gt;&gt;
-  &lt;br&gt;&lt;br&gt;Following the death of your _smdOldTitle without any surviving relatives to take over the household, you have found a new position with a new employer.&lt;br&gt;&lt;br&gt;
+  Following the death of your _smdOldTitle without any surviving relatives to take over the household, you have found a new position with a new employer.&lt;br&gt;&lt;br&gt;
 &lt;&lt;/if&gt;&gt;
 /* After a successful succession (not dissolution), prefix deceased non-servants
    with &quot;late &quot;. &quot;mistress&quot; maps to &quot;late master&#39;s wife&quot;; all others prepend &quot;late &quot;. */
@@ -3814,8 +3813,8 @@ You are desperate to save the sick but don&#39;t know what will actually work.
 &lt;&lt;else&gt;&gt;The infection seems to have burned itself out, and you can now focus on the recovery of those who survived.&lt;br&gt;&lt;br&gt;
 &lt;&lt;if $plagueInfection is 1&gt;&gt;[[You wonder what has happened while you were away from the world.-&gt;Sickness]]&lt;&lt;else&gt;&gt;[[You wonder what has happened while you were away from the world.-&gt;Reconnecting]]&lt;&lt;/if&gt;&gt;
 &lt;&lt;/if&gt;&gt;
-&lt;&lt;health-update&gt;&gt;
 &lt;&lt;fumigant&gt;&gt;
+&lt;&lt;health-update&gt;&gt;
 &lt;&lt;else&gt;&gt;
 /* Infected family members branch */
 &lt;&lt;if $quarantine gte 4&gt;&gt;Unfortunately, even more members of your household have fallen ill. Your &lt;&lt;else&gt;&gt;The illness has spread through your household and your &lt;&lt;/if&gt;&gt;
@@ -6493,7 +6492,7 @@ Despite everything, court life proceeds as usual. A friend living the countrysid
 &lt;&lt;set _cuFrom to (def _args[0] &amp;&amp; _args[0] !== null) ? _args[0] : $monthIndex&gt;&gt;
 &lt;&lt;set _cuTo to (def _args[1] &amp;&amp; _args[1] !== null) ? _args[1] : $monthIndex + 1&gt;&gt;
 &lt;&lt;if _cuTo gt _cuFrom + 1&gt;&gt;
-&lt;br&gt;&#39;&#39;Your neighbors are eager to catch you up on everything you missed.&#39;&#39;&lt;br&gt;
+&#39;&#39;Your neighbors are eager to catch you up on everything you missed.&#39;&#39;&lt;br&gt;
 &lt;&lt;for _cuIdx = _cuFrom + 1; _cuIdx &lt; _cuTo; _cuIdx++&gt;&gt;
 &lt;br&gt;&#39;&#39;&lt;&lt;print $timeline[_cuIdx]&gt;&gt;:&#39;&#39; &lt;&lt;print $catchUpSummaries[_cuIdx]&gt;&gt;
 &lt;&lt;if $corpseBuried and $corpseBuried[$parish]&gt;&gt;
@@ -7124,10 +7123,10 @@ Your &lt;&lt;for _rc, _ri range _flightSafeKids&gt;&gt;&lt;&lt;if _flightSafeKid
   &lt;&lt;/if&gt;&gt;
 &lt;&lt;/for&gt;&gt;
 
-&lt;&lt;if _smuggleEligible.length gt 0&gt;&gt;&lt;br&gt;&lt;br&gt;
+&lt;&lt;if _smuggleEligible.length gt 0&gt;&gt;
 &lt;&lt;set _smugIdx to _smuggleEligible[0]&gt;&gt;
 &lt;&lt;done&gt;&gt;&lt;&lt;run $(&quot;#smuggle-continue&quot;).hide()&gt;&gt;&lt;&lt;/done&gt;&gt;
-&lt;span id=&quot;smuggle-choice&quot;&gt;&lt;br&gt;&lt;br&gt;Under the guise of bringing you food, your neighbors offer to help you evade the quarantine and smuggle &lt;&lt;if _smuggleEligible.length eq 1&gt;&gt;your $NPCs[_smugIdx].relationship $NPCs[_smugIdx].name&lt;&lt;else&gt;&gt;your healthy children&lt;&lt;/if&gt;&gt; out of the house. Do you &lt;&lt;if $hoh is 4&gt;&gt;and your husband &lt;&lt;/if&gt;&gt;accept their offer?&lt;br&gt;&lt;br&gt;
+&lt;span id=&quot;smuggle-choice&quot;&gt;Under the guise of bringing you food, your neighbors offer to help you evade the quarantine and smuggle &lt;&lt;if _smuggleEligible.length eq 1&gt;&gt;your $NPCs[_smugIdx].relationship $NPCs[_smugIdx].name&lt;&lt;else&gt;&gt;your healthy children&lt;&lt;/if&gt;&gt; out of the house. Do you &lt;&lt;if $hoh is 4&gt;&gt;and your husband &lt;&lt;/if&gt;&gt;accept their offer?&lt;br&gt;&lt;br&gt;
 &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#smuggle-choice&quot;&gt;&gt;
 &lt;&lt;set $getaway = []&gt;&gt;
 &lt;&lt;for _se range _smuggleEligible&gt;&gt;
@@ -7155,13 +7154,13 @@ Under cover of night, your neighbors manage to smuggle &lt;&lt;for _f, _g range 
 &lt;&lt;/for&gt;&gt;
 &lt;&lt;if _safeKids.length gt 0&gt;&gt;
 &lt;&lt;done&gt;&gt;&lt;&lt;run $(&quot;#return-continue&quot;).hide()&gt;&gt;&lt;&lt;/done&gt;&gt;
-&lt;br&gt;&lt;br&gt;&lt;span id=&quot;return-children&quot;&gt;Your &lt;&lt;for _rc, _ri range _safeKids&gt;&gt;&lt;&lt;if _safeKids.length eq 1&gt;&gt;$NPCs[_ri].relationship $NPCs[_ri].name has&lt;&lt;else&gt;&gt;&lt;&lt;if _rc gt 0 and _safeKids.length gt 2&gt;&gt;, &lt;&lt;/if&gt;&gt;&lt;&lt;if _rc gt 0 and _rc is _safeKids.length - 1&gt;&gt;&lt;&lt;if _safeKids.length is 2&gt;&gt; and &lt;&lt;else&gt;&gt;and &lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;$NPCs[_ri].relationship $NPCs[_ri].name&lt;&lt;if _rc is _safeKids.length - 1&gt;&gt; have&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt; been safe in the countryside but you are now free to open up your house and resume your regular life. Do you &lt;&lt;if $hoh is 4&gt;&gt;and your husband &lt;&lt;/if&gt;&gt; want to bring your child&lt;&lt;if _safeKids.length &gt; 1&gt;&gt;ren&lt;&lt;/if&gt;&gt; home now?&lt;br&gt;&lt;br&gt;
+&lt;span id=&quot;return-children&quot;&gt;Your &lt;&lt;for _rc, _ri range _safeKids&gt;&gt;&lt;&lt;if _safeKids.length eq 1&gt;&gt;$NPCs[_ri].relationship $NPCs[_ri].name has&lt;&lt;else&gt;&gt;&lt;&lt;if _rc gt 0 and _safeKids.length gt 2&gt;&gt;, &lt;&lt;/if&gt;&gt;&lt;&lt;if _rc gt 0 and _rc is _safeKids.length - 1&gt;&gt;&lt;&lt;if _safeKids.length is 2&gt;&gt; and &lt;&lt;else&gt;&gt;and &lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;$NPCs[_ri].relationship $NPCs[_ri].name&lt;&lt;if _rc is _safeKids.length - 1&gt;&gt; have&lt;&lt;/if&gt;&gt;&lt;&lt;/if&gt;&gt;&lt;&lt;/for&gt;&gt; been safe in the countryside but you are now free to open up your house and resume your regular life. Do you &lt;&lt;if $hoh is 4&gt;&gt;and your husband &lt;&lt;/if&gt;&gt; want to bring your child&lt;&lt;if _safeKids.length &gt; 1&gt;&gt;ren&lt;&lt;/if&gt;&gt; home now?&lt;br&gt;&lt;br&gt;
 &lt;&lt;link &quot;Yes&quot;&gt;&gt;&lt;&lt;replace &quot;#return-children&quot;&gt;&gt;
 &lt;&lt;for _rk range _safeKids&gt;&gt;&lt;&lt;set $NPCs[_rk].health to &quot;healthy&quot;&gt;&gt;&lt;&lt;set $NPCs[_rk].location to $location&gt;&gt;&lt;&lt;/for&gt;&gt;&lt;&lt;set $getaway to []&gt;&gt;
-You are ready to reunite your family and hasten to bring your child&lt;&lt;if _safeKids.length &gt; 1&gt;&gt;ren&lt;&lt;/if&gt;&gt; home.
+You are ready to reunite your family and hasten to bring your child&lt;&lt;if _safeKids.length &gt; 1&gt;&gt;ren&lt;&lt;/if&gt;&gt; home.&lt;br&gt;&lt;br&gt;
 &lt;&lt;done&gt;&gt;&lt;&lt;run $(&quot;#return-continue&quot;).show()&gt;&gt;&lt;&lt;/done&gt;&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt; | &lt;&lt;link &quot;No&quot;&gt;&gt;&lt;&lt;replace &quot;#return-children&quot;&gt;&gt;
-As much as you miss your child&lt;&lt;if _safeKids.length &gt; 1&gt;&gt;ren&lt;&lt;/if&gt;&gt;, it&#39;s not safe to reunite your family yet.
+As much as you miss your child&lt;&lt;if _safeKids.length &gt; 1&gt;&gt;ren&lt;&lt;/if&gt;&gt;, it&#39;s not safe to reunite your family yet.&lt;br&gt;&lt;br&gt;
 &lt;&lt;done&gt;&gt;&lt;&lt;run $(&quot;#return-continue&quot;).show()&gt;&gt;&lt;&lt;/done&gt;&gt;
 &lt;&lt;/replace&gt;&gt;&lt;&lt;/link&gt;&gt;
 &lt;/span&gt;


### PR DESCRIPTION
Removed redundant <br> tags that accumulated at widget/passage boundaries, producing 3-6 consecutive line breaks where only 2 were intended:

- smuggle-children (pid 119): removed internal double <br><br> (lines 10+13) that created 4-6 breaks depending on preceding recovery text
- return-children (pid 119): removed leading <br><br>; added trailing <br><br> to resolution text for proper separation from catch-up
- servant-master-death (pid 35): removed leading <br><br> from all 4 succession branches (kept trailing) to prevent collision with preceding orphan-check/contagion-spread output
- funeral-choice (pid 13): removed leading <br>; added <br><br> to inline resolution text for proper separation from continuation span
- Quarantine Continues (pid 60): swapped fumigant/health-update order in no-new-infections branch to match infected branch and avoid trailing health-update <br><br> colliding with fumigant leading <br><br>
- catch-up (pid 106): removed leading <br> to prevent 3-break accumulation with passage/widget trailing <br><br>

https://claude.ai/code/session_01S81bfhJAXWjsxqcrbBcQ7G